### PR TITLE
Add FiberActiveI4Contraction constitutive law and ActiveContraction example

### DIFF
--- a/examples/Solid/ActiveContraction.cpp
+++ b/examples/Solid/ActiveContraction.cpp
@@ -1,0 +1,273 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2025.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+/**
+ * @file ActiveContraction.cpp
+ * @brief Hill–Maxwell-inspired active contraction with explicit local internal updates.
+ *
+ * This example keeps active variables as FE fields (P0) and avoids Schur/local
+ * elimination in the global mechanics solve. Internal variable updates are done
+ * per-cell through a local nonlinear fixed-point/Newton loop.
+ */
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+#include <Rodin/Geometry.h>
+#include <Rodin/Assembly.h>
+#include <Rodin/Variational.h>
+#include <Rodin/QF/PolytopeQuadratureFormula.h>
+#include <Rodin/IO/XDMF.h>
+#include <Rodin/Solver/SparseLU.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+using namespace Rodin::Solver;
+
+int main(int, char**)
+{
+  constexpr size_t nx = 65;
+  constexpr size_t ny = 17;
+
+  Mesh mesh;
+  mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx, ny });
+  mesh.scale(1.0 / static_cast<Real>(ny - 1));
+  mesh.getConnectivity().compute(1, 2);
+
+  constexpr Attribute leftBC = 1;
+  constexpr Real eps = 1e-10;
+  for (auto it = mesh.getBoundary(); !it.end(); ++it)
+  {
+    const auto& verts = it->getVertices();
+    Real xSum = 0;
+    for (size_t i = 0; i < verts.size(); ++i)
+      xSum += mesh.getVertexCoordinates(verts[i])(0);
+    if (xSum / static_cast<Real>(verts.size()) < eps)
+      mesh.setAttribute({ 1, it->getIndex() }, leftBC);
+  }
+
+  const size_t dim = mesh.getSpaceDimension();
+  const size_t d = mesh.getDimension();
+
+  // Mechanics on vector P1, internal variables on cellwise P0.
+  P1 Vh(mesh, dim);
+  P0 Qh(mesh);
+
+  GridFunction u_n(Vh);
+  u_n.setName("Displacement");
+  u_n = VectorFunction{ Zero(), Zero() };
+
+  GridFunction ec_n(Qh);    ec_n.setName("ec");    ec_n = RealFunction(0.0);
+  GridFunction gamma_n(Qh); gamma_n.setName("gamma"); gamma_n = RealFunction(1.0);
+  GridFunction beta_n(Qh);  beta_n.setName("beta");  beta_n = RealFunction(0.0);
+  GridFunction activation_n(Qh); activation_n.setName("activation"); activation_n = RealFunction(0.0);
+
+  IO::XDMF xdmf("ActiveContraction");
+  auto grid = xdmf.grid();
+  grid.setMesh(mesh);
+  grid.add(u_n);
+  grid.add(ec_n);
+  grid.add(gamma_n);
+  grid.add(beta_n);
+  grid.add(activation_n);
+
+  // Material/model parameters.
+  const Real E  = 120.0;
+  const Real nu = 0.35;
+  const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
+  const Real mu     = E / (2.0 * (1.0 + nu));
+
+  const Real Es         = 40.0;
+  const Real muParallel = 0.5;
+  const Real alphaD     = 0.2;
+  const Real k0         = 1.0;
+  const Real sigma0     = 1.0;
+
+  constexpr size_t nSteps = 20;
+  const Real T = 1.0;
+  const Real dt = T / static_cast<Real>(nSteps);
+  const Real pi = Math::Constants::pi();
+
+  GridFunction ecPrev(Qh), gammaPrev(Qh), betaPrev(Qh);
+  GridFunction ecCur(Qh), gammaCur(Qh), betaCur(Qh);
+
+  // Frank-Starling reduction factor (piecewise linear; clamped at 0).
+  const auto starling = [](Real fib0) -> Real
+  {
+    const Real x1 = -0.4, y1 = 0.0;
+    const Real x2 =  0.3, y2 = 0.38;
+    const Real x3 =  0.73, y3 = 0.74;
+    const Real x4 =  1.0, y4 = 1.0;
+    const Real x5 =  1.3, y5 = 1.0;
+    const Real x6 =  2.4, y6 = 0.0;
+
+    Real n0 = 0.0;
+    if (fib0 < x2) n0 = ((y2-y1)/(x2-x1)) * (fib0 - x2) + y2;
+    else if (fib0 < x3) n0 = ((y3-y2)/(x3-x2)) * (fib0 - x3) + y3;
+    else if (fib0 < x4) n0 = ((y4-y3)/(x4-x3)) * (fib0 - x4) + y4;
+    else if (fib0 < x5) n0 = y4;
+    else if (fib0 < x6) n0 = ((y6-y5)/(x6-x5)) * (fib0 - x6) + y6;
+    return std::max<Real>(0.0, n0);
+  };
+
+  const size_t nCells = mesh.getConnectivity().getCount(d);
+  std::vector<Real> e1D(nCells, 0.0);
+  const Real invSqrt2 = 1.0 / std::sqrt(2.0);
+
+  for (size_t step = 1; step <= nSteps; ++step)
+  {
+    const Real time = dt * static_cast<Real>(step);
+    const Real activation = 0.5 * (1.0 + std::sin(2.0 * pi * time));
+    const Real activationPlus = std::max<Real>(0.0, activation);
+    for (size_t c = 0; c < nCells; ++c)
+      activation_n.getData()(c) = activation;
+
+    ecPrev = ec_n; gammaPrev = gamma_n; betaPrev = beta_n;
+    ecCur = ecPrev; gammaCur = gammaPrev; betaCur = betaPrev;
+
+    constexpr size_t maxIter = 25;
+    constexpr Real tol = 1e-10;
+
+    for (size_t iter = 0; iter < maxIter; ++iter)
+    {
+      // 1) Mechanics solve for u given current ec.
+      {
+        TrialFunction u(Vh);
+        TestFunction  v(Vh);
+
+        Problem mechanics(u, v);
+        mechanics =
+            Integral(mu * Jacobian(u), Jacobian(v))
+          + Integral(lambda * Div(u), Div(v))
+          + Integral(Es * Div(u), Div(v))
+          - Integral(Es * ecCur, Div(v))
+          + DirichletBC(u, VectorFunction{ Zero(), Zero() }).on(leftBC);
+
+        mechanics.assemble();
+        SparseLU(mechanics).solve();
+        u_n = u.getSolution();
+      }
+
+      // 2) Cell-wise e1D proxy from centroid div(u) + moved-fiber stretch.
+      //    We transport a reference fiber a0=(1,1)/sqrt(2) through a simple
+      //    deformation proxy F = diag(1+div(u), 1) and set e1D = |F a0| - 1.
+      {
+        const auto& fes = u_n.getFiniteElementSpace();
+        for (size_t c = 0; c < nCells; ++c)
+        {
+          Polytope cell(d, c, mesh);
+          const auto& fe = fes.getFiniteElement(d, c);
+          const size_t ndof = fe.getCount();
+          const size_t vdim = fes.getVectorDimension();
+
+          const auto& qf = QF::PolytopeQuadratureFormula::get(0, cell.getGeometry());
+          const auto& quadrature = cell.getQuadrature(qf);
+          const auto& pt = quadrature.getPoint(0);
+          const auto& rc = qf.getPoint(0);
+          const auto& JacInv = pt.getJacobianInverse();
+
+          Real divCell = 0.0;
+          for (size_t dof = 0; dof < ndof; ++dof)
+          {
+            const auto refJac  = fe.getBasis(dof).getJacobian()(rc);
+            const auto physJac = refJac * JacInv;
+            const Real uDof = u_n.getData()(fes.getGlobalIndex({d, c}, dof));
+            for (size_t k = 0; k < std::min(vdim, d); ++k)
+              divCell += uDof * physJac(k, k);
+          }
+          const Real fax = (1.0 + divCell) * invSqrt2;
+          const Real fay = invSqrt2;
+          const Real lambdaF = std::sqrt(fax * fax + fay * fay);
+          e1D[c] = lambdaF - 1.0;
+        }
+      }
+
+      // 3) Local update of (ec, gamma, beta) per cell.
+      auto& ecData = ecCur.getData();
+      auto& gammaData = gammaCur.getData();
+      auto& betaData = betaCur.getData();
+      const auto& ec0Data = ecPrev.getData();
+      const auto& gamma0Data = gammaPrev.getData();
+      const auto& beta0Data = betaPrev.getData();
+
+      Real maxDiff = 0.0;
+      for (size_t c = 0; c < nCells; ++c)
+      {
+        Real ec = ecData(c);
+        Real gamma = gammaData(c);
+        Real beta = betaData(c);
+
+        const Real ec0 = ec0Data(c);
+        const Real gamma0 = gamma0Data(c);
+        const Real beta0 = beta0Data(c);
+        const Real n0 = starling(ec0);
+
+        for (size_t lit = 0; lit < 8; ++lit)
+        {
+          const Real edot = (ec - ec0) / dt;
+
+          // Positivity-style gamma/beta updates.
+          const Real Dg = 1.0 + dt * (std::abs(activation) + alphaD * std::abs(edot));
+          const Real gammaSq = std::max<Real>(1e-16, (gamma0 * gamma0 + dt * n0 * k0 * activationPlus) / Dg);
+          gamma = std::sqrt(gammaSq);
+
+          const Real Db = 1.0
+            + 0.5 * dt * n0 * k0 * activationPlus / gammaSq
+            + 0.5 * dt * (std::abs(activation) + alphaD * std::abs(edot));
+
+          beta = (beta0 + gamma * (ec - ec0) + dt * n0 * sigma0 * activationPlus / gamma) / Db;
+
+          // Solve RA(ec)=0 with tau = gamma*beta (frozen during local Newton).
+          const Real tau = gamma * beta;
+          for (size_t nit = 0; nit < 6; ++nit)
+          {
+            const Real onep2ec = 1.0 + 2.0 * ec;
+            const Real onep2e1D = 1.0 + 2.0 * e1D[c];
+
+            const Real R =
+              (tau + muParallel * (ec - ec0) / dt) * std::pow(onep2ec, 3)
+              - Es * (e1D[c] - ec) * onep2e1D;
+
+            const Real dR =
+              (muParallel / dt) * std::pow(onep2ec, 3)
+              + (tau + muParallel * (ec - ec0) / dt) * 6.0 * std::pow(onep2ec, 2)
+              + Es * onep2e1D;
+
+            const Real dec = -R / dR;
+            ec += dec;
+            ec = std::max<Real>(ec, -0.49);
+            if (std::abs(dec) < 1e-12)
+              break;
+          }
+        }
+
+        maxDiff = std::max(maxDiff, std::abs(ec - ecData(c)));
+        maxDiff = std::max(maxDiff, std::abs(gamma - gammaData(c)));
+        maxDiff = std::max(maxDiff, std::abs(beta - betaData(c)));
+
+        ecData(c) = ec;
+        gammaData(c) = gamma;
+        betaData(c) = beta;
+      }
+
+      if (maxDiff < tol)
+        break;
+    }
+
+    ec_n = ecCur;
+    gamma_n = gammaCur;
+    beta_n = betaCur;
+
+    std::cout << "Step " << step << " t=" << time << std::endl;
+    xdmf.write(time).flush();
+  }
+
+  xdmf.close();
+  return 0;
+}

--- a/examples/Solid/CMakeLists.txt
+++ b/examples/Solid/CMakeLists.txt
@@ -11,3 +11,10 @@ target_link_libraries(RodinSolidBlockGravity
   Rodin::Solid
   Rodin::Variational
   Rodin::IO)
+
+add_executable(RodinSolidActiveContraction ActiveContraction.cpp)
+target_link_libraries(RodinSolidActiveContraction
+  PUBLIC
+  Rodin::Solid
+  Rodin::Variational
+  Rodin::IO)

--- a/src/Rodin/Solid.h
+++ b/src/Rodin/Solid.h
@@ -40,6 +40,7 @@
 // Constitutive laws
 #include "Solid/Constitutive/Hooke.h"
 #include "Solid/Constitutive/HyperElasticLaw.h"
+#include "Solid/Constitutive/ActiveContraction.h"
 #include "Solid/Constitutive/NeoHookean.h"
 #include "Solid/Constitutive/SaintVenantKirchhoff.h"
 #include "Solid/Constitutive/MooneyRivlin.h"

--- a/src/Rodin/Solid/CMakeLists.txt
+++ b/src/Rodin/Solid/CMakeLists.txt
@@ -10,6 +10,7 @@ set(RodinSolid_HEADERS
   Kinematics/KinematicState.h
   Kinematics/Invariants.h
   Constitutive/HyperElasticLaw.h
+  Constitutive/ActiveContraction.h
   Constitutive/NeoHookean.h
   Constitutive/SaintVenantKirchhoff.h
   Constitutive/MooneyRivlin.h

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -1,0 +1,160 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2025.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+/**
+ * @file ActiveContraction.h
+ * @brief Active fiber-contraction decorator for hyperelastic constitutive laws.
+ *
+ * This law composes a passive hyperelastic law with an additive active
+ * contribution aligned with a user-provided fiber direction:
+ *
+ * @f[
+ *   W_{\mathrm{active}} = \frac{1}{2} T_a \alpha (\lambda_f - \lambda_0)^2,
+ *   \quad \lambda_f = \sqrt{I_4},
+ *   \quad I_4 = \mathbf{a}_0 \cdot \mathbf{C} \mathbf{a}_0
+ * @f]
+ *
+ * where @f$T_a@f$ is the active tension scale, @f$\alpha@f$ is the activation
+ * (injected through @c Tags::Activation), and @f$\mathbf{a}_0@f$ is the fiber
+ * direction in the reference configuration (injected through
+ * @c Tags::FiberDirection).
+ *
+ * The resulting first Piola-Kirchhoff stress is
+ * @f[
+ *   \mathbf{P} = \mathbf{P}_{\mathrm{passive}}
+ *   + T_a \alpha\left(1 - \frac{\lambda_0}{\lambda_f}\right)
+ *     (\mathbf{F}\mathbf{a}_0) \otimes \mathbf{a}_0.
+ * @f]
+ *
+ * No Schur/local elimination machinery is required: this follows Rodin's
+ * existing constitutive/integrator architecture and stays fully local at each
+ * quadrature point.
+ */
+#ifndef RODIN_SOLID_CONSTITUTIVE_ACTIVECONTRACTION_H
+#define RODIN_SOLID_CONSTITUTIVE_ACTIVECONTRACTION_H
+
+#include <cmath>
+#include <algorithm>
+#include <cassert>
+
+#include "Rodin/Types.h"
+#include "Rodin/Math/SpatialMatrix.h"
+#include "Rodin/Math/SpatialVector.h"
+
+#include "Rodin/Solid/Local/ConstitutivePoint.h"
+
+#include "HyperElasticLaw.h"
+
+namespace Rodin::Solid
+{
+  /**
+   * @brief Decorates a passive hyperelastic law with fiber-aligned active contraction.
+   *
+   * @tparam PassiveLaw The passive law type (must satisfy HyperElasticLaw API)
+   */
+  template <class PassiveLaw>
+  class FiberActiveI4Contraction final : public HyperElasticLaw<FiberActiveI4Contraction<PassiveLaw>>
+  {
+    public:
+      struct Cache
+      {
+        typename PassiveLaw::Cache passive;
+        Math::SpatialVector<Real> a0;
+        Math::SpatialVector<Real> f;
+        Real activation;
+        Real lambdaF;
+      };
+
+      /**
+       * @param passive Passive constitutive law.
+       * @param activeTensionScale Active tension scale @f$T_a@f$.
+       * @param referenceFiberStretch Active reference fiber stretch @f$\lambda_0@f$.
+       */
+      FiberActiveI4Contraction(
+          const PassiveLaw& passive,
+          Real activeTensionScale,
+          Real referenceFiberStretch = 1.0)
+        : m_passive(passive),
+          m_activeTensionScale(activeTensionScale),
+          m_referenceFiberStretch(referenceFiberStretch)
+      {}
+
+      void setCache(Cache& cache, const ConstitutivePoint& cp) const
+      {
+        m_passive.setCache(cache.passive, cp);
+
+        assert(cp.has<Tags::FiberDirection>());
+        cache.a0 = cp.get<Tags::FiberDirection>();
+        const Real norm = cache.a0.norm();
+        assert(norm > 0.0);
+        cache.a0 /= norm;
+
+        cache.activation = cp.has<Tags::Activation>()
+          ? cp.get<Tags::Activation>()
+          : 1.0;
+
+        const auto& F = cp.getKinematicState().getDeformationGradient();
+        cache.f = F * cache.a0;
+
+        const Real I4 = std::max<Real>(cache.f.dot(cache.f), 1e-16);
+        cache.lambdaF = std::sqrt(I4);
+      }
+
+      Real getStrainEnergyDensity(const Cache& cache, const ConstitutivePoint& cp) const
+      {
+        const Real passiveEnergy = m_passive.getStrainEnergyDensity(cache.passive, cp);
+        const Real delta = cache.lambdaF - m_referenceFiberStretch;
+        return passiveEnergy + 0.5 * m_activeTensionScale * cache.activation * delta * delta;
+      }
+
+      void getFirstPiolaKirchhoffStress(
+          Math::SpatialMatrix<Real>& P,
+          const Cache& cache,
+          const ConstitutivePoint& cp) const
+      {
+        m_passive.getFirstPiolaKirchhoffStress(P, cache.passive, cp);
+
+        const Real coef = m_activeTensionScale * cache.activation
+                        * (1.0 - m_referenceFiberStretch / cache.lambdaF);
+
+        P += coef * (cache.f * cache.a0.transpose());
+      }
+
+      void getMaterialTangent(
+          Math::SpatialMatrix<Real>& dP,
+          const Cache& cache,
+          const ConstitutivePoint& cp,
+          const Math::SpatialMatrix<Real>& dF) const
+      {
+        m_passive.getMaterialTangent(dP, cache.passive, cp, dF);
+
+        const Math::SpatialVector<Real> df = dF * cache.a0;
+        const Real fdotdf = cache.f.dot(df);
+
+        const Real coef = m_activeTensionScale * cache.activation
+                        * (1.0 - m_referenceFiberStretch / cache.lambdaF);
+
+        const Real dCoef = m_activeTensionScale * cache.activation
+                         * m_referenceFiberStretch * fdotdf
+                         / (cache.lambdaF * cache.lambdaF * cache.lambdaF);
+
+        dP += dCoef * (cache.f * cache.a0.transpose())
+            + coef * (df * cache.a0.transpose());
+      }
+
+      const PassiveLaw& getPassiveLaw() const { return m_passive; }
+      Real getActiveTensionScale() const { return m_activeTensionScale; }
+      Real getReferenceFiberStretch() const { return m_referenceFiberStretch; }
+
+    private:
+      PassiveLaw m_passive;
+      Real m_activeTensionScale;
+      Real m_referenceFiberStretch;
+  };
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation
- Provide a reusable, local active fiber-contraction model that composes with existing hyperelastic laws so active tension and fiber-direction/activation tags can be used in solid mechanics simulations.

### Description
- Add `src/Rodin/Solid/Constitutive/ActiveContraction.h` which implements the template `FiberActiveI4Contraction<PassiveLaw>` providing strain energy, first Piola-Kirchhoff stress, and material tangent contributions for an I4-based fiber-active term and a small `Cache` structure for quadrature-point data.
- Expose the new header in the Solid public header (`src/Rodin/Solid.h`) and declare it in the Solid CMake list (`src/Rodin/Solid/CMakeLists.txt`).
- Add a new demonstration `examples/Solid/ActiveContraction.cpp` showing an explicit per-cell internal-variable update loop with active contraction and register the example executable in `examples/Solid/CMakeLists.txt` as `RodinSolidActiveContraction`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6206fc06c832cae359a4ca32d0053)