### PR TITLE
Elements and CCL

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,12 +7,14 @@ else()
 endif()
 
 if (RODIN_BUILD_EXAMPLES)
-  add_subdirectory(MMG)
-  add_subdirectory(Gmsh)
+  add_subdirectory(IO)
+  add_subdirectory(Mesh)
   add_subdirectory(Variational)
   add_subdirectory(ShapeOptimization)
   add_subdirectory(DensityOptimization)
   # add_subdirectory(SurfaceOptimization)
+
+  add_subdirectory(MMG)
 
   if (RODIN_USE_MPI)
     add_subdirectory(Parallel)

--- a/examples/Gmsh/CMakeLists.txt
+++ b/examples/Gmsh/CMakeLists.txt
@@ -1,8 +1,0 @@
-add_executable(IO IO.cpp)
-target_link_libraries(IO
-  PUBLIC
-  Rodin::Mesh
-  Rodin::Solver
-  Rodin::Variational
-  )
-

--- a/examples/IO/CMakeLists.txt
+++ b/examples/IO/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(Gmsh Gmsh.cpp)
+target_link_libraries(Gmsh
+  PUBLIC
+  Rodin::Mesh)
+

--- a/examples/IO/Gmsh.cpp
+++ b/examples/IO/Gmsh.cpp
@@ -1,0 +1,21 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <Rodin/Mesh.h>
+
+using namespace Rodin;
+
+int main(int, char**)
+{
+  Mesh mesh;
+  mesh.load("../resources/gmsh/inductor.msh", IO::MeshFormat::GMSH);
+
+  std::cout << "Saved Gmsh file to mfem.mesh in Mfem format" << std::endl;
+
+  mesh.save("mfem.mesh", IO::MeshFormat::MFEM);
+
+  return 0;
+}

--- a/examples/Mesh/CCL.cpp
+++ b/examples/Mesh/CCL.cpp
@@ -5,19 +5,13 @@
  *          https://www.boost.org/LICENSE_1_0.txt)
  */
 #include <Rodin/Mesh.h>
-#include <Rodin/Solver.h>
-#include <Rodin/Variational.h>
 
 using namespace Rodin;
-using namespace Rodin::Variational;
 
 int main(int, char**)
 {
   Mesh mesh;
-  mesh.load("../resources/gmsh/inductor.msh", IO::MeshFormat::GMSH);
 
-  std::cout << "Saved Gmsh file to mfem.mesh in Mfem format" << std::endl;
-  mesh.save("mfem.mesh", IO::MeshFormat::MFEM);
 
   return 0;
 }

--- a/examples/Mesh/CCL.cpp
+++ b/examples/Mesh/CCL.cpp
@@ -5,13 +5,38 @@
  *          https://www.boost.org/LICENSE_1_0.txt)
  */
 #include <Rodin/Mesh.h>
+#include <Rodin/Alert.h>
 
 using namespace Rodin;
 
 int main(int, char**)
 {
   Mesh mesh;
+  mesh.load("Omega.mesh");
 
+  Alert::Info() << "Performing CCL on mesh attributes..." << Alert::Raise;
+
+  auto ccs = mesh.ccl(
+      [](const Element& el1, const Element& el2)
+      {
+        return el1.getAttribute() == el2.getAttribute();
+      });
+
+  Alert::Info() << ccs.size() << " components found." << Alert::Raise;
+
+  for (size_t i = 0; i < ccs.size(); i++)
+  {
+    const auto& cc = ccs[i];
+    mesh.edit(cc,
+        [&](ElementView element)
+        {
+          element.setAttribute(i + 1);
+        });
+  }
+
+  Alert::Info() << "Saved mesh to CCL.mesh" << Alert::Raise;
+
+  mesh.save("CCL.mesh");
 
   return 0;
 }

--- a/examples/Mesh/CMakeLists.txt
+++ b/examples/Mesh/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(CCL CCL.cpp)
+target_link_libraries(CCL
+  PUBLIC
+  Rodin::Mesh)
+

--- a/src/Rodin/Alert.h
+++ b/src/Rodin/Alert.h
@@ -11,5 +11,6 @@ namespace Rodin::Alert {}
 
 #include "Alert/Exception.h"
 #include "Alert/Warning.h"
+#include "Alert/Info.h"
 
 #endif

--- a/src/Rodin/Alert/CMakeLists.txt
+++ b/src/Rodin/Alert/CMakeLists.txt
@@ -8,12 +8,14 @@ set(RodinAlert_HEADERS
   Alert.h
   Exception.h
   Warning.h
+  Info.h
   )
 
 set(RodinAlert_SRCS
   Alert.cpp
   Exception.cpp
   Warning.cpp
+  Info.cpp
   )
 
 add_library(RodinAlert ${RodinAlert_SRCS} ${RodinAlert_HEADERS})

--- a/src/Rodin/Alert/Info.cpp
+++ b/src/Rodin/Alert/Info.cpp
@@ -1,0 +1,22 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <iostream>
+#include <rang.hpp>
+
+#include "Info.h"
+
+namespace Rodin::Alert
+{
+   void Info::raise() const noexcept
+   {
+      std::cout << rang::fg::blue
+                << "Info: "
+                << rang::fg::reset
+                << what()
+                << std::endl;
+   }
+}

--- a/src/Rodin/Alert/Info.h
+++ b/src/Rodin/Alert/Info.h
@@ -1,0 +1,45 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef RODIN_ALERT_INFO_H
+#define RODIN_ALERT_INFO_H
+
+#include "Alert.h"
+
+namespace Rodin::Alert
+{
+   class Info : public Alert
+   {
+      public:
+         /**
+          * @brief Constructs a Info with an empty message.
+          */
+         Info() = default;
+
+         /**
+          * @brief Constructs a Info with the given message.
+          * @param[in] what Description or reason for the Info being raised.
+          */
+         Info(const std::string& what)
+            : Alert(what)
+         {}
+
+         /**
+          * @brief Copies the Info message.
+          */
+         Info(const Info&) = default;
+
+         /**
+          * @brief Raises the Info to the user.
+          *
+          * Default behaviour is to output a formatted Info message to
+          * stderr.
+          */
+         virtual void raise() const noexcept override;
+   };
+}
+
+#endif

--- a/src/Rodin/Mesh.h
+++ b/src/Rodin/Mesh.h
@@ -14,4 +14,6 @@
 #include "Mesh/Mesh.h"
 #include "Mesh/SubMesh.h"
 
+#include "Mesh/Element.h"
+
 #endif

--- a/src/Rodin/Mesh/Element.cpp
+++ b/src/Rodin/Mesh/Element.cpp
@@ -3,11 +3,20 @@
 
 namespace Rodin
 {
-   ElementBase::ElementBase(MeshBase& mesh, mfem::Element* element, int index)
-      : m_mesh(mesh), m_element(element), m_index(index)
-   {}
+   std::set<int> Element::adjacent() const
+   {
+      std::set<int> res;
+      // This call does not actually modify the Element object. Only the Mesh
+      // object. Hence we const_cast to access the ElementToElementTable table
+      // method.
+      auto& adj = const_cast<MeshBase&>(getMesh()).getHandle().ElementToElementTable();
+      const int* elements = adj.GetRow(getIndex());
+      for (int i = 0; i < adj.RowSize(getIndex()); i++)
+         res.insert(elements[i]);
+      return res;
+   }
 
-   double ElementBase::getAttribute() const
+   int ElementBase::getAttribute() const
    {
       return m_element->GetAttribute();
    }
@@ -28,10 +37,10 @@ namespace Rodin
       return volume;
    }
 
-   double BoundaryElement::getArea() const
+   double Face::getArea() const
    {
       mfem::ElementTransformation *et = const_cast<MeshBase&>(getMesh()
-            ).getHandle().GetBdrElementTransformation(getIndex());
+            ).getHandle().GetFaceTransformation(getIndex());
       const mfem::IntegrationRule &ir = mfem::IntRules.Get(
             getHandle().GetGeometryType(), et->OrderJ());
       double area = 0.0;

--- a/src/Rodin/Mesh/Element.cpp
+++ b/src/Rodin/Mesh/Element.cpp
@@ -9,7 +9,7 @@ namespace Rodin
       // This call does not actually modify the Element object. Only the Mesh
       // object. Hence we const_cast to access the ElementToElementTable table
       // method.
-      auto& adj = const_cast<MeshBase&>(getMesh()).getHandle().ElementToElementTable();
+      const auto& adj = const_cast<MeshBase&>(getMesh()).getHandle().ElementToElementTable();
       const int* elements = adj.GetRow(getIndex());
       for (int i = 0; i < adj.RowSize(getIndex()); i++)
          res.insert(elements[i]);
@@ -19,6 +19,12 @@ namespace Rodin
    int ElementBase::getAttribute() const
    {
       return m_element->GetAttribute();
+   }
+
+   ElementView& ElementView::setAttribute(int attr)
+   {
+      getMesh().getHandle().SetAttribute(getIndex(), attr);
+      return *this;
    }
 
    double Element::getVolume() const
@@ -51,5 +57,11 @@ namespace Rodin
          area += ip.weight * et->Weight();
       }
       return area;
+   }
+
+   BoundaryElementView& BoundaryElementView::setAttribute(int attr)
+   {
+      FaceView::getMesh().getHandle().SetBdrAttribute(FaceView::getIndex(), attr);
+      return *this;
    }
 }

--- a/src/Rodin/Mesh/Element.h
+++ b/src/Rodin/Mesh/Element.h
@@ -8,6 +8,9 @@
 
 namespace Rodin
 {
+   /**
+    * @brief Base class for all geometric elements of the mesh.
+    */
    class ElementBase
    {
       public:
@@ -30,6 +33,10 @@ namespace Rodin
                m_index(index)
          {}
 
+         ElementBase(const ElementBase&) = default;
+
+         ElementBase(ElementBase&&) = default;
+
          virtual ~ElementBase()
          {
             m_element = nullptr; // This is deallocated by the mfem::Mesh class
@@ -40,13 +47,22 @@ namespace Rodin
             return static_cast<Geometry>(m_element->GetGeometryType());
          }
 
+         /**
+          * @brief Gets the attribute of the element.
+          */
          int getAttribute() const;
 
+         /**
+          * @brief Gets the index of the element in the mesh.
+          */
          int getIndex() const
          {
             return m_index;
          }
 
+         /**
+          * @brief Gets the associated mesh to the element.
+          */
          const MeshBase& getMesh() const
          {
             return m_mesh;
@@ -57,6 +73,12 @@ namespace Rodin
             return *m_element;
          }
 
+         /**
+          * @brief Gets the set of spatially adjacent elements (of the same
+          * dimension).
+          * @returns Set of integer indices corresponding to the spatially
+          * adjacent elements of the same dimension.
+          */
          virtual std::set<int> adjacent() const = 0;
 
       private:
@@ -65,6 +87,14 @@ namespace Rodin
          int m_index;
    };
 
+   /**
+    * @brief Class for representing elements of the highest dimension in the
+    * mesh, i.e. tetrahedra in 3D, triangles in 2D or lines in 1D.
+    *
+    * This class is designed so that modifications cannot be made to the
+    * element. If one wishes to modify the element then one must use
+    * ElementView.
+    */
    class Element : public ElementBase
    {
       public:
@@ -72,11 +102,29 @@ namespace Rodin
             : ElementBase(mesh, element, index)
          {}
 
+         Element(const Element& other)
+            : ElementBase(other)
+         {}
+
+         Element(Element&& other)
+            : ElementBase(std::move(other))
+         {}
+
+         /**
+          * @brief Computes the volume of the element.
+          */
          double getVolume() const;
 
          std::set<int> adjacent() const override;
    };
 
+   /**
+    * @brief Class for representing elements of the highest dimension in the
+    * mesh, i.e. tetrahedra in 3D, triangles in 2D or lines in 1D.
+    *
+    * This class is designed so that modifications can be made to the element,
+    * while retaining the functionality of the more general Element class.
+    */
    class ElementView : public Element
    {
       public:
@@ -86,14 +134,33 @@ namespace Rodin
               m_element(element)
          {}
 
+         ElementView(const ElementView& other)
+            : Element(other),
+              m_mesh(other.m_mesh),
+              m_element(other.m_element)
+         {}
+
+         ElementView(ElementView&& other)
+            : Element(std::move(other)),
+              m_mesh(other.m_mesh),
+              m_element(other.m_element)
+         {
+            other.m_element = nullptr;
+         }
+
+         /**
+          * @brief Sets the attribute of the element.
+          */
+         ElementView& setAttribute(int attr);
+
          MeshBase& getMesh()
          {
             return m_mesh;
          }
 
-         mfem::Element* getHandle()
+         mfem::Element& getHandle()
          {
-            return m_element;
+            return *m_element;
          }
 
       private:
@@ -102,6 +169,14 @@ namespace Rodin
 
    };
 
+   /**
+    * @brief Class for representing elements of codimension 1 in the
+    * mesh, i.e. triangles in 3D or lines in 2D.
+    *
+    * This class is designed so that modifications cannot be made to the
+    * face. If one wishes to modify the face then one must use
+    * FaceView.
+    */
    class Face : public ElementBase
    {
       public:
@@ -109,14 +184,36 @@ namespace Rodin
             : ElementBase(mesh, element, index)
          {}
 
+         Face(MeshBase& mesh, mfem::Element* element, int index)
+            : ElementBase(mesh, element, index)
+         {}
+
+         Face(const Face& other)
+            : ElementBase(other)
+         {}
+
+         Face(Face&& other)
+            : ElementBase(std::move(other))
+         {}
+
          std::set<int> adjacent() const override
          {
             assert(false);
          }
 
+         /**
+          * @brief Gets the area of the face element.
+          */
          double getArea() const;
    };
 
+   /**
+    * @brief Class for representing elements of codimension 1 in the
+    * mesh, i.e. triangles in 3D or lines in 2D.
+    *
+    * This class is designed so that modifications can be made to the face,
+    * while retaining the functionality of the more general face class.
+    */
    class FaceView : public Face
    {
       public:
@@ -126,19 +223,89 @@ namespace Rodin
               m_element(element)
          {}
 
+         FaceView(const FaceView& other)
+            : Face(other),
+              m_mesh(other.m_mesh),
+              m_element(other.m_element)
+         {}
+
+         FaceView(FaceView&& other)
+            : Face(std::move(other)),
+              m_mesh(other.m_mesh),
+              m_element(other.m_element)
+         {
+            m_element = nullptr;
+         }
+
          MeshBase& getMesh()
          {
             return m_mesh;
          }
 
-         mfem::Element* getHandle()
+         mfem::Element& getHandle()
          {
-            return m_element;
+            return *m_element;
          }
 
       private:
          MeshBase& m_mesh;
          mfem::Element* m_element;
+   };
+
+   /**
+    * @brief Class for representing boundary elements in the mesh, i.e. face
+    * elements which are at the boundary.
+    *
+    * This class is designed so that modifications can be made to the
+    * boundary element. If one wishes to modify the face then one must use
+    * BoundaryElementView.
+    */
+   class BoundaryElement : public Face
+   {
+      public:
+         BoundaryElement(const MeshBase& mesh, const mfem::Element* element, int index)
+            : Face(mesh, element, index)
+         {}
+
+         BoundaryElement(const BoundaryElement& other)
+            :  Face(other)
+         {}
+
+         BoundaryElement(BoundaryElement&& other)
+            :  Face(std::move(other))
+         {}
+   };
+
+   /**
+    * @brief Class for representing boundary elements in the mesh, i.e. face
+    * elements which are at the boundary.
+    *
+    * This class is designed so that modifications cannot be made to the
+    * boundary element, while retaining the functionality of the more general
+    * FaceView and BoundaryElement classes.
+    */
+   class BoundaryElementView : public FaceView, public BoundaryElement
+   {
+      public:
+         BoundaryElementView(MeshBase& mesh, mfem::Element* element, int index)
+            : FaceView(mesh, element, index),
+              BoundaryElement(mesh, element, index)
+         {}
+
+         BoundaryElementView(const BoundaryElementView& other)
+            :  FaceView(other),
+               BoundaryElement(other)
+         {}
+
+         BoundaryElementView(BoundaryElementView&& other)
+            :  FaceView(std::move(other)),
+               BoundaryElement(std::move(other))
+         {}
+
+         /**
+          * @brief Sets the attribute of the boundary element.
+          */
+         BoundaryElementView& setAttribute(int attr);
    };
 }
 

--- a/src/Rodin/Mesh/ForwardDecls.h
+++ b/src/Rodin/Mesh/ForwardDecls.h
@@ -49,6 +49,9 @@ namespace Rodin
 
    class Face;
    class FaceView;
+
+   class BoundaryElement;
+   class BoundaryElementView;
 }
 
 #endif

--- a/src/Rodin/Mesh/ForwardDecls.h
+++ b/src/Rodin/Mesh/ForwardDecls.h
@@ -43,8 +43,12 @@ namespace Rodin
    class SubMesh;
 
    class ElementBase;
+
    class Element;
-   class BoundaryElement;
+   class ElementView;
+
+   class Face;
+   class FaceView;
 }
 
 #endif

--- a/src/Rodin/Mesh/Mesh.cpp
+++ b/src/Rodin/Mesh/Mesh.cpp
@@ -18,14 +18,34 @@
 namespace Rodin
 {
    // ---- MeshBase ----------------------------------------------------------
-   Element MeshBase::getElement(int i)
+   ElementView MeshBase::getElement(int i)
+   {
+      return ElementView(*this, getHandle().GetElement(i), i);
+   }
+
+   Element MeshBase::getElement(int i) const
    {
       return Element(*this, getHandle().GetElement(i), i);
    }
 
-   BoundaryElement MeshBase::getBoundaryElement(int i)
+   FaceView MeshBase::getBoundaryElement(int i)
    {
-      return BoundaryElement(*this, getHandle().GetElement(i), i);
+      return FaceView(*this, getHandle().GetElement(i), i);
+   }
+
+   Face MeshBase::getBoundaryElement(int i) const
+   {
+      return Face(*this, getHandle().GetElement(i), i);
+   }
+
+   int MeshBase::getElementCount() const
+   {
+      return getHandle().GetNE();
+   }
+
+   int MeshBase::getBoundaryElementCount() const
+   {
+      return getHandle().GetNBE();
    }
 
    int MeshBase::getSpaceDimension() const
@@ -112,7 +132,7 @@ namespace Rodin
    double MeshBase::getVolume()
    {
       double totalVolume = 0;
-      for (int i = 0; i < getHandle().GetNE(); i++)
+      for (int i = 0; i < getElementCount(); i++)
          totalVolume += getHandle().GetElementVolume(i);
       return totalVolume;
    }
@@ -120,7 +140,7 @@ namespace Rodin
    double MeshBase::getVolume(int attr)
    {
       double totalVolume = 0;
-      for (int i = 0; i < getHandle().GetNE(); i++)
+      for (int i = 0; i < getElementCount(); i++)
          totalVolume += getHandle().GetElementVolume(i) * (getHandle().GetAttribute(i) == attr);
       return totalVolume;
    }
@@ -143,7 +163,7 @@ namespace Rodin
    double MeshBase::getPerimeter()
    {
       double totalArea = 0;
-      for (int i = 0; i < getHandle().GetNBE(); i++)
+      for (int i = 0; i < getElementCount(); i++)
          totalArea += getBoundaryElementArea(i);
       return totalArea;
    }
@@ -151,9 +171,38 @@ namespace Rodin
    double MeshBase::getPerimeter(int attr)
    {
       double totalVolume = 0;
-      for (int i = 0; i < getHandle().GetNBE(); i++)
+      for (int i = 0; i < getBoundaryElementCount(); i++)
          totalVolume += getBoundaryElementArea(i) * (getHandle().GetBdrAttribute(i) == attr);
       return totalVolume;
+   }
+
+   std::deque<std::set<int>> MeshBase::ccl(
+         std::function<bool(const Element&, const Element&)> p) const
+   {
+      std::set<int> visited;
+      std::deque<int> searchQueue;
+      std::deque<std::set<int>> res;
+
+      // Perform the labelling
+      for (int i = 0; i < getElementCount(); i++)
+      {
+         if (!visited.count(i))
+         {
+            res.push_back({});
+            searchQueue.push_back(i);
+            while (searchQueue.size() > 0)
+            {
+               int el = searchQueue.front();
+               searchQueue.pop_front();
+               visited.insert(el);
+               res.back().insert(el);
+               for (int n : getElement(el).adjacent())
+                  if (!visited.count(n) && p(getElement(el), getElement(n)))
+                     searchQueue.push_back(n);
+            }
+         }
+      }
+      return res;
    }
 
 #ifdef RODIN_USE_MPI
@@ -219,7 +268,7 @@ namespace Rodin
 
       // Count the number of elements in the trimmed mesh
       int ne = 0;
-      for (int i = 0; i < getHandle().GetNE(); i++)
+      for (int i = 0; i < getElementCount(); i++)
       {
          int elemAttr = getHandle().GetElement(i)->GetAttribute();
          ne += !attrs.count(elemAttr); // Count is always 0 or 1
@@ -258,7 +307,7 @@ namespace Rodin
          trimmed.AddVertex(getHandle().GetVertex(i));
 
       // Copy elements
-      for (int i = 0; i < getHandle().GetNE(); i++)
+      for (int i = 0; i < getElementCount(); i++)
       {
          mfem::Element* el = getHandle().GetElement(i);
          int elemAttr = el->GetAttribute();
@@ -272,7 +321,7 @@ namespace Rodin
       }
 
       // Copy selected boundary elements
-      for (int i = 0; i < getHandle().GetNBE(); i++)
+      for (int i = 0; i < getBoundaryElementCount(); i++)
       {
          int e, info;
          getHandle().GetBdrElementAdjacentElement(i, e, info);
@@ -391,7 +440,7 @@ namespace Rodin
 
          // Copy nodes to trimmed mesh
          int te = 0;
-         for (int e = 0; e < getHandle().GetNE(); e++)
+         for (int e = 0; e < getElementCount(); e++)
          {
             mfem::Element* el = getHandle().GetElement(e);
             int elemAttr = el->GetAttribute();
@@ -450,7 +499,7 @@ namespace Rodin
 
       // Determine mapping from vertex to boundary vertex
       std::set<int> bdrVertices;
-      for (int i = 0; i < getHandle().GetNBE(); i++)
+      for (int i = 0; i < getBoundaryElementCount(); i++)
       {
          mfem::Element* el = getHandle().GetBdrElement(i);
          int *v = el->GetVertices();
@@ -460,7 +509,7 @@ namespace Rodin
       }
 
       mfem::Mesh res(getDimension() - 1, bdrVertices.size(),
-            getHandle().GetNBE(), 0, getSpaceDimension());
+            getBoundaryElementCount(), 0, getSpaceDimension());
 
       // Copy vertices to the boundary mesh
       int vertexIdx = 0;
@@ -474,7 +523,7 @@ namespace Rodin
       }
 
       // Copy elements to the boundary mesh
-      for (int i = 0; i < getHandle().GetNBE(); i++)
+      for (int i = 0; i < getBoundaryElementCount(); i++)
       {
          mfem::Element *el = getHandle().GetBdrElement(i);
          int *v = el->GetVertices();
@@ -520,7 +569,7 @@ namespace Rodin
             mfem::Array<int> vdofs;
             mfem::Array<int> bvdofs;
             mfem::Vector v;
-            for (int i = 0; i < getHandle().GetNBE(); i++)
+            for (int i = 0; i < getBoundaryElementCount(); i++)
             {
                fes->GetBdrElementVDofs(i, vdofs);
                getHandle().GetNodes()->GetSubVector(vdofs, v);

--- a/src/Rodin/Mesh/Mesh.h
+++ b/src/Rodin/Mesh/Mesh.h
@@ -9,6 +9,7 @@
 
 #include <set>
 #include <string>
+#include <deque>
 
 #include <mfem.hpp>
 
@@ -33,9 +34,17 @@ namespace Rodin
    class MeshBase
    {
       public:
-         Element getElement(int i);
+         int getElementCount() const;
 
-         BoundaryElement getBoundaryElement(int i);
+         int getBoundaryElementCount() const;
+
+         ElementView getElement(int i);
+
+         Element getElement(int i) const;
+
+         FaceView getBoundaryElement(int i);
+
+         Face getBoundaryElement(int i) const;
 
          /**
           * @brief Gets the dimension of the ambient space
@@ -45,12 +54,19 @@ namespace Rodin
          int getSpaceDimension() const;
 
          /**
-          * @brief Gets the dimension of the elements
-          * @returns Dimension of the elements
+          * @brief Gets the dimension of the elements.
+          * @returns Dimension of the elements.
           * @see getSpaceDimension() const
           */
          int getDimension() const;
 
+         /**
+          * @brief Indicates whether the mesh is a surface or not.
+          * @returns True if mesh is a surface, false otherwise.
+          *
+          * A surface mesh is a mesh of codimension 1. That is, the difference
+          * between its space dimension and dimension is 1.
+          */
          bool isSurface() const;
 
          /**
@@ -140,6 +156,9 @@ namespace Rodin
           * will return 0 as the perimeter.
           */
          double getPerimeter(int attr);
+
+         std::deque<std::set<int>> ccl(
+               std::function<bool(const Element&, const Element&)> p) const;
 
          /**
           * @brief Indicates whether the mesh is a submesh or not.

--- a/src/Rodin/Mesh/Mesh.h
+++ b/src/Rodin/Mesh/Mesh.h
@@ -42,9 +42,9 @@ namespace Rodin
 
          Element getElement(int i) const;
 
-         FaceView getBoundaryElement(int i);
+         BoundaryElementView getBoundaryElement(int i);
 
-         Face getBoundaryElement(int i) const;
+         BoundaryElement getBoundaryElement(int i) const;
 
          /**
           * @brief Gets the dimension of the ambient space
@@ -157,8 +157,43 @@ namespace Rodin
           */
          double getPerimeter(int attr);
 
+         /**
+          * @brief Performs connected-component labelling.
+          * @param[in] p Function which returns true if two adjacent elements
+          * belong to the same component, false otherwise.
+          * @returns List of sets, each set representing a component containing
+          * the indices of its elements.
+          *
+          * @note Both elements passed to the function will always be adjacent
+          * to each other, i.e. it is not necessary to verify this is the case.
+          */
          std::deque<std::set<int>> ccl(
                std::function<bool(const Element&, const Element&)> p) const;
+
+         /**
+          * @brief Obtains a set of elements satisfying the given condition.
+          * @param[in] condition Function which returns true if the element
+          * satisfies the condition.
+          * @returns Set containing the element indices satisfying the
+          * condition.
+          */
+         std::set<int> where(std::function<bool(const Element&)> condition) const;
+
+         /**
+          * @brief Edits all elements in the mesh via the given function.
+          * @param[in] f Function which takes an ElementView to modify each
+          * element.
+          */
+         MeshBase& edit(std::function<void(ElementView)> f);
+
+         /**
+          * @brief Edits the specified elements in the mesh via the given function.
+          * @param[in] f Function which takes an ElementView to modify each
+          * element.
+          * @param[in] elements Set of indices corresponding to the elements
+          * which will be modified.
+          */
+         MeshBase& edit(std::function<void(ElementView)> f, const std::set<int>& elements);
 
          /**
           * @brief Indicates whether the mesh is a submesh or not.

--- a/src/Rodin/Mesh/SubMesh.h
+++ b/src/Rodin/Mesh/SubMesh.h
@@ -39,6 +39,7 @@ namespace Rodin
 
          /**
           * @brief Sets the SubMesh to Mesh vertex map
+          * @param[in] Map going from SubMesh to Mesh vertex indices.
           *
           * Each key-value pair in the map indicates the correspondence between
           * vertex indices in the SubMesh and vertex indices in the parent


### PR DESCRIPTION
# Mesh convenience

This PR adds the Element and ElementView classes, which are useful to query for different properties of the element and modify them. For example, to get the volume of an element one can use the following snippet of code:

```c++
Mesh mesh;
mesh.load("miaow.mesh");

// Get the volume of the 0-th element
int elementIdx = 0;
auto element = mesh.getElement(elementIdx);
std::cout << "Element " << elementIdx << " has volume: " << element.getVolume();
```

Furthermore, one can now set the attribute:
```
mesh.getElement(elementIdx).setAttribute(myNewAttribute);
```

Also one can now edit mesh elements easily. For example one can change materials via the following snippet of code: 
```c++
int oldAttribute = 1;
auto elements = mesh.where(
  [&](const Element& element) { return element.getAttribute() == oldAttribute; });

int newAttribute = 2;
mesh.edit(
  [&](ElementView element) { element.setAttribute(newAttribute); }, elements);
```

# Connected-component labelling


Finally, a CCL function has been added. The example of how to do this is `examples/Mesh/CCL.cpp`. In short, one can detect connected-components based on a predicate function. This function indicates whether two elements belong to the same component. For example, if we had a mesh with 2 attributes (black and white):

<img width="856" alt="Screenshot 2022-07-13 at 14 03 06" src="https://user-images.githubusercontent.com/6352283/178729331-2fdcd5cf-69b4-4229-a09d-be3efb4f0ceb.png">

we can call the `Mesh::ccl()` function to obtain the connected components which belong to the same attribute. Each color now represents a different component:

<img width="855" alt="Screenshot 2022-07-13 at 14 02 27" src="https://user-images.githubusercontent.com/6352283/178729451-b6e5393b-f5dd-4234-a472-8af385ca69e5.png">
