### PR TITLE
Add configurable reconciliation options and throttled global checks to MPIMesh::reconcile

### DIFF
--- a/src/Rodin/MPI/Geometry/Mesh.cpp
+++ b/src/Rodin/MPI/Geometry/Mesh.cpp
@@ -491,6 +491,11 @@ namespace Rodin::Geometry
 
   Mesh<Context::MPI>& MPIMesh::reconcile(size_t d)
   {
+    return reconcile(d, ReconcileOptions::SmallToMidModeratePartitions());
+  }
+
+  Mesh<Context::MPI>& MPIMesh::reconcile(size_t d, const ReconcileOptions& options)
+  {
     auto& shard = this->getShard();
     auto& conn  = shard.getConnectivity();
 
@@ -748,8 +753,21 @@ namespace Rodin::Geometry
     // --------------------------------------------------------------------------
     using OwnerMsg = std::pair<Index, int>;
 
+    const size_t checkPeriod = std::max<size_t>(1, options.globalCheckPeriod);
+    size_t ownerRounds = 0;
+    bool ownerDirtySinceCheck = false;
     while (true)
     {
+      if (ownerRounds >= options.maxOwnerRounds)
+      {
+        if (options.strictRoundCap)
+        {
+          throw std::runtime_error(
+              "MPIMesh::reconcile owner convergence exceeded maxOwnerRounds");
+        }
+      }
+      ++ownerRounds;
+
       std::vector<std::vector<OwnerMsg>> sendbuf(neighbors.size());
 
       for (size_t k = 0; k < neighbors.size(); ++k)
@@ -791,11 +809,19 @@ namespace Rodin::Geometry
 
       boost::mpi::wait_all(reqs.begin(), reqs.end());
 
-      bool globallyChanged = false;
-      boost::mpi::all_reduce(comm, changed, globallyChanged, std::logical_or<bool>());
+      ownerDirtySinceCheck = ownerDirtySinceCheck || changed;
 
-      if (!globallyChanged)
-        break;
+      const bool forceCheck = !changed;
+      const bool periodicCheck = (ownerRounds % checkPeriod) == 0;
+      if (forceCheck || periodicCheck)
+      {
+        bool globallyChanged = false;
+        boost::mpi::all_reduce(comm, ownerDirtySinceCheck, globallyChanged, std::logical_or<bool>());
+        ownerDirtySinceCheck = false;
+
+        if (!globallyChanged)
+          break;
+      }
     }
 
     for (Index i = 0; i < static_cast<Index>(nd); ++i)
@@ -833,8 +859,20 @@ namespace Rodin::Geometry
     // --------------------------------------------------------------------------
     using GidMsg = std::pair<Index, Index>;
 
+    size_t gidRounds = 0;
+    bool gidDirtySinceCheck = false;
     while (true)
     {
+      if (gidRounds >= options.maxGidRounds)
+      {
+        if (options.strictRoundCap)
+        {
+          throw std::runtime_error(
+              "MPIMesh::reconcile gid convergence exceeded maxGidRounds");
+        }
+      }
+      ++gidRounds;
+
       std::vector<std::vector<GidMsg>> sendbuf(neighbors.size());
 
       for (size_t k = 0; k < neighbors.size(); ++k)
@@ -882,11 +920,19 @@ namespace Rodin::Geometry
 
       boost::mpi::wait_all(reqs.begin(), reqs.end());
 
-      bool globallyChanged = false;
-      boost::mpi::all_reduce(comm, changed, globallyChanged, std::logical_or<bool>());
+      gidDirtySinceCheck = gidDirtySinceCheck || changed;
 
-      if (!globallyChanged)
-        break;
+      const bool forceCheck = !changed;
+      const bool periodicCheck = (gidRounds % checkPeriod) == 0;
+      if (forceCheck || periodicCheck)
+      {
+        bool globallyChanged = false;
+        boost::mpi::all_reduce(comm, gidDirtySinceCheck, globallyChanged, std::logical_or<bool>());
+        gidDirtySinceCheck = false;
+
+        if (!globallyChanged)
+          break;
+      }
     }
 
     for (Index i = 0; i < static_cast<Index>(nd); ++i)

--- a/src/Rodin/MPI/Geometry/Mesh.h
+++ b/src/Rodin/MPI/Geometry/Mesh.h
@@ -17,6 +17,7 @@
  */
 
 #include <mpi.h>
+#include <limits>
 #include <type_traits>
 
 #include "Rodin/Configure.h"
@@ -775,6 +776,83 @@ namespace Rodin::Geometry
        * @return Reference to the mesh.
        */
       Mesh& reconcile(size_t d);
+
+      /**
+       * @brief Options controlling iterative reconciliation rounds.
+       */
+      struct ReconcileOptions
+      {
+        /**
+         * @brief Legacy behavior preset.
+         *
+         * Checks global convergence every round and uses unlimited rounds.
+         */
+        static ReconcileOptions Legacy()
+        {
+          ReconcileOptions opts;
+          opts.maxOwnerRounds = std::numeric_limits<size_t>::max();
+          opts.maxGidRounds = std::numeric_limits<size_t>::max();
+          opts.globalCheckPeriod = 1;
+          opts.strictRoundCap = false;
+          return opts;
+        }
+
+        /**
+         * @brief Preset for small-to-mid entity counts and moderate partitions.
+         *
+         * This preset keeps robust convergence while reducing global checks.
+         */
+        static ReconcileOptions SmallToMidModeratePartitions()
+        {
+          ReconcileOptions opts;
+          opts.maxOwnerRounds = 12;
+          opts.maxGidRounds = 12;
+          opts.globalCheckPeriod = 2;
+          opts.strictRoundCap = false;
+          return opts;
+        }
+
+        /**
+         * Maximum number of owner-convergence rounds.
+         *
+         * Defaults to unlimited.
+         */
+        size_t maxOwnerRounds = std::numeric_limits<size_t>::max();
+
+        /**
+         * Maximum number of gid-convergence rounds.
+         *
+         * Defaults to unlimited.
+         */
+        size_t maxGidRounds = std::numeric_limits<size_t>::max();
+
+        /**
+         * Controls how often global convergence is checked.
+         *
+         * A value of 1 checks every round (legacy behavior). Larger values reduce
+         * the frequency of global all-reduce operations during active convergence.
+         */
+        size_t globalCheckPeriod = 1;
+
+        /**
+         * If true, exceeding a round cap throws; otherwise reconciliation keeps
+         * converging with existing state.
+         */
+        bool strictRoundCap = false;
+      };
+
+      /**
+       * @brief Reconciles entities of dimension @p d with configurable options.
+       *
+       * For a convenience baseline tuned for small-to-mid entity counts and
+       * moderate partition counts, use
+       * ReconcileOptions::SmallToMidModeratePartitions().
+       *
+       * @param[in] d Topological dimension of the entities to reconcile.
+       * @param[in] options Reconciliation options.
+       * @return Reference to the mesh.
+       */
+      Mesh& reconcile(size_t d, const ReconcileOptions& options);
 
     private:
       /// MPI execution context associated with this distributed mesh.

--- a/tests/unit/Rodin/MPI/Geometry/SharderTest.cpp
+++ b/tests/unit/Rodin/MPI/Geometry/SharderTest.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <numeric>
 #include <cstdio>
+#include <limits>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -2002,6 +2003,82 @@ namespace Rodin::Tests::Unit
         << "Rank " << world.rank()
         << ": edge " << i << " state changed on second reconcile.";
     }
+  }
+
+  /**
+   * @brief Verifies that strict round caps are enforced for reconcile().
+   */
+  TEST(Rodin_MPI_Geometry_Mesh, Reconcile_Edges2D_StrictRoundCapThrows)
+  {
+    const auto& world = *g_world;
+    if (world.size() < 2 || world.size() > 3)
+      GTEST_SKIP() << "Test requires 2 or 3 MPI ranks.";
+
+    Context::MPI ctx(*g_env, world);
+    auto mpiMesh = Mesh<Context::MPI>::UniformGrid(ctx, Polytope::Type::Triangle, {4, 4});
+    mpiMesh.getConnectivity().compute(1, 2);
+
+    Mesh<Context::MPI>::ReconcileOptions opts;
+    opts.maxOwnerRounds = 0;
+    opts.strictRoundCap = true;
+
+    EXPECT_THROW(mpiMesh.reconcile(1, opts), std::runtime_error);
+  }
+
+  /**
+   * @brief Verifies that throttled global checks preserve reconcile correctness.
+   */
+  TEST(Rodin_MPI_Geometry_Mesh, Reconcile_Edges2D_GlobalCheckPeriodPreservesState)
+  {
+    const auto& world = *g_world;
+    if (world.size() > 3)
+      GTEST_SKIP() << "Test designed for at most 3 MPI ranks.";
+
+    Context::MPI ctx(*g_env, world);
+    auto baseline = Mesh<Context::MPI>::UniformGrid(ctx, Polytope::Type::Triangle, {4, 4});
+    auto throttled = Mesh<Context::MPI>::UniformGrid(ctx, Polytope::Type::Triangle, {4, 4});
+
+    baseline.getConnectivity().compute(1, 2);
+    throttled.getConnectivity().compute(1, 2);
+
+    baseline.reconcile(1);
+
+    Mesh<Context::MPI>::ReconcileOptions opts;
+    opts.globalCheckPeriod = 3;
+    throttled.reconcile(1, opts);
+
+    const auto& bShard = baseline.getShard();
+    const auto& tShard = throttled.getShard();
+
+    ASSERT_EQ(bShard.getPolytopeCount(1), tShard.getPolytopeCount(1));
+
+    for (Index i = 0; i < bShard.getPolytopeCount(1); ++i)
+    {
+      EXPECT_EQ(bShard.getPolytopeMap(1).left.at(i), tShard.getPolytopeMap(1).left.at(i))
+        << "Rank " << world.rank() << ": edge gid mismatch at local index " << i;
+
+      EXPECT_EQ(bShard.isOwned(1, i), tShard.isOwned(1, i))
+        << "Rank " << world.rank() << ": owned flag mismatch at local index " << i;
+      EXPECT_EQ(bShard.isShared(1, i), tShard.isShared(1, i))
+        << "Rank " << world.rank() << ": shared flag mismatch at local index " << i;
+      EXPECT_EQ(bShard.isGhost(1, i), tShard.isGhost(1, i))
+        << "Rank " << world.rank() << ": ghost flag mismatch at local index " << i;
+    }
+  }
+
+  TEST(Rodin_MPI_Geometry_Mesh, ReconcileOptions_Presets)
+  {
+    const auto legacy = Mesh<Context::MPI>::ReconcileOptions::Legacy();
+    EXPECT_EQ(legacy.globalCheckPeriod, 1u);
+    EXPECT_EQ(legacy.maxOwnerRounds, std::numeric_limits<size_t>::max());
+    EXPECT_EQ(legacy.maxGidRounds, std::numeric_limits<size_t>::max());
+    EXPECT_FALSE(legacy.strictRoundCap);
+
+    const auto tuned = Mesh<Context::MPI>::ReconcileOptions::SmallToMidModeratePartitions();
+    EXPECT_EQ(tuned.globalCheckPeriod, 2u);
+    EXPECT_EQ(tuned.maxOwnerRounds, 12u);
+    EXPECT_EQ(tuned.maxGidRounds, 12u);
+    EXPECT_FALSE(tuned.strictRoundCap);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce costly global all-reduce frequency during iterative owner/gid convergence and provide tunable limits to convergence rounds for distributed mesh reconciliation.
- Preserve legacy behavior by providing a compatibility preset while offering a tuned default for small-to-mid entity counts and moderate partitioning.
- Expose behavior control to tests and callers so strict round caps and periodic global checks can be validated.

### Description
- Introduces `Mesh<Context::MPI>::ReconcileOptions` with presets `Legacy()` and `SmallToMidModeratePartitions()` and fields `maxOwnerRounds`, `maxGidRounds`, `globalCheckPeriod`, and `strictRoundCap`.
- Adds an overload `Mesh::reconcile(size_t d, const ReconcileOptions& options)` and makes the old `reconcile(size_t d)` delegate to `reconcile(d, ReconcileOptions::SmallToMidModeratePartitions())`.
- Implements throttled global convergence checks by tracking per-loop rounds and dirty flags (`ownerRounds`, `gidRounds`, `*DirtySinceCheck`) and only performing the global `all_reduce` when forced or on a periodic boundary, and throws when a strict round cap is exceeded.
- Adds a `<limits>` include and updates unit tests to validate strict round cap behavior, correctness when using a larger `globalCheckPeriod`, and the correctness of the preset values.

### Testing
- Added unit tests in `tests/unit/Rodin/MPI/Geometry/SharderTest.cpp`: `Reconcile_Edges2D_StrictRoundCapThrows`, `Reconcile_Edges2D_GlobalCheckPeriodPreservesState`, and `ReconcileOptions_Presets` to cover the new options and behavior.
- Ran the updated unit test file `tests/unit/Rodin/MPI/Geometry/SharderTest.cpp` (MPI-enabled tests) and the new tests passed.
- Full unit test suite was executed (CI/local `ctest` run) and completed successfully for the modified components.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c6c60a18832c95e76f25894c9322)