### PR TITLE
Preserve spatial range types in variational traits

### DIFF
--- a/src/Rodin/Variational/Traits.h
+++ b/src/Rodin/Variational/Traits.h
@@ -140,7 +140,14 @@ namespace Rodin::FormLanguage
   struct RangeOf<Math::SpatialVector<Scalar>>
   {
     using Type =
-      Math::Vector<Scalar>;
+      Math::SpatialVector<Scalar>;
+  };
+
+  template <class Scalar>
+  struct RangeOf<Math::SpatialMatrix<Scalar>>
+  {
+    using Type =
+      Math::SpatialMatrix<Scalar>;
   };
 
   /**
@@ -165,8 +172,16 @@ namespace Rodin::FormLanguage
    *
    * Deduces whether the expression is a vector or matrix based on compile-time properties.
    */
+  template <class MatrixXpr, class = void>
+  struct EigenRangeOf;
+
   template <class MatrixXpr>
-  struct RangeOf
+  struct EigenRangeOf<
+    MatrixXpr,
+    std::void_t<
+      decltype(MatrixXpr::IsVectorAtCompileTime),
+      decltype(MatrixXpr::ColsAtCompileTime),
+      typename MatrixXpr::Scalar>>
   {
     using Type =
       std::conditional_t<
@@ -176,6 +191,12 @@ namespace Rodin::FormLanguage
           Math::Matrix<typename MatrixXpr::Scalar>
         >
       >;
+  };
+
+  template <class MatrixXpr>
+  struct RangeOf
+  {
+    using Type = typename EigenRangeOf<MatrixXpr>::Type;
   };
 
   /**


### PR DESCRIPTION
### Motivation
- Spatial linear-algebra types (`Math::SpatialVector` / `Math::SpatialMatrix`) were being collapsed to generic `Math::Vector`/`Math::Matrix` when deducing expression range types, which loses semantic information needed by variational code paths. 
- Ensure explicit spatial specializations take precedence while keeping the Eigen-expression fallback for generic Eigen types.

### Description
- Changed `RangeOf<Math::SpatialVector<Scalar>>` to return `Math::SpatialVector<Scalar>` instead of `Math::Vector<Scalar>` in `src/Rodin/Variational/Traits.h`.
- Added explicit `RangeOf<Math::SpatialMatrix<Scalar>>` specialization that returns `Math::SpatialMatrix<Scalar>`.
- Refactored the Eigen-expression fallback into a constrained helper `EigenRangeOf` using `std::void_t` so the generic fallback only applies to Eigen-like expression types and does not override explicit spatial specializations.
- Left `RangeOf<Variational::FunctionBase<...>>` and `RangeOf<Variational::ShapeFunctionBase<...>>` logic unchanged so they continue to resolve via `RangeOf<std::remove_cvref_t<ResultType>>`, allowing spatial result types to propagate unchanged.

### Testing
- Ran `git diff --check` which reported no issues and completed successfully.
- Ran `rg -n "RangeOf<Variational::FunctionBase|RangeOf<Variational::ShapeFunctionBase" src/Rodin/Variational/{Traits.h,Function.h,ShapeFunction.h}` to verify usages and the search completed successfully.
- Changes were committed on the working branch (commit recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cb580a34832cbfeafe848946347e)