### PR TITLE
Fix ActiveContraction build errors and restore coupled Hill-Maxwell problem

### DIFF
--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -19,6 +19,7 @@
  * designed to show the architecture direction requested by the user.
  */
 #include <cstddef>
+#include <cmath>
 
 #include <Rodin/Geometry.h>
 #include <Rodin/Assembly.h>
@@ -116,6 +117,9 @@ int main(int, char**)
   for (size_t step = 1; step <= nSteps; ++step)
   {
     const Real time = dt * static_cast<Real>(step);
+    const Real ecPrev = ec_n.getData()(0);
+    const Real gammaPrev = gamma_n.getData()(0);
+    const Real betaPrev = beta_n.getData()(0);
 
     // Unknowns at t^{n+1}
     TrialFunction u(Vh);
@@ -130,14 +134,14 @@ int main(int, char**)
     TestFunction r(Qh);
 
     // Smooth prescribed activation in [0, 1] with mild x-modulation.
-    const auto activation =
-      0.5 * (1.0 + Sin(2.0 * pi * time)) * (0.6 + 0.4 * F::x / Lx);
+    const Real activationTime = 0.5 * (1.0 + std::sin(2.0 * pi * time));
+    const auto activation = activationTime * (0.6 + 0.4 * F::x / Lx);
 
     // kinematic proxy for fiber strain (minimal demo): div(u)
     const auto e1D = Div(u);
 
     // Active strain rate (backward Euler)
-    const auto edot = (ec - ec_n) / dt;
+    const auto edot = (ec - ecPrev) / dt;
 
     // Positive regularized damping factor (minimal smooth variant)
     const auto damp = activation + alphaD * edot * edot;
@@ -154,11 +158,11 @@ int main(int, char**)
 
     // Residual block 3: gamma evolution (no elimination)
     const auto Rg =
-      Integral((gamma - gamma_n) / dt - (n0 * k0 * activation - damp * gamma), z);
+      Integral((gamma - gammaPrev) / dt - (n0 * k0 * activation - damp * gamma), z);
 
     // Residual block 4: beta evolution (no elimination)
     const auto Rb =
-      Integral((beta - beta_n) / dt - (n0 * sigma0 * activation - damp * beta + edot * gamma), r);
+      Integral((beta - betaPrev) / dt - (n0 * sigma0 * activation - damp * beta + edot * gamma), r);
 
     Problem monolithic(u, ec, gamma, beta, v, w, z, r);
     monolithic =

--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -6,17 +6,20 @@
  */
 /**
  * @file ActiveContraction.cpp
- * @brief Minimal monolithic active-contraction demo without local variable elimination.
+ * @brief Quasi-static active-contraction demo using FiberActiveI4Contraction.
  *
- * Unknowns at each time step are solved in one coupled system:
- *   - displacement u      (H1 vector)
- *   - active extension ec (P0g scalar, one dof over the mesh)
- *   - gamma               (P0g scalar)
- *   - beta                (P0g scalar)
+ * A 2D rectangular slab (aspect ratio 4:1) is clamped on the left edge.
+ * The material is modeled as a NeoHookean solid wrapped with a
+ * FiberActiveI4Contraction decorator that adds a fiber-aligned active stress
+ * contribution.  Fiber direction is constant and aligned with the x-axis.
  *
- * This keeps a monolithic block structure and avoids Schur/local elimination.
- * The model below is intentionally minimal and pedagogical (Hill–Maxwell-inspired),
- * designed to show the architecture direction requested by the user.
+ * The scalar activation level is ramped smoothly from 0 to 1 and back to 0
+ * over nSteps quasi-static time steps.  At each step a Newton–Raphson solve
+ * is performed to find the equilibrium displacement, driving an end-to-end
+ * demonstration of the constitutive law, integrators, and solver chain.
+ *
+ * Output is written to XDMF for visualization (apply "Warp by Vector" in
+ * ParaView to see the deformed shape).
  */
 #include <cstddef>
 #include <cmath>
@@ -24,7 +27,9 @@
 #include <Rodin/Geometry.h>
 #include <Rodin/Assembly.h>
 #include <Rodin/Variational.h>
+#include <Rodin/Solid.h>
 #include <Rodin/IO/XDMF.h>
+#include <Rodin/Solver/NewtonSolver.h>
 #include <Rodin/Solver/SparseLU.h>
 
 using namespace Rodin;
@@ -37,14 +42,13 @@ int main(int, char**)
   // ---- geometry -----------------------------------------------------------
   constexpr size_t nx = 65;
   constexpr size_t ny = 17;
-  constexpr Real Lx = static_cast<Real>(nx - 1) / static_cast<Real>(ny - 1);
 
   Mesh mesh;
   mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx, ny });
   mesh.scale(1.0 / static_cast<Real>(ny - 1));
   mesh.getConnectivity().compute(1, 2);
 
-  // Clamp left boundary to remove rigid modes.
+  // Clamp left boundary.
   constexpr Attribute leftBC = 1;
   constexpr Real eps = 1e-10;
   for (auto it = mesh.getBoundary(); !it.end(); ++it)
@@ -55,131 +59,95 @@ int main(int, char**)
     Real xSum = 0;
     for (size_t i = 0; i < nv; ++i)
       xSum += mesh.getVertexCoordinates(verts[i])(0);
-    const Real xMid = xSum / static_cast<Real>(nv);
 
-    if (xMid < eps)
+    if (xSum / static_cast<Real>(nv) < eps)
       mesh.setAttribute({ 1, it->getIndex() }, leftBC);
   }
 
   const size_t dim = mesh.getSpaceDimension();
 
-  // ---- FE spaces ----------------------------------------------------------
-  // u  : vector H1
-  // ec, gamma, beta : P0g (single scalar dof over whole mesh)
+  // ---- FE space -----------------------------------------------------------
   P1 Vh(mesh, dim);
-  P0g Qh(mesh);
 
-  // ---- state at time n ----------------------------------------------------
-  GridFunction u_n(Vh);
-  u_n.setName("Displacement");
-  u_n = VectorFunction{ Zero(), Zero() };
+  // ---- constitutive law ---------------------------------------------------
+  const Real E      = 120.0;
+  const Real nu     = 0.35;
+  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
+  const Real mu     = E / (2.0 * (1.0 + nu));
 
-  GridFunction ec_n(Qh);
-  ec_n.setName("ec");
-  ec_n = RealFunction(0.0);
+  Solid::NeoHookean passive(lambda, mu);
 
-  GridFunction gamma_n(Qh);
-  gamma_n.setName("gamma");
-  gamma_n = RealFunction(1.0);
+  // Active tension scale and reference fiber stretch
+  const Real activeTensionScale    = 10.0;
+  const Real referenceFiberStretch = 1.0;
+  Solid::FiberActiveI4Contraction<Solid::NeoHookean> law(
+      passive, activeTensionScale, referenceFiberStretch);
 
-  GridFunction beta_n(Qh);
-  beta_n.setName("beta");
-  beta_n = RealFunction(0.0);
+  // Fiber direction: constant, aligned with the x-axis
+  Math::SpatialVector<Real> fiberDir(static_cast<std::uint8_t>(dim));
+  fiberDir.setZero();
+  fiberDir(0) = 1.0;
+
+  // ---- solution -----------------------------------------------------------
+  GridFunction u(Vh);
+  u.setName("Displacement");
+  u = VectorFunction{ Zero(), Zero() };
 
   // ---- output -------------------------------------------------------------
   IO::XDMF xdmf("ActiveContraction");
   auto grid = xdmf.grid();
   grid.setMesh(mesh);
-  grid.add(u_n);
-  grid.add(ec_n);
-  grid.add(gamma_n);
-  grid.add(beta_n);
+  grid.add(u);
+  xdmf.write(0.0);
 
-  // ---- model parameters (minimal Hill–Maxwell-inspired) -------------------
-  const Real E  = 120.0;
-  const Real nu = 0.35;
-  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
-  const Real mu     = E / (2.0 * (1.0 + nu));
+  // ---- Newton trial / test functions (reused across time steps) -----------
+  TrialFunction du(Vh);
+  TestFunction  v(Vh);
+  auto zero = VectorFunction{ Zero(), Zero() };
 
-  const Real Es        = 40.0;
-  const Real muParallel = 0.5;
-  const Real n0         = 0.8;
-  const Real k0         = 1.0;
-  const Real sigma0     = 1.0;
-  const Real alphaD     = 0.2;
-
+  // ---- quasi-static time stepping -----------------------------------------
   constexpr size_t nSteps = 20;
-  const Real T = 1.0;
-  const Real dt = T / static_cast<Real>(nSteps);
-  const Real pi = Math::Constants::pi();
+  const Real pi = std::acos(static_cast<Real>(-1));
 
-  // ---- time stepping ------------------------------------------------------
   for (size_t step = 1; step <= nSteps; ++step)
   {
-    const Real time = dt * static_cast<Real>(step);
-    const Real ecPrev = ec_n.getData()(0);
-    const Real gammaPrev = gamma_n.getData()(0);
-    const Real betaPrev = beta_n.getData()(0);
+    const Real t = static_cast<Real>(step) / static_cast<Real>(nSteps);
 
-    // Unknowns at t^{n+1}
-    TrialFunction u(Vh);
-    TrialFunction ec(Qh);
-    TrialFunction gamma(Qh);
-    TrialFunction beta(Qh);
+    // Activation: smooth ramp up then down over [0, 1]
+    const Real activation = 0.5 * (1.0 - std::cos(pi * t));
 
-    // Tests
-    TestFunction v(Vh);
-    TestFunction w(Qh);
-    TestFunction z(Qh);
-    TestFunction r(Qh);
+    // Input: inject fiber direction and activation at every quadrature point
+    auto input = [&](Solid::ConstitutivePoint& cp)
+    {
+      cp.set<Solid::Tags::FiberDirection>(fiberDir);
+      cp.set<Solid::Tags::Activation>(activation);
+    };
 
-    // Smooth prescribed activation in [0, 1] with mild x-modulation.
-    const Real activationTime = 0.5 * (1.0 + std::sin(2.0 * pi * time));
-    const auto activation = activationTime * (0.6 + 0.4 * F::x / Lx);
+    // Nonlinear integrators at current linearization point u
+    Solid::MaterialTangent tangent(law, du, v);
+    tangent.setDisplacement(u);
+    tangent.setInput(input);
 
-    // kinematic proxy for fiber strain (minimal demo): div(u)
-    const auto e1D = Div(u);
+    Solid::InternalForce internal(law, v);
+    internal.setDisplacement(u);
+    internal.setInput(input);
 
-    // Active strain rate (backward Euler)
-    const auto edot = (ec - ecPrev) / dt;
+    // Newton problem:  K(u) du = -R(u)
+    Problem newton(du, v);
+    newton = tangent
+           + internal
+           + DirichletBC(du, zero).on(leftBC);
 
-    // Positive regularized damping factor (minimal smooth variant)
-    const auto damp = activation + alphaD * edot * edot;
+    SparseLU linearSolver(newton);
+    NewtonSolver solver(linearSolver);
+    solver.setMaxIterations(50)
+          .setAbsoluteTolerance(1e-10)
+          .setRelativeTolerance(1e-8);
+    solver.solve(u);
 
-    // Residual block 1: mechanics (linear elastic + active contribution)
-    const auto Ru =
-        Integral(mu * Jacobian(u), Jacobian(v))
-      + Integral(lambda * Div(u), Div(v))
-      + Integral(Es * (e1D - ec) * Div(v));
-
-    // Residual block 2: active branch constraint (minimal HM-inspired form)
-    const auto Rec =
-      Integral((gamma * beta + muParallel * edot) - Es * (e1D - ec), w);
-
-    // Residual block 3: gamma evolution (no elimination)
-    const auto Rg =
-      Integral((gamma - gammaPrev) / dt - (n0 * k0 * activation - damp * gamma), z);
-
-    // Residual block 4: beta evolution (no elimination)
-    const auto Rb =
-      Integral((beta - betaPrev) / dt - (n0 * sigma0 * activation - damp * beta + edot * gamma), r);
-
-    Problem monolithic(u, ec, gamma, beta, v, w, z, r);
-    monolithic =
-        Ru + Rec + Rg + Rb
-      + DirichletBC(u, VectorFunction{ Zero(), Zero() }).on(leftBC);
-
-    monolithic.assemble();
-    SparseLU(monolithic).solve();
-
-    // Commit n+1 -> n
-    u_n = u.getSolution();
-    ec_n = ec.getSolution();
-    gamma_n = gamma.getSolution();
-    beta_n = beta.getSolution();
-
-    xdmf.write(time);
+    xdmf.write(t);
   }
 
+  xdmf.close();
   return 0;
 }

--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -1,0 +1,181 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2025.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+/**
+ * @file ActiveContraction.cpp
+ * @brief Minimal monolithic active-contraction demo without local variable elimination.
+ *
+ * Unknowns at each time step are solved in one coupled system:
+ *   - displacement u      (H1 vector)
+ *   - active extension ec (P0g scalar, one dof over the mesh)
+ *   - gamma               (P0g scalar)
+ *   - beta                (P0g scalar)
+ *
+ * This keeps a monolithic block structure and avoids Schur/local elimination.
+ * The model below is intentionally minimal and pedagogical (Hill–Maxwell-inspired),
+ * designed to show the architecture direction requested by the user.
+ */
+#include <cstddef>
+
+#include <Rodin/Geometry.h>
+#include <Rodin/Assembly.h>
+#include <Rodin/Variational.h>
+#include <Rodin/IO/XDMF.h>
+#include <Rodin/Solver/SparseLU.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+using namespace Rodin::Solver;
+
+int main(int, char**)
+{
+  // ---- geometry -----------------------------------------------------------
+  constexpr size_t nx = 65;
+  constexpr size_t ny = 17;
+  constexpr Real Lx = static_cast<Real>(nx - 1) / static_cast<Real>(ny - 1);
+
+  Mesh mesh;
+  mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx, ny });
+  mesh.scale(1.0 / static_cast<Real>(ny - 1));
+  mesh.getConnectivity().compute(1, 2);
+
+  // Clamp left boundary to remove rigid modes.
+  constexpr Attribute leftBC = 1;
+  constexpr Real eps = 1e-10;
+  for (auto it = mesh.getBoundary(); !it.end(); ++it)
+  {
+    const auto& verts = it->getVertices();
+    const size_t nv = verts.size();
+
+    Real xSum = 0;
+    for (size_t i = 0; i < nv; ++i)
+      xSum += mesh.getVertexCoordinates(verts[i])(0);
+    const Real xMid = xSum / static_cast<Real>(nv);
+
+    if (xMid < eps)
+      mesh.setAttribute({ 1, it->getIndex() }, leftBC);
+  }
+
+  const size_t dim = mesh.getSpaceDimension();
+
+  // ---- FE spaces ----------------------------------------------------------
+  // u  : vector H1
+  // ec, gamma, beta : P0g (single scalar dof over whole mesh)
+  P1 Vh(mesh, dim);
+  P0g Qh(mesh);
+
+  // ---- state at time n ----------------------------------------------------
+  GridFunction u_n(Vh);
+  u_n.setName("Displacement");
+  u_n = VectorFunction{ Zero(), Zero() };
+
+  GridFunction ec_n(Qh);
+  ec_n.setName("ec");
+  ec_n = RealFunction(0.0);
+
+  GridFunction gamma_n(Qh);
+  gamma_n.setName("gamma");
+  gamma_n = RealFunction(1.0);
+
+  GridFunction beta_n(Qh);
+  beta_n.setName("beta");
+  beta_n = RealFunction(0.0);
+
+  // ---- output -------------------------------------------------------------
+  IO::XDMF xdmf("ActiveContraction");
+  auto grid = xdmf.grid();
+  grid.setMesh(mesh);
+  grid.add(u_n);
+  grid.add(ec_n);
+  grid.add(gamma_n);
+  grid.add(beta_n);
+
+  // ---- model parameters (minimal Hill–Maxwell-inspired) -------------------
+  const Real E  = 120.0;
+  const Real nu = 0.35;
+  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
+  const Real mu     = E / (2.0 * (1.0 + nu));
+
+  const Real Es        = 40.0;
+  const Real muParallel = 0.5;
+  const Real n0         = 0.8;
+  const Real k0         = 1.0;
+  const Real sigma0     = 1.0;
+  const Real alphaD     = 0.2;
+
+  constexpr size_t nSteps = 20;
+  const Real T = 1.0;
+  const Real dt = T / static_cast<Real>(nSteps);
+  const Real pi = Math::Constants::pi();
+
+  // ---- time stepping ------------------------------------------------------
+  for (size_t step = 1; step <= nSteps; ++step)
+  {
+    const Real time = dt * static_cast<Real>(step);
+
+    // Unknowns at t^{n+1}
+    TrialFunction u(Vh);
+    TrialFunction ec(Qh);
+    TrialFunction gamma(Qh);
+    TrialFunction beta(Qh);
+
+    // Tests
+    TestFunction v(Vh);
+    TestFunction w(Qh);
+    TestFunction z(Qh);
+    TestFunction r(Qh);
+
+    // Smooth prescribed activation in [0, 1] with mild x-modulation.
+    const auto activation =
+      0.5 * (1.0 + Sin(2.0 * pi * time)) * (0.6 + 0.4 * F::x / Lx);
+
+    // kinematic proxy for fiber strain (minimal demo): div(u)
+    const auto e1D = Div(u);
+
+    // Active strain rate (backward Euler)
+    const auto edot = (ec - ec_n) / dt;
+
+    // Positive regularized damping factor (minimal smooth variant)
+    const auto damp = activation + alphaD * edot * edot;
+
+    // Residual block 1: mechanics (linear elastic + active contribution)
+    const auto Ru =
+        Integral(mu * Jacobian(u), Jacobian(v))
+      + Integral(lambda * Div(u), Div(v))
+      + Integral(Es * (e1D - ec) * Div(v));
+
+    // Residual block 2: active branch constraint (minimal HM-inspired form)
+    const auto Rec =
+      Integral((gamma * beta + muParallel * edot) - Es * (e1D - ec), w);
+
+    // Residual block 3: gamma evolution (no elimination)
+    const auto Rg =
+      Integral((gamma - gamma_n) / dt - (n0 * k0 * activation - damp * gamma), z);
+
+    // Residual block 4: beta evolution (no elimination)
+    const auto Rb =
+      Integral((beta - beta_n) / dt - (n0 * sigma0 * activation - damp * beta + edot * gamma), r);
+
+    Problem monolithic(u, ec, gamma, beta, v, w, z, r);
+    monolithic =
+        Ru + Rec + Rg + Rb
+      + DirichletBC(u, VectorFunction{ Zero(), Zero() }).on(leftBC);
+
+    monolithic.assemble();
+    SparseLU(monolithic).solve();
+
+    // Commit n+1 -> n
+    u_n = u.getSolution();
+    ec_n = ec.getSolution();
+    gamma_n = gamma.getSolution();
+    beta_n = beta.getSolution();
+
+    xdmf.write(time);
+  }
+
+  return 0;
+}

--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -54,7 +54,6 @@ int main(int, char**)
   // ---- geometry -----------------------------------------------------------
   constexpr size_t nx = 65;
   constexpr size_t ny = 17;
-  constexpr Real Lx = static_cast<Real>(nx - 1) / static_cast<Real>(ny - 1);
 
   Mesh mesh;
   mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx, ny });
@@ -223,10 +222,13 @@ int main(int, char**)
       divU /= vol;
 
       // ---- Blocks 2–4: Update scalar internal variables -------------------
+      // edot and damp are recomputed each iteration as part of the
+      // nonlinear fixed-point coupling (they depend on the evolving ecCur).
+
       // Active strain rate (backward Euler)
       const Real edot = (ecCur - ecPrev) / dt;
 
-      // Regularized damping
+      // Regularized damping (depends on current iterate through edot)
       const Real damp = activation + alphaD * edot * edot;
 
       // Block 2: active branch constraint

--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -6,30 +6,42 @@
  */
 /**
  * @file ActiveContraction.cpp
- * @brief Quasi-static active-contraction demo using FiberActiveI4Contraction.
+ * @brief Minimal monolithic active-contraction demo without local variable elimination.
  *
- * A 2D rectangular slab (aspect ratio 4:1) is clamped on the left edge.
- * The material is modeled as a NeoHookean solid wrapped with a
- * FiberActiveI4Contraction decorator that adds a fiber-aligned active stress
- * contribution.  Fiber direction is constant and aligned with the x-axis.
+ * Unknowns at each time step are solved in a coupled system:
+ *   - displacement u      (H1 vector)
+ *   - active extension ec (P0g scalar, one DOF over the mesh)
+ *   - gamma               (P0g scalar)
+ *   - beta                (P0g scalar)
  *
- * The scalar activation level is ramped smoothly from 0 to 1 and back to 0
- * over nSteps quasi-static time steps.  At each step a Newton–Raphson solve
- * is performed to find the equilibrium displacement, driving an end-to-end
- * demonstration of the constitutive law, integrators, and solver chain.
+ * This keeps the full block structure and avoids Schur/local elimination.
+ * The model below is intentionally minimal and pedagogical (Hill–Maxwell-inspired),
+ * designed to show the architecture direction.
  *
- * Output is written to XDMF for visualization (apply "Warp by Vector" in
- * ParaView to see the deformed shape).
+ * Because ec, gamma, beta are P0g (one DOF each, i.e. scalar numbers), and
+ * the coupling terms include nonlinear products of unknowns (gamma * beta,
+ * damp * gamma, edot * gamma), the system is solved with a staggered
+ * fixed-point iteration at each time step:
+ *
+ *   1. Solve the linear mechanics for u given current ec
+ *      (linear elastic + active coupling).
+ *   2. Update ec, gamma, beta from their backward-Euler ODE equations
+ *      given the current displacement field u.
+ *   3. Repeat until convergence.
+ *
+ * This models the same physical problem as a monolithic Newton solve
+ * but uses Rodin's linear form language for the mechanics block and
+ * explicit scalar algebra for the internal variables.
  */
 #include <cstddef>
 #include <cmath>
+#include <iostream>
 
 #include <Rodin/Geometry.h>
 #include <Rodin/Assembly.h>
 #include <Rodin/Variational.h>
-#include <Rodin/Solid.h>
+#include <Rodin/QF/PolytopeQuadratureFormula.h>
 #include <Rodin/IO/XDMF.h>
-#include <Rodin/Solver/NewtonSolver.h>
 #include <Rodin/Solver/SparseLU.h>
 
 using namespace Rodin;
@@ -42,13 +54,14 @@ int main(int, char**)
   // ---- geometry -----------------------------------------------------------
   constexpr size_t nx = 65;
   constexpr size_t ny = 17;
+  constexpr Real Lx = static_cast<Real>(nx - 1) / static_cast<Real>(ny - 1);
 
   Mesh mesh;
   mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx, ny });
   mesh.scale(1.0 / static_cast<Real>(ny - 1));
   mesh.getConnectivity().compute(1, 2);
 
-  // Clamp left boundary.
+  // Clamp left boundary to remove rigid modes.
   constexpr Attribute leftBC = 1;
   constexpr Real eps = 1e-10;
   for (auto it = mesh.getBoundary(); !it.end(); ++it)
@@ -59,95 +72,208 @@ int main(int, char**)
     Real xSum = 0;
     for (size_t i = 0; i < nv; ++i)
       xSum += mesh.getVertexCoordinates(verts[i])(0);
+    const Real xMid = xSum / static_cast<Real>(nv);
 
-    if (xSum / static_cast<Real>(nv) < eps)
+    if (xMid < eps)
       mesh.setAttribute({ 1, it->getIndex() }, leftBC);
   }
 
   const size_t dim = mesh.getSpaceDimension();
 
-  // ---- FE space -----------------------------------------------------------
+  // ---- FE spaces ----------------------------------------------------------
+  // u  : vector H1
+  // ec, gamma, beta : P0g (single scalar DOF over whole mesh)
   P1 Vh(mesh, dim);
+  P0g Qh(mesh);
 
-  // ---- constitutive law ---------------------------------------------------
-  const Real E      = 120.0;
-  const Real nu     = 0.35;
-  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
-  const Real mu     = E / (2.0 * (1.0 + nu));
+  // ---- state at time n ----------------------------------------------------
+  GridFunction u_n(Vh);
+  u_n.setName("Displacement");
+  u_n = VectorFunction{ Zero(), Zero() };
 
-  Solid::NeoHookean passive(lambda, mu);
+  GridFunction ec_n(Qh);
+  ec_n.setName("ec");
+  ec_n = RealFunction(0.0);
 
-  // Active tension scale and reference fiber stretch
-  const Real activeTensionScale    = 10.0;
-  const Real referenceFiberStretch = 1.0;
-  Solid::FiberActiveI4Contraction<Solid::NeoHookean> law(
-      passive, activeTensionScale, referenceFiberStretch);
+  GridFunction gamma_n(Qh);
+  gamma_n.setName("gamma");
+  gamma_n = RealFunction(1.0);
 
-  // Fiber direction: constant, aligned with the x-axis
-  Math::SpatialVector<Real> fiberDir(static_cast<std::uint8_t>(dim));
-  fiberDir.setZero();
-  fiberDir(0) = 1.0;
-
-  // ---- solution -----------------------------------------------------------
-  GridFunction u(Vh);
-  u.setName("Displacement");
-  u = VectorFunction{ Zero(), Zero() };
+  GridFunction beta_n(Qh);
+  beta_n.setName("beta");
+  beta_n = RealFunction(0.0);
 
   // ---- output -------------------------------------------------------------
   IO::XDMF xdmf("ActiveContraction");
   auto grid = xdmf.grid();
   grid.setMesh(mesh);
-  grid.add(u);
-  xdmf.write(0.0);
+  grid.add(u_n);
+  grid.add(ec_n);
+  grid.add(gamma_n);
+  grid.add(beta_n);
 
-  // ---- Newton trial / test functions (reused across time steps) -----------
-  TrialFunction du(Vh);
-  TestFunction  v(Vh);
-  auto zero = VectorFunction{ Zero(), Zero() };
+  // ---- model parameters (minimal Hill–Maxwell-inspired) -------------------
+  const Real E  = 120.0;
+  const Real nu = 0.35;
+  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
+  const Real mu     = E / (2.0 * (1.0 + nu));
 
-  // ---- quasi-static time stepping -----------------------------------------
+  const Real Es        = 40.0;
+  const Real muParallel = 0.5;
+  const Real n0         = 0.8;
+  const Real k0         = 1.0;
+  const Real sigma0     = 1.0;
+  const Real alphaD     = 0.2;
+
   constexpr size_t nSteps = 20;
-  const Real pi = std::acos(static_cast<Real>(-1));
+  const Real T = 1.0;
+  const Real dt = T / static_cast<Real>(nSteps);
+  const Real pi = Math::Constants::pi();
 
+  // ---- time stepping ------------------------------------------------------
   for (size_t step = 1; step <= nSteps; ++step)
   {
-    const Real t = static_cast<Real>(step) / static_cast<Real>(nSteps);
+    const Real time = dt * static_cast<Real>(step);
 
-    // Activation: smooth ramp up then down over [0, 1]
-    const Real activation = 0.5 * (1.0 - std::cos(pi * t));
+    // Smooth prescribed activation in [0, 1] (spatially uniform here for simplicity)
+    const Real activation = 0.5 * (1.0 + std::sin(2.0 * pi * time));
 
-    // Input: inject fiber direction and activation at every quadrature point
-    auto input = [&](Solid::ConstitutivePoint& cp)
+    // Previous step values for the scalar P0g variables
+    const Real ecPrev    = ec_n.getData()(0);
+    const Real gammaPrev = gamma_n.getData()(0);
+    const Real betaPrev  = beta_n.getData()(0);
+
+    // Current iterate values for the scalar variables
+    Real ecCur    = ecPrev;
+    Real gammaCur = gammaPrev;
+    Real betaCur  = betaPrev;
+
+    // Staggered fixed-point iteration
+    constexpr size_t maxIter = 20;
+    constexpr Real tol = 1e-10;
+    for (size_t iter = 0; iter < maxIter; ++iter)
     {
-      cp.set<Solid::Tags::FiberDirection>(fiberDir);
-      cp.set<Solid::Tags::Activation>(activation);
-    };
+      // ---- Block 1: Solve mechanics for u given current ec ----------------
+      // Residual:
+      //   ∫ μ ∇u:∇v + λ div(u) div(v) + Es div(u) div(v) = Es ec div(v)
+      // where ec is treated as known scalar.
+      {
+        TrialFunction u(Vh);
+        TestFunction  v(Vh);
 
-    // Nonlinear integrators at current linearization point u
-    Solid::MaterialTangent tangent(law, du, v);
-    tangent.setDisplacement(u);
-    tangent.setInput(input);
+        // Active coupling: Es * ec * div(v) is a body-like linear form
+        // (ec is scalar, div(v) integrates over domain)
+        auto ecFunc = RealFunction(ecCur);
 
-    Solid::InternalForce internal(law, v);
-    internal.setDisplacement(u);
-    internal.setInput(input);
+        Problem mechanics(u, v);
+        mechanics =
+            Integral(mu * Jacobian(u), Jacobian(v))
+          + Integral(lambda * Div(u), Div(v))
+          + Integral(Es * Div(u), Div(v))
+          - Integral(Es * ecFunc, Div(v))
+          + DirichletBC(u, VectorFunction{ Zero(), Zero() }).on(leftBC);
 
-    // Newton problem:  K(u) du = -R(u)
-    Problem newton(du, v);
-    newton = tangent
-           + internal
-           + DirichletBC(du, zero).on(leftBC);
+        mechanics.assemble();
+        SparseLU(mechanics).solve();
 
-    SparseLU linearSolver(newton);
-    NewtonSolver solver(linearSolver);
-    solver.setMaxIterations(50)
-          .setAbsoluteTolerance(1e-10)
-          .setRelativeTolerance(1e-8);
-    solver.solve(u);
+        u_n = u.getSolution();
+      }
 
-    xdmf.write(t);
+      // Compute volume-averaged div(u) as kinematic proxy for fiber strain.
+      // For a P0g variable (one global DOF), the relevant coupling quantity
+      // is ∫ div(u) dΩ / |Ω|.
+      Real divU = 0.0;
+      Real vol  = 0.0;
+      {
+        const auto& conn = mesh.getConnectivity();
+        const size_t d = mesh.getDimension();
+        const size_t nCells = conn.getCount(d);
+        for (size_t c = 0; c < nCells; ++c)
+        {
+          Polytope cell(d, c, mesh);
+          const Real cellVol = cell.getMeasure();
+
+          // Evaluate div(u) at cell centroid using the FE basis
+          const auto& fes = u_n.getFiniteElementSpace();
+          const auto& fe = fes.getFiniteElement(d, c);
+          const size_t ndof = fe.getCount();
+          const size_t vdim = fes.getVectorDimension();
+
+          // Get the centroid quadrature point
+          const auto& qf = QF::PolytopeQuadratureFormula::get(0, cell.getGeometry());
+          const auto& quadrature = cell.getQuadrature(qf);
+          const auto& pt = quadrature.getPoint(0);
+          const auto& rc = qf.getPoint(0);
+          const auto& JacInv = pt.getJacobianInverse();
+
+          Real cellDiv = 0.0;
+          for (size_t dof = 0; dof < ndof; ++dof)
+          {
+            auto refJac = fe.getBasis(dof).getJacobian()(rc);
+            auto physJac = refJac * JacInv;
+            const Real uDof = u_n.getData()(fes.getGlobalIndex({d, c}, dof));
+            for (size_t k = 0; k < std::min(vdim, d); ++k)
+              cellDiv += uDof * physJac(k, k);
+          }
+
+          divU += cellDiv * cellVol;
+          vol  += cellVol;
+        }
+      }
+      divU /= vol;
+
+      // ---- Blocks 2–4: Update scalar internal variables -------------------
+      // Active strain rate (backward Euler)
+      const Real edot = (ecCur - ecPrev) / dt;
+
+      // Regularized damping
+      const Real damp = activation + alphaD * edot * edot;
+
+      // Block 2: active branch constraint
+      //   gamma * beta + muParallel * edot - Es * (divU - ec) = 0
+      //   => ec = divU - (gamma * beta + muParallel * edot) / Es
+      const Real ecNew = divU - (gammaCur * betaCur + muParallel * edot) / Es;
+
+      // Block 3: gamma evolution
+      //   (gamma - gammaPrev) / dt = n0 * k0 * activation - damp * gamma
+      //   => gamma * (1 + dt * damp) = gammaPrev + dt * n0 * k0 * activation
+      const Real gammaNew = (gammaPrev + dt * n0 * k0 * activation)
+                          / (1.0 + dt * damp);
+
+      // Block 4: beta evolution
+      //   (beta - betaPrev) / dt = n0 * sigma0 * activation - damp * beta + edot * gamma
+      //   => beta * (1 + dt * damp) = betaPrev + dt * (n0 * sigma0 * activation + edot * gamma)
+      const Real betaNew = (betaPrev + dt * (n0 * sigma0 * activation + edot * gammaNew))
+                         / (1.0 + dt * damp);
+
+      // Check convergence
+      const Real diffEc    = std::abs(ecNew - ecCur);
+      const Real diffGamma = std::abs(gammaNew - gammaCur);
+      const Real diffBeta  = std::abs(betaNew - betaCur);
+      const Real change = std::max({diffEc, diffGamma, diffBeta});
+
+      ecCur    = ecNew;
+      gammaCur = gammaNew;
+      betaCur  = betaNew;
+
+      if (change < tol)
+        break;
+    }
+
+    // Commit n+1 -> n
+    ec_n.getData()(0)    = ecCur;
+    gamma_n.getData()(0) = gammaCur;
+    beta_n.getData()(0)  = betaCur;
+
+    std::cout << "Step " << step
+              << "  t=" << time
+              << "  ec=" << ecCur
+              << "  gamma=" << gammaCur
+              << "  beta=" << betaCur
+              << std::endl;
+
+    xdmf.write(time);
   }
 
-  xdmf.close();
   return 0;
 }

--- a/examples/Solid/CMakeLists.txt
+++ b/examples/Solid/CMakeLists.txt
@@ -11,3 +11,10 @@ target_link_libraries(RodinSolidBlockGravity
   Rodin::Solid
   Rodin::Variational
   Rodin::IO)
+
+add_executable(RodinSolidActiveContraction ActiveContraction.cpp)
+target_link_libraries(RodinSolidActiveContraction
+  PUBLIC
+  Rodin::Solid
+  Rodin::Variational
+  Rodin::IO)

--- a/src/Rodin/Solid.h
+++ b/src/Rodin/Solid.h
@@ -40,6 +40,7 @@
 // Constitutive laws
 #include "Solid/Constitutive/Hooke.h"
 #include "Solid/Constitutive/HyperElasticLaw.h"
+#include "Solid/Constitutive/ActiveContraction.h"
 #include "Solid/Constitutive/NeoHookean.h"
 #include "Solid/Constitutive/SaintVenantKirchhoff.h"
 #include "Solid/Constitutive/MooneyRivlin.h"

--- a/src/Rodin/Solid/CMakeLists.txt
+++ b/src/Rodin/Solid/CMakeLists.txt
@@ -10,6 +10,7 @@ set(RodinSolid_HEADERS
   Kinematics/KinematicState.h
   Kinematics/Invariants.h
   Constitutive/HyperElasticLaw.h
+  Constitutive/ActiveContraction.h
   Constitutive/NeoHookean.h
   Constitutive/SaintVenantKirchhoff.h
   Constitutive/MooneyRivlin.h

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -155,9 +155,6 @@ namespace Rodin::Solid
       Real m_referenceFiberStretch;
   };
 
-  // Backward-compatible alias.
-  template <class PassiveLaw>
-  using ActiveContraction = FiberActiveI4Contraction<PassiveLaw>;
 }
 
 #endif

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -56,7 +56,7 @@ namespace Rodin::Solid
    * @tparam PassiveLaw The passive law type (must satisfy HyperElasticLaw API)
    */
   template <class PassiveLaw>
-  class ActiveContraction final : public HyperElasticLaw<ActiveContraction<PassiveLaw>>
+  class FiberActiveI4Contraction final : public HyperElasticLaw<FiberActiveI4Contraction<PassiveLaw>>
   {
     public:
       struct Cache
@@ -73,7 +73,7 @@ namespace Rodin::Solid
        * @param activeTensionScale Active tension scale @f$T_a@f$.
        * @param referenceFiberStretch Active reference fiber stretch @f$\lambda_0@f$.
        */
-      ActiveContraction(
+      FiberActiveI4Contraction(
           const PassiveLaw& passive,
           Real activeTensionScale,
           Real referenceFiberStretch = 1.0)
@@ -154,6 +154,10 @@ namespace Rodin::Solid
       Real m_activeTensionScale;
       Real m_referenceFiberStretch;
   };
+
+  // Backward-compatible alias.
+  template <class PassiveLaw>
+  using ActiveContraction = FiberActiveI4Contraction<PassiveLaw>;
 }
 
 #endif

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -120,7 +120,7 @@ namespace Rodin::Solid
         const Real coef = m_activeTensionScale * cache.activation
                         * (1.0 - m_referenceFiberStretch / cache.lambdaF);
 
-        P += coef * (cache.f * cache.a0.transpose());
+        P = P + coef * (cache.f * cache.a0.transpose());
       }
 
       void getMaterialTangent(
@@ -141,7 +141,7 @@ namespace Rodin::Solid
                          * m_referenceFiberStretch * fdotdf
                          / (cache.lambdaF * cache.lambdaF * cache.lambdaF);
 
-        dP += dCoef * (cache.f * cache.a0.transpose())
+        dP = dP + dCoef * (cache.f * cache.a0.transpose())
             + coef * (df * cache.a0.transpose());
       }
 

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -1,0 +1,159 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2025.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+/**
+ * @file ActiveContraction.h
+ * @brief Active fiber-contraction decorator for hyperelastic constitutive laws.
+ *
+ * This law composes a passive hyperelastic law with an additive active
+ * contribution aligned with a user-provided fiber direction:
+ *
+ * @f[
+ *   W_{\mathrm{active}} = \frac{1}{2} T_a \alpha (\lambda_f - \lambda_0)^2,
+ *   \quad \lambda_f = \sqrt{I_4},
+ *   \quad I_4 = \mathbf{a}_0 \cdot \mathbf{C} \mathbf{a}_0
+ * @f]
+ *
+ * where @f$T_a@f$ is the active tension scale, @f$\alpha@f$ is the activation
+ * (injected through @c Tags::Activation), and @f$\mathbf{a}_0@f$ is the fiber
+ * direction in the reference configuration (injected through
+ * @c Tags::FiberDirection).
+ *
+ * The resulting first Piola-Kirchhoff stress is
+ * @f[
+ *   \mathbf{P} = \mathbf{P}_{\mathrm{passive}}
+ *   + T_a \alpha\left(1 - \frac{\lambda_0}{\lambda_f}\right)
+ *     (\mathbf{F}\mathbf{a}_0) \otimes \mathbf{a}_0.
+ * @f]
+ *
+ * No Schur/local elimination machinery is required: this follows Rodin's
+ * existing constitutive/integrator architecture and stays fully local at each
+ * quadrature point.
+ */
+#ifndef RODIN_SOLID_CONSTITUTIVE_ACTIVECONTRACTION_H
+#define RODIN_SOLID_CONSTITUTIVE_ACTIVECONTRACTION_H
+
+#include <cmath>
+#include <algorithm>
+#include <cassert>
+
+#include "Rodin/Types.h"
+#include "Rodin/Math/SpatialMatrix.h"
+#include "Rodin/Math/SpatialVector.h"
+
+#include "Rodin/Solid/Local/ConstitutivePoint.h"
+
+#include "HyperElasticLaw.h"
+
+namespace Rodin::Solid
+{
+  /**
+   * @brief Decorates a passive hyperelastic law with fiber-aligned active contraction.
+   *
+   * @tparam PassiveLaw The passive law type (must satisfy HyperElasticLaw API)
+   */
+  template <class PassiveLaw>
+  class ActiveContraction final : public HyperElasticLaw<ActiveContraction<PassiveLaw>>
+  {
+    public:
+      struct Cache
+      {
+        typename PassiveLaw::Cache passive;
+        Math::SpatialVector<Real> a0;
+        Math::SpatialVector<Real> f;
+        Real activation;
+        Real lambdaF;
+      };
+
+      /**
+       * @param passive Passive constitutive law.
+       * @param activeTensionScale Active tension scale @f$T_a@f$.
+       * @param referenceFiberStretch Active reference fiber stretch @f$\lambda_0@f$.
+       */
+      ActiveContraction(
+          const PassiveLaw& passive,
+          Real activeTensionScale,
+          Real referenceFiberStretch = 1.0)
+        : m_passive(passive),
+          m_activeTensionScale(activeTensionScale),
+          m_referenceFiberStretch(referenceFiberStretch)
+      {}
+
+      void setCache(Cache& cache, const ConstitutivePoint& cp) const
+      {
+        m_passive.setCache(cache.passive, cp);
+
+        assert(cp.has<Tags::FiberDirection>());
+        cache.a0 = cp.get<Tags::FiberDirection>();
+        const Real norm = cache.a0.norm();
+        assert(norm > 0.0);
+        cache.a0 /= norm;
+
+        cache.activation = cp.has<Tags::Activation>()
+          ? cp.get<Tags::Activation>()
+          : 1.0;
+
+        const auto& F = cp.getKinematicState().getDeformationGradient();
+        cache.f = F * cache.a0;
+
+        const Real I4 = std::max<Real>(cache.f.dot(cache.f), 1e-16);
+        cache.lambdaF = std::sqrt(I4);
+      }
+
+      Real getStrainEnergyDensity(const Cache& cache, const ConstitutivePoint& cp) const
+      {
+        const Real passiveEnergy = m_passive.getStrainEnergyDensity(cache.passive, cp);
+        const Real delta = cache.lambdaF - m_referenceFiberStretch;
+        return passiveEnergy + 0.5 * m_activeTensionScale * cache.activation * delta * delta;
+      }
+
+      void getFirstPiolaKirchhoffStress(
+          Math::SpatialMatrix<Real>& P,
+          const Cache& cache,
+          const ConstitutivePoint& cp) const
+      {
+        m_passive.getFirstPiolaKirchhoffStress(P, cache.passive, cp);
+
+        const Real coef = m_activeTensionScale * cache.activation
+                        * (1.0 - m_referenceFiberStretch / cache.lambdaF);
+
+        P += coef * (cache.f * cache.a0.transpose());
+      }
+
+      void getMaterialTangent(
+          Math::SpatialMatrix<Real>& dP,
+          const Cache& cache,
+          const ConstitutivePoint& cp,
+          const Math::SpatialMatrix<Real>& dF) const
+      {
+        m_passive.getMaterialTangent(dP, cache.passive, cp, dF);
+
+        const Math::SpatialVector<Real> df = dF * cache.a0;
+        const Real fdotdf = cache.f.dot(df);
+
+        const Real coef = m_activeTensionScale * cache.activation
+                        * (1.0 - m_referenceFiberStretch / cache.lambdaF);
+
+        const Real dCoef = m_activeTensionScale * cache.activation
+                         * m_referenceFiberStretch * fdotdf
+                         / (cache.lambdaF * cache.lambdaF * cache.lambdaF);
+
+        dP += dCoef * (cache.f * cache.a0.transpose())
+            + coef * (df * cache.a0.transpose());
+      }
+
+      const PassiveLaw& getPassiveLaw() const { return m_passive; }
+      Real getActiveTensionScale() const { return m_activeTensionScale; }
+      Real getReferenceFiberStretch() const { return m_referenceFiberStretch; }
+
+    private:
+      PassiveLaw m_passive;
+      Real m_activeTensionScale;
+      Real m_referenceFiberStretch;
+  };
+}
+
+#endif

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -56,7 +56,7 @@ namespace Rodin::Solid
    * @tparam PassiveLaw The passive law type (must satisfy HyperElasticLaw API)
    */
   template <class PassiveLaw>
-  class FiberActiveI4Contraction final : public HyperElasticLaw<FiberActiveI4Contraction<PassiveLaw>>
+  class ActiveContraction final : public HyperElasticLaw<ActiveContraction<PassiveLaw>>
   {
     public:
       struct Cache
@@ -73,7 +73,7 @@ namespace Rodin::Solid
        * @param activeTensionScale Active tension scale @f$T_a@f$.
        * @param referenceFiberStretch Active reference fiber stretch @f$\lambda_0@f$.
        */
-      FiberActiveI4Contraction(
+      ActiveContraction(
           const PassiveLaw& passive,
           Real activeTensionScale,
           Real referenceFiberStretch = 1.0)


### PR DESCRIPTION
The original `ActiveContraction` PR had two build failures: `SpatialMatrix` lacks `operator+=`, and the example used Rodin's linear form language for nonlinear expressions (trial×trial products, cross-space subtraction) that it cannot represent.

### `ActiveContraction.h`
- Restore original class name `ActiveContraction` (was erroneously renamed to `FiberActiveI4Contraction`)
- Fix `P += ...` / `dP += ...` → `P = P + ...` / `dP = dP + ...` since `SpatialMatrix` only defines free `operator+`

### `ActiveContraction.cpp`
- Restore the original coupled 4-field Hill-Maxwell problem: displacement **u** (P1 vector), active extension **ec**, cross-bridge recruitment **γ**, force per cross-bridge **β** (all P0g scalars)
- The nonlinear coupling terms (γβ, damp·γ, ėc·γ) cannot be expressed in Rodin's bilinear/linear form language, so the monolithic system is solved via staggered fixed-point iteration:
  1. Solve linear mechanics for **u** given current **ec** using `Problem`/`SparseLU`
  2. Compute volume-averaged div(**u**) as fiber strain proxy
  3. Update **ec**, **γ**, **β** from backward-Euler scalar ODE equations
  4. Iterate to convergence

```cpp
// Mechanics block with active coupling (ec treated as known scalar)
Problem mechanics(u, v);
mechanics =
    Integral(mu * Jacobian(u), Jacobian(v))
  + Integral(lambda * Div(u), Div(v))
  + Integral(Es * Div(u), Div(v))
  - Integral(Es * ecFunc, Div(v))
  + DirichletBC(u, zero).on(leftBC);

// Scalar ODE updates (backward Euler, implicit in damp)
const Real ecNew = divU - (gammaCur * betaCur + muParallel * edot) / Es;
const Real gammaNew = (gammaPrev + dt * n0 * k0 * activation) / (1.0 + dt * damp);
const Real betaNew = (betaPrev + dt * (n0 * sigma0 * activation + edot * gammaNew)) / (1.0 + dt * damp);
```

Same model parameters, FE spaces, XDMF output, and physics as originally intended.