### PR TITLE
Fix ShapeOptimization LevelSetArch2D to build and run

### DIFF
--- a/examples/ShapeOptimization/CMakeLists.txt
+++ b/examples/ShapeOptimization/CMakeLists.txt
@@ -34,14 +34,14 @@ target_link_libraries(LevelSetCantilever2D
 #   Rodin::External::MMG
 #   )
 # 
-# add_executable(LevelSetArch2D LevelSetArch2D.cpp)
-# target_link_libraries(LevelSetArch2D
-#   PUBLIC
-#   Rodin::Geometry
-#   Rodin::Solver
-#   Rodin::Variational
-#   Rodin::External::MMG
-#   )
+add_executable(LevelSetArch2D LevelSetArch2D.cpp)
+target_link_libraries(LevelSetArch2D
+  PUBLIC
+  Rodin::Geometry
+  Rodin::Solver
+  Rodin::Variational
+  Rodin::External::MMG
+  )
 
 # Commented out because it breaks CI
 # add_executable(LevelSetEigenvalue2D LevelSetEigenvalue2D.cpp)

--- a/examples/ShapeOptimization/LevelSetArch2D.cpp
+++ b/examples/ShapeOptimization/LevelSetArch2D.cpp
@@ -4,161 +4,158 @@
  *       (See accompanying file LICENSE or copy at
  *          https://www.boost.org/LICENSE_1_0.txt)
  */
+#include "Rodin/Geometry/Region.h"
+#include "Rodin/Models/Advection/Lagrangian.h"
+#include "Rodin/Models/Distance/Eikonal.h"
 #include <Rodin/Solver.h>
+#include <Rodin/Assembly.h>
 #include <Rodin/Geometry.h>
 #include <Rodin/Variational.h>
+#include <Rodin/Variational/LinearElasticity.h>
 #include <RodinExternal/MMG.h>
 
 using namespace Rodin;
-using namespace Rodin::External;
 using namespace Rodin::Geometry;
+using namespace Rodin::External;
 using namespace Rodin::Variational;
 
 // Define interior and exterior for level set discretization
-static constexpr int Interior = 1, Exterior = 2;
+static constexpr Attribute interior = 1, exterior = 2;
 
 // Define boundary attributes
-static constexpr int Gamma0 = 1;  // Traction free boundary
-static constexpr int GammaD = 2;  // Homogenous Dirichlet
-static constexpr int GammaN = 3;  // Inhomogenous Neumann
-static constexpr int Gamma  = 4;  // Shape boundary
+static constexpr Attribute Gamma0 = 1, GammaD = 2, GammaN = 3, Gamma = 4;
 
 // Lamé coefficients
-static constexpr double mu    = 0.3846;
+static constexpr double mu = 0.3846;
 static constexpr double lambda = 0.5769;
 
 // Optimization parameters
 static constexpr size_t maxIt = 250;
 static constexpr double eps  = 1e-6;
 static constexpr double hmax  = 0.05;
+static constexpr double hmin = 0.1 * hmax;
+static constexpr double hausd = 0.5 * hmin;
 static constexpr double ell  = 0.2;
-static constexpr double alpha = 4 * hmax * hmax;
+const constexpr Real dt = 0.5 * (hmax - hmin);
+static constexpr double alpha = 0.1;
 
-// Compliance
-double compliance(GridFunction<H1<Context::Serial>>& w);
+using FES = VectorP1<Mesh<Context::Local>>;
+
+template <class Data>
+Real compliance(const GridFunction<FES, Data>& w)
+{
+  auto& vh = w.getFiniteElementSpace();
+  TrialFunction u(vh);
+  TestFunction  v(vh);
+  BilinearForm  bf(u, v);
+  bf = LinearElasticityIntegral(u, v)(lambda, mu);
+  bf.assemble();
+  return bf(w, w);
+}
 
 int main(int, char**)
 {
-  const char* meshFile = "../resources/mfem/levelset-arch2d-example.mesh";
+  const char* meshFile = "../resources/examples/ShapeOptimization/LevelSetArch2D.mfem.mesh";
 
   // Load mesh
-  MMG::Mesh Omega;
-  Omega.load(meshFile);
+  MMG::Mesh th;
+  th.load(meshFile);
+  MMG::Optimizer().setHMax(hmax).setHMin(hmin).optimize(th);
 
-  MMG::MeshOptimizer().setHMax(hmax / 2.0).optimize(Omega);
-
-  Omega.save("Omega0.mesh");
+  th.save("Omega0.mesh", IO::FileFormat::MEDIT);
 
   Alert::Info() << "Saved initial mesh to Omega0.mesh" << Alert::Raise;
 
-  Solver::UMFPack solver;
-
   // Optimization loop
   std::vector<double> obj;
+  std::ofstream fObj("obj.txt");
   for (size_t i = 0; i < maxIt; i++)
   {
-   Alert::Info() << "----- Iteration: " << i << Alert::Raise;
+    th.getConnectivity().compute(1, 2);
+    th.getConnectivity().compute(0, 0);
+    Alert::Info() << "----- Iteration: " << i << Alert::Raise;
 
-   // Vector field finite element space over the whole domain
-   int d = 2;
-   H1 Vh(Omega, d);
+    SubMesh trimmed = th.trim(exterior);
+    trimmed.save("Omega.mesh");
 
-   // Trim the exterior part of the mesh to solve the elasticity system
-   SubMesh trimmed = Omega.trim(Exterior);
+    const size_t d = th.getSpaceDimension();
+    P1 sh(th);
+    P1 vh(th, d);
+    P1 vhInt(trimmed, d);
 
-   // Build a finite element space over the trimmed mesh
-   H1 VhInt(trimmed, d);
+    auto f = VectorFunction{0, -1};
+    TrialFunction u(vhInt);
+    TestFunction  v(vhInt);
+    Problem elasticity(u, v);
+    elasticity = LinearElasticityIntegral(u, v)(lambda, mu)
+               - BoundaryIntegral(f, v).over(GammaN)
+               + DirichletBC(u, VectorFunction{0, 0}).on(GammaD);
+    Solver::CG(elasticity).solve();
 
-   // Elasticity equation
-   auto f = VectorFunction{0, -1};
-   TrialFunction uInt(VhInt);
-   TestFunction  vInt(VhInt);
-   Problem elasticity(uInt, vInt);
-   elasticity = Integral(lambda * Div(uInt), Div(vInt))
-          + Integral(
-             mu * (Jacobian(uInt) + Jacobian(uInt).T()), 0.5 * (Jacobian(vInt) + Jacobian(vInt).T()))
-          - BoundaryIntegral(f, vInt).over(GammaN)
-          + DirichletBC(uInt, VectorFunction{0, 0}).on(GammaD);
-   elasticity.solve(solver);
+    auto jac = Jacobian(u.getSolution());
+    jac.traceOf(interior);
+    auto e = 0.5 * (jac + jac.T());
+    auto Ae = 2.0 * mu * e + lambda * Trace(e) * IdentityMatrix(d);
+    auto n = FaceNormal(th);
+    n.traceOf(interior);
 
-   auto jac = Jacobian(uInt.getSolution());
-   jac.traceOf(Interior);
+    TrialFunction g(vh);
+    TestFunction w(vh);
+    Problem hilbert(g, w);
+    hilbert = Integral(alpha * alpha * Jacobian(g), Jacobian(w))
+            + Integral(g, w)
+            - FaceIntegral(Dot(Ae, e) - ell, Dot(n, w)).over(Gamma)
+            + DirichletBC(g, VectorFunction{0, 0, 0}).on(GammaN);
+    Solver::CG(hilbert).solve();
 
-   // Hilbert extension-regularization procedure
-   auto e = 0.5 * (jac + jac.T());
-   auto Ae = 2.0 * mu * e + lambda * Trace(e) * IdentityMatrix(d);
-   auto n = Normal(d);
-   n.traceOf(Interior);
+    auto& dJ = g.getSolution();
+    const double objective = compliance(u.getSolution()) + ell * th.getArea(interior);
+    obj.push_back(objective);
+    fObj << objective << "\n";
+    fObj.flush();
+    Alert::Info() << "   | Objective: " << objective << Alert::Raise;
 
-   TrialFunction g(Vh);
-   TestFunction  v(Vh);
-   Problem hilbert(g, v);
-   hilbert = Integral(alpha * Jacobian(g), Jacobian(v))
-        + Integral(g, v)
-        - FaceIntegral(Dot(Ae, e) - ell, Dot(n, v)).over(Gamma)
-        + DirichletBC(g, VectorFunction{0, 0}).on(GammaN);
-   hilbert.solve(solver);
-   g.getSolution().save("g.gf");
-   Omega.save("g.mesh");
+    GridFunction dist(sh);
+    Models::Distance::Eikonal(dist).setInterior(interior)
+                                   .setInterface(Gamma)
+                                   .solve()
+                                   .sign();
 
-   // Update objective
-   obj.push_back(
-      compliance(uInt.getSolution()) + ell * Omega.getVolume(Interior));
-   Alert::Info() << "   | Objective: " << obj[i] << Alert::Raise;
+    GridFunction norm(sh);
+    norm = Frobenius(dJ);
+    dJ /= norm.max();
 
-   // Generate signed distance function
-   H1 Dh(Omega);
-   auto dist = MMG::Distancer(Dh).setInteriorDomain(Interior)
-                       .distance(Omega);
+    TrialFunction advect(sh);
+    TestFunction test(sh);
+    Models::Advection::Lagrangian(advect, test, dist, dJ).step(dt);
 
-   // Advect the level set function
-   Alert::Info() << "   | Advecting the distance function." << Alert::Raise;
-   GridFunction gNorm(Dh);
-   gNorm = RealFunction(
-      [&](const Point& v) -> double
-      {
-       Math::Vector val = g.getSolution()(v);
-       return val.norm();
-      });
-   double gInf = gNorm.max();
-   double dt = 4 * hmax / gInf;
-   MMG::Advect(dist, g.getSolution()).step(dt);
+    th = MMG::ImplicitDomainMesher().split(interior, {interior, exterior})
+                                    .split(exterior, {interior, exterior})
+                                    .setRMC(1e-6)
+                                    .setHMax(hmax)
+                                    .setHMin(hmin)
+                                    .setHausdorff(hausd)
+                                    .setAngleDetection(false)
+                                    .setBoundaryReference(Gamma)
+                                    .setBaseReferences(GammaD)
+                                    .discretize(advect.getSolution());
 
-   // Recover the implicit domain
-   Omega = MMG::ImplicitDomainMesher().split(Interior, {Interior, Exterior})
-                          .split(Exterior, {Interior, Exterior})
-                          .setRMC(1e-3)
-                          .setAngleDetection(false)
-                          .setBoundaryReference(Gamma)
-                          .setBaseReferences(GammaD)
-                          .discretize(dist);
-   MMG::MeshOptimizer().setHMax(hmax).optimize(Omega);
+    MMG::Optimizer().setHMax(hmax)
+                    .setHMin(hmin)
+                    .setHausdorff(hausd)
+                    .setAngleDetection(false)
+                    .optimize(th);
 
-   // Save mesh
-   Omega.save("Omega.mesh");
+    th.save("out/Omega." + std::to_string(i) + ".mesh");
 
-   // Test for convergence
-   if (obj.size() >= 2 && abs(obj[i] - obj[i - 1]) < eps)
-   {
-    Alert::Info() << "Convergence!" << Alert::Raise;
-    break;
-   }
+    if (obj.size() >= 2 && std::abs(obj[i] - obj[i - 1]) < eps)
+    {
+      Alert::Info() << "Convergence!" << Alert::Raise;
+      break;
+    }
   }
 
-  Alert::Info() << "Saved final mesh to Omega.mesh" << Alert::Raise;
+  Alert::Info() << "Saved final meshes to out/Omega.*.mesh" << Alert::Raise;
 
   return 0;
 }
-
-double compliance(GridFunction<H1<Context::Serial>>& w)
-{
-  auto& Vh = w.getFiniteElementSpace();
-  TrialFunction u(Vh);
-  TestFunction  v(Vh);
-  BilinearForm  bf(u, v);
-  bf = Integral(lambda * Div(u), Div(v))
-    + Integral(
-      mu * (Jacobian(u) + Jacobian(u).T()), 0.5 * (Jacobian(v) + Jacobian(v).T()));
-  return bf(w, w);
-};
-


### PR DESCRIPTION
## Summary
Fix `examples/ShapeOptimization/LevelSetArch2D.cpp` so the example can be built and executed with current Rodin APIs.

## Changes
- Update `LevelSetArch2D.cpp` to current FEM/optimization workflow APIs.
- Re-enable `LevelSetArch2D` target in `examples/ShapeOptimization/CMakeLists.txt`.
- Keep behavior consistent with existing shape-optimization examples.

## Validation
- Build target: `LevelSetArch2D`
- Run example and verify it produces optimization outputs (`Omega*.mesh`, objective history).
