### PR TITLE
Refactor variational ranges to SpatialVector/SpatialMatrix and add RangeKind detection

### DIFF
--- a/src/Rodin/FormLanguage/Base.h
+++ b/src/Rodin/FormLanguage/Base.h
@@ -18,6 +18,9 @@
 #include "Rodin/Copyable.h"
 #include "Rodin/Identifiable.h"
 #include "Rodin/Math/ForwardDecls.h"
+#include "Rodin/Math/Traits.h"
+#include "Rodin/Math/SpatialVector.h"
+#include "Rodin/Math/SpatialMatrix.h"
 #include "Rodin/Variational/ForwardDecls.h"
 
 #include "Traits.h"
@@ -113,8 +116,53 @@ namespace Rodin::FormLanguage
        * 
        * @note Only plain object types (as defined by IsPlainObject) are accepted
        */
-      template <class T, typename =
-        std::enable_if_t<FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value>>
+      template <class T>
+      using DecayT = std::remove_cv_t<std::remove_reference_t<T>>;
+
+      template <class T>
+      static constexpr bool IsStackBackedObject =
+        FormLanguage::RangeKindOf<DecayT<T>>::Value != FormLanguage::RangeKind::Unknown;
+
+      /**
+       * @brief Materializes stack-backed math objects.
+       *
+       * Supported categories are Boolean, Integer, Real, Complex,
+       * SpatialVector and SpatialMatrix. Vector/matrix-like Eigen expressions
+       * are explicitly materialized into spatial objects.
+       */
+      template <class T, std::enable_if_t<IsStackBackedObject<T>, int> = 0>
+      constexpr
+      auto object(T&& obj) const noexcept
+      {
+        using D = DecayT<T>;
+        constexpr auto kind = FormLanguage::RangeKindOf<D>::Value;
+        if constexpr (kind == FormLanguage::RangeKind::Boolean
+                   || kind == FormLanguage::RangeKind::Integer
+                   || kind == FormLanguage::RangeKind::Real
+                   || kind == FormLanguage::RangeKind::Complex)
+        {
+          return static_cast<D>(std::forward<T>(obj));
+        }
+        else if constexpr (kind == FormLanguage::RangeKind::Vector)
+        {
+          using Scalar = typename D::Scalar;
+          return Math::SpatialVector<Scalar>(std::forward<T>(obj));
+        }
+        else if constexpr (kind == FormLanguage::RangeKind::Matrix)
+        {
+          using Scalar = typename D::Scalar;
+          return Math::SpatialMatrix<Scalar>(std::forward<T>(obj));
+        }
+        else
+        {
+          return static_cast<D>(std::forward<T>(obj));
+        }
+      }
+
+      template <class T,
+        std::enable_if_t<
+          !IsStackBackedObject<T> && FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value,
+        int> = 0>
       constexpr
       const T& object(T&& obj) const noexcept
       {
@@ -141,8 +189,10 @@ namespace Rodin::FormLanguage
        * or expression templates) by forwarding them directly without storage.
        * It is selected via SFINAE when T is not a plain object.
        */
-      template <class T, typename =
-        std::enable_if_t<!FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value>>
+      template <class T,
+        std::enable_if_t<
+          !IsStackBackedObject<T> && !FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value,
+        int> = 0>
       constexpr
       T object(T&& obj) const noexcept
       {

--- a/src/Rodin/FormLanguage/Base.h
+++ b/src/Rodin/FormLanguage/Base.h
@@ -17,13 +17,9 @@
 #include "Rodin/Copyable.h"
 #include "Rodin/Identifiable.h"
 #include "Rodin/Math/ForwardDecls.h"
-#include "Rodin/Math/Traits.h"
-#include "Rodin/Math/SpatialVector.h"
-#include "Rodin/Math/SpatialMatrix.h"
 #include "Rodin/Variational/ForwardDecls.h"
 
 #include "Traits.h"
-#include "IsPlaneObject.h"
 
 namespace Rodin::FormLanguage
 {
@@ -40,9 +36,7 @@ namespace Rodin::FormLanguage
    *
    * ## Key Features
    * - **Unique Identification**: Each instance receives a unique UUID for tracking
- * - **Object Management**: Value materialization for expression objects
-   * - **Polymorphic Operations**: Support for copying and cloning operations
-   * - **Type Safety**: Template-based object storage with type validation
+ * - **Polymorphic Operations**: Support for copying and cloning operations
    */
   class Base : public Copyable, public Identifiable
   {
@@ -95,93 +89,6 @@ namespace Rodin::FormLanguage
       virtual Optional<StringView> getName() const
       {
         return {};
-      }
-
-      /**
-       * @brief Materializes expression objects into concrete value objects.
-       *
-       * @tparam T Type of object to materialize
-       * @param obj Object to materialize
-       */
-      template <class T>
-      using DecayT = std::remove_cv_t<std::remove_reference_t<T>>;
-
-      template <class T>
-      static constexpr bool IsStackBackedObject =
-        FormLanguage::RangeKindOf<DecayT<T>>::Value != FormLanguage::RangeKind::Unknown;
-
-      /**
-       * @brief Materializes stack-backed math objects.
-       *
-       * Supported categories are Boolean, Integer, Real, Complex,
-       * SpatialVector and SpatialMatrix. Vector/matrix-like Eigen expressions
-       * are explicitly materialized into spatial objects.
-       */
-      template <class T, std::enable_if_t<IsStackBackedObject<T>, int> = 0>
-      constexpr
-      auto object(T&& obj) const noexcept
-      {
-        using D = DecayT<T>;
-        constexpr auto kind = FormLanguage::RangeKindOf<D>::Value;
-        if constexpr (kind == FormLanguage::RangeKind::Boolean
-                   || kind == FormLanguage::RangeKind::Integer
-                   || kind == FormLanguage::RangeKind::Real
-                   || kind == FormLanguage::RangeKind::Complex)
-        {
-          return static_cast<D>(std::forward<T>(obj));
-        }
-        else if constexpr (kind == FormLanguage::RangeKind::Vector)
-        {
-          using Scalar = typename D::Scalar;
-          return Math::SpatialVector<Scalar>(std::forward<T>(obj));
-        }
-        else if constexpr (kind == FormLanguage::RangeKind::Matrix)
-        {
-          using Scalar = typename D::Scalar;
-          return Math::SpatialMatrix<Scalar>(std::forward<T>(obj));
-        }
-        else
-        {
-          return static_cast<D>(std::forward<T>(obj));
-        }
-      }
-
-      template <class T,
-        std::enable_if_t<
-          !IsStackBackedObject<T> && FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value,
-        int> = 0>
-      constexpr
-      DecayT<T> object(T&& obj) const noexcept
-      {
-        return static_cast<DecayT<T>>(std::forward<T>(obj));
-      }
-
-      /**
-       * @brief Forwards non-plain objects unchanged.
-       * @tparam T Type of object (must not be a plain object type)
-       * @param[in] obj Object to forward
-       * @return Forwarded object
-       *
-       * This overload handles non-plain object types (such as scalars, references,
-       * or expression templates) by forwarding them directly without storage.
-       * It is selected via SFINAE when T is not a plain object.
-       */
-      template <class T,
-        std::enable_if_t<
-          !IsStackBackedObject<T> && !FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value,
-        int> = 0>
-      constexpr
-      T object(T&& obj) const noexcept
-      {
-        return std::forward<T>(obj);
-      }
-
-      /**
-       * @brief Clears internal temporary state.
-       */
-      void clear()
-      {
-        // No-op: object() now materializes values without heap storage.
       }
 
       /**

--- a/src/Rodin/FormLanguage/Base.h
+++ b/src/Rodin/FormLanguage/Base.h
@@ -9,7 +9,6 @@
 
 #include <atomic>
 #include <vector>
-#include <memory>
 #include <cassert>
 #include <variant>
 #include <typeinfo>
@@ -41,14 +40,12 @@ namespace Rodin::FormLanguage
    *
    * ## Key Features
    * - **Unique Identification**: Each instance receives a unique UUID for tracking
-   * - **Object Management**: Automatic lifetime management for temporary objects
+ * - **Object Management**: Value materialization for expression objects
    * - **Polymorphic Operations**: Support for copying and cloning operations
    * - **Type Safety**: Template-based object storage with type validation
    */
   class Base : public Copyable, public Identifiable
   {
-    using ObjectTable = std::vector<std::shared_ptr<const void>>;
-
     public:
       /**
        * @brief Constructor.
@@ -60,8 +57,7 @@ namespace Rodin::FormLanguage
        */
       Base(const Base& other)
         : Copyable(other),
-          Identifiable(other),
-          m_objs(other.m_objs)
+          Identifiable(other)
       {}
 
       /**
@@ -69,8 +65,7 @@ namespace Rodin::FormLanguage
        */
       Base(Base&& other)
         : Copyable(std::move(other)),
-          Identifiable(std::move(other)),
-          m_objs(std::move(other.m_objs))
+          Identifiable(std::move(other))
       {}
 
       /**
@@ -103,18 +98,10 @@ namespace Rodin::FormLanguage
       }
 
       /**
-       * @brief Stores an object for automatic lifetime management.
-       * 
-       * @tparam T Type of object to store (must be a plain object type)
-       * @param obj Object to store (rvalue) or reference (lvalue) 
-       * @return const T& Reference to the stored object
-       * 
-       * This method provides automatic lifetime management for temporary objects
-       * used in form language expressions. For rvalue references, the object is
-       * moved into internal storage and its lifetime is tied to this Base instance.
-       * For lvalue references, the original object is returned unchanged.
-       * 
-       * @note Only plain object types (as defined by IsPlainObject) are accepted
+       * @brief Materializes expression objects into concrete value objects.
+       *
+       * @tparam T Type of object to materialize
+       * @param obj Object to materialize
        */
       template <class T>
       using DecayT = std::remove_cv_t<std::remove_reference_t<T>>;
@@ -164,19 +151,9 @@ namespace Rodin::FormLanguage
           !IsStackBackedObject<T> && FormLanguage::IsPlainObject<std::remove_reference_t<T>>::Value,
         int> = 0>
       constexpr
-      const T& object(T&& obj) const noexcept
+      DecayT<T> object(T&& obj) const noexcept
       {
-        if constexpr (std::is_lvalue_reference_v<T>)
-        {
-          return obj;
-        }
-        else
-        {
-          using R = typename std::remove_reference_t<T>;
-          const R* res = new R(std::forward<T>(obj));
-          m_objs.emplace_back(res);
-          return *res;
-        }
+        return static_cast<DecayT<T>>(std::forward<T>(obj));
       }
 
       /**
@@ -200,18 +177,11 @@ namespace Rodin::FormLanguage
       }
 
       /**
-       * @brief Clears all stored objects, releasing their memory.
-       *
-       * Destroys all objects that were stored via the object() method,
-       * freeing the associated memory. This is useful for managing
-       * temporary object lifetimes explicitly.
-       *
-       * @note After calling clear(), any references obtained from previous
-       * object() calls become invalid.
+       * @brief Clears internal temporary state.
        */
       void clear()
       {
-        m_objs.clear();
+        // No-op: object() now materializes values without heap storage.
       }
 
       /**
@@ -226,8 +196,6 @@ namespace Rodin::FormLanguage
        */
       virtual Base* copy() const noexcept override = 0;
 
-    private:
-      mutable std::vector<std::shared_ptr<const void>> m_objs;
   };
 }
 

--- a/src/Rodin/Math/Traits.h
+++ b/src/Rodin/Math/Traits.h
@@ -103,36 +103,50 @@ namespace Rodin::FormLanguage
   };
 
   template <class T>
-  struct IsSpatialVector : std::false_type {};
+  struct IsSpatialVector : std::false_type { static constexpr bool Value = false; };
 
   template <class Scalar>
-  struct IsSpatialVector<Math::SpatialVector<Scalar>> : std::true_type {};
+  struct IsSpatialVector<Math::SpatialVector<Scalar>> : std::true_type { static constexpr bool Value = true; };
 
   template <class T>
-  struct IsSpatialMatrix : std::false_type {};
+  struct IsSpatialMatrix : std::false_type { static constexpr bool Value = false; };
 
   template <class Scalar>
-  struct IsSpatialMatrix<Math::SpatialMatrix<Scalar>> : std::true_type {};
+  struct IsSpatialMatrix<Math::SpatialMatrix<Scalar>> : std::true_type { static constexpr bool Value = true; };
 
   template <class T>
   struct IsVectorRange
     : std::bool_constant<
-        IsSpatialVector<std::decay_t<T>>::value
+        IsSpatialVector<std::decay_t<T>>::Value
         || (
           IsEigenObject<std::decay_t<T>>::Value
           && (std::decay_t<T>::ColsAtCompileTime == 1)
         )>
-  {};
+  {
+    static constexpr bool Value =
+      IsSpatialVector<std::decay_t<T>>::Value
+      || (
+        IsEigenObject<std::decay_t<T>>::Value
+        && (std::decay_t<T>::ColsAtCompileTime == 1)
+      );
+  };
 
   template <class T>
   struct IsMatrixRange
     : std::bool_constant<
-        IsSpatialMatrix<std::decay_t<T>>::value
+        IsSpatialMatrix<std::decay_t<T>>::Value
         || (
           IsEigenObject<std::decay_t<T>>::Value
           && (std::decay_t<T>::ColsAtCompileTime != 1)
         )>
-  {};
+  {
+    static constexpr bool Value =
+      IsSpatialMatrix<std::decay_t<T>>::Value
+      || (
+        IsEigenObject<std::decay_t<T>>::Value
+        && (std::decay_t<T>::ColsAtCompileTime != 1)
+      );
+  };
 
   template <class T>
   struct RangeKindOf
@@ -141,8 +155,8 @@ namespace Rodin::FormLanguage
       std::is_same_v<std::decay_t<T>, Boolean> ? RangeKind::Boolean
       : std::is_same_v<std::decay_t<T>, Integer> ? RangeKind::Integer
       : std::is_same_v<std::decay_t<T>, Real> ? RangeKind::Real
-      : IsVectorRange<std::decay_t<T>>::value ? RangeKind::Vector
-      : IsMatrixRange<std::decay_t<T>>::value ? RangeKind::Matrix
+      : IsVectorRange<std::decay_t<T>>::Value ? RangeKind::Vector
+      : IsMatrixRange<std::decay_t<T>>::Value ? RangeKind::Matrix
       : RangeKind::Unknown;
   };
 

--- a/src/Rodin/Math/Traits.h
+++ b/src/Rodin/Math/Traits.h
@@ -97,6 +97,7 @@ namespace Rodin::FormLanguage
     Boolean,
     Integer,
     Real,
+    Complex,
     Vector,
     Matrix,
     Unknown
@@ -155,6 +156,7 @@ namespace Rodin::FormLanguage
       std::is_same_v<std::decay_t<T>, Boolean> ? RangeKind::Boolean
       : std::is_same_v<std::decay_t<T>, Integer> ? RangeKind::Integer
       : std::is_same_v<std::decay_t<T>, Real> ? RangeKind::Real
+      : std::is_same_v<std::decay_t<T>, Complex> ? RangeKind::Complex
       : IsVectorRange<std::decay_t<T>>::Value ? RangeKind::Vector
       : IsMatrixRange<std::decay_t<T>>::Value ? RangeKind::Matrix
       : RangeKind::Unknown;
@@ -257,4 +259,3 @@ namespace Rodin::FormLanguage
 }
 
 #endif
-

--- a/src/Rodin/Math/Traits.h
+++ b/src/Rodin/Math/Traits.h
@@ -46,6 +46,18 @@ namespace Rodin::FormLanguage
       std::is_base_of_v<Eigen::EigenBase<typename std::decay<T>::type>, typename std::decay<T>::type>;
   };
 
+  template <class T, class = void>
+  struct ColsAtCompileTime
+  {
+    static constexpr int Value = -1;
+  };
+
+  template <class T>
+  struct ColsAtCompileTime<T, std::void_t<decltype(std::decay_t<T>::ColsAtCompileTime)>>
+  {
+    static constexpr int Value = std::decay_t<T>::ColsAtCompileTime;
+  };
+
   /**
    * @brief Traits specialization for Boolean type.
    */
@@ -121,14 +133,14 @@ namespace Rodin::FormLanguage
         IsSpatialVector<std::decay_t<T>>::Value
         || (
           IsEigenObject<std::decay_t<T>>::Value
-          && (std::decay_t<T>::ColsAtCompileTime == 1)
+          && (ColsAtCompileTime<std::decay_t<T>>::Value == 1)
         )>
   {
     static constexpr bool Value =
       IsSpatialVector<std::decay_t<T>>::Value
       || (
         IsEigenObject<std::decay_t<T>>::Value
-        && (std::decay_t<T>::ColsAtCompileTime == 1)
+        && (ColsAtCompileTime<std::decay_t<T>>::Value == 1)
       );
   };
 
@@ -138,14 +150,14 @@ namespace Rodin::FormLanguage
         IsSpatialMatrix<std::decay_t<T>>::Value
         || (
           IsEigenObject<std::decay_t<T>>::Value
-          && (std::decay_t<T>::ColsAtCompileTime != 1)
+          && (ColsAtCompileTime<std::decay_t<T>>::Value != 1)
         )>
   {
     static constexpr bool Value =
       IsSpatialMatrix<std::decay_t<T>>::Value
       || (
         IsEigenObject<std::decay_t<T>>::Value
-        && (std::decay_t<T>::ColsAtCompileTime != 1)
+        && (ColsAtCompileTime<std::decay_t<T>>::Value != 1)
       );
   };
 

--- a/src/Rodin/Math/Traits.h
+++ b/src/Rodin/Math/Traits.h
@@ -24,6 +24,7 @@
 #include "Rodin/Types.h"
 
 #include "Common.h"
+#include "ForwardDecls.h"
 
 namespace Rodin::FormLanguage
 {
@@ -89,6 +90,64 @@ namespace Rodin::FormLanguage
    * @tparam LHS Type of left-hand side operand
    * @tparam RHS Type of right-hand side operand
    */
+
+
+  enum class RangeKind
+  {
+    Boolean,
+    Integer,
+    Real,
+    Vector,
+    Matrix,
+    Unknown
+  };
+
+  template <class T>
+  struct IsSpatialVector : std::false_type {};
+
+  template <class Scalar>
+  struct IsSpatialVector<Math::SpatialVector<Scalar>> : std::true_type {};
+
+  template <class T>
+  struct IsSpatialMatrix : std::false_type {};
+
+  template <class Scalar>
+  struct IsSpatialMatrix<Math::SpatialMatrix<Scalar>> : std::true_type {};
+
+  template <class T>
+  struct IsVectorRange
+    : std::bool_constant<
+        IsSpatialVector<std::decay_t<T>>::value
+        || (
+          IsEigenObject<std::decay_t<T>>::Value
+          && (std::decay_t<T>::ColsAtCompileTime == 1)
+        )>
+  {};
+
+  template <class T>
+  struct IsMatrixRange
+    : std::bool_constant<
+        IsSpatialMatrix<std::decay_t<T>>::value
+        || (
+          IsEigenObject<std::decay_t<T>>::Value
+          && (std::decay_t<T>::ColsAtCompileTime != 1)
+        )>
+  {};
+
+  template <class T>
+  struct RangeKindOf
+  {
+    static constexpr RangeKind Value =
+      std::is_same_v<std::decay_t<T>, Boolean> ? RangeKind::Boolean
+      : std::is_same_v<std::decay_t<T>, Integer> ? RangeKind::Integer
+      : std::is_same_v<std::decay_t<T>, Real> ? RangeKind::Real
+      : IsVectorRange<std::decay_t<T>>::value ? RangeKind::Vector
+      : IsMatrixRange<std::decay_t<T>>::value ? RangeKind::Matrix
+      : RangeKind::Unknown;
+  };
+
+  template <class T>
+  inline constexpr auto RangeKindOfV = RangeKindOf<T>::Value;
   template <class LHS, class RHS>
   struct Sum
   {

--- a/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
+++ b/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
@@ -35,6 +35,7 @@
 #include "Rodin/Variational/P1/ForwardDecls.h"
 #include "Rodin/Variational/P1/P1.h"
 #include "Rodin/QF/Centroid.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
+++ b/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
@@ -82,7 +82,7 @@ namespace Rodin::Variational
       using LambdaRangeType =
         typename FormLanguage::Traits<LambdaType>::RangeType;
 
-      static_assert(FormLanguage::IsVectorRange<Range>::value);
+      static_assert(FormLanguage::IsVectorRange<Range>::Value);
 
     public:
       LinearElasticityIntegrator(

--- a/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
+++ b/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
@@ -81,7 +81,7 @@ namespace Rodin::Variational
       using LambdaRangeType =
         typename FormLanguage::Traits<LambdaType>::RangeType;
 
-      static_assert(std::is_same_v<Range, Math::Vector<ScalarType>>);
+      static_assert(FormLanguage::IsVectorRange<Range>::value);
 
     public:
       LinearElasticityIntegrator(

--- a/src/Rodin/Variational/Average.h
+++ b/src/Rodin/Variational/Average.h
@@ -145,7 +145,9 @@ namespace Rodin::Variational
         it2->getTransformation().inverse(rc2, pc);
         const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
         const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
-        return 0.5 * (this->object(getOperand().getValue(p1)) + this->object(getOperand().getValue(p2)));
+        const auto v1 = getOperand().getValue(p1);
+        const auto v2 = getOperand().getValue(p2);
+        return 0.5 * (v1 + v2);
       }
 
       constexpr
@@ -312,9 +314,9 @@ namespace Rodin::Variational
         const IntegrationPoint ip1(p1, m_ip->getQuadratureFormula(), m_ip->getIndex());
         const IntegrationPoint ip2(p2, m_ip->getQuadratureFormula(), m_ip->getIndex());
         m_operand->setIntegrationPoint(ip1);
-        const auto& val1 = this->object(m_operand->getBasis(local));
+        const auto val1 = m_operand->getBasis(local);
         m_operand->setIntegrationPoint(ip2);
-        const auto& val2 = this->object(m_operand->getBasis(local));
+        const auto val2 = m_operand->getBasis(local);
         return 0.5 * (val1 + val2);
       }
 

--- a/src/Rodin/Variational/Average.h
+++ b/src/Rodin/Variational/Average.h
@@ -128,9 +128,6 @@ namespace Rodin::Variational
        */
       auto getValue(const Geometry::Point& p) const
       {
-        static thread_local Math::SpatialPoint s_rc1;
-        static thread_local Math::SpatialPoint s_rc2;
-
         assert(p.getPolytope().isFace());
         const auto& face = p.getPolytope();
         const size_t d = face.getDimension();
@@ -142,10 +139,12 @@ namespace Rodin::Variational
         const auto it1 = mesh.getPolytope(d + 1, idx1);
         const auto it2 = mesh.getPolytope(d + 1, idx2);
         const auto& pc = p.getPhysicalCoordinates();
-        it1->getTransformation().inverse(s_rc1, pc);
-        it2->getTransformation().inverse(s_rc2, pc);
-        const Geometry::Point p1(std::cref(*it1), std::cref(s_rc1), pc);
-        const Geometry::Point p2(std::cref(*it2), std::cref(s_rc2), pc);
+        Math::SpatialPoint rc1;
+        Math::SpatialPoint rc2;
+        it1->getTransformation().inverse(rc1, pc);
+        it2->getTransformation().inverse(rc2, pc);
+        const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
+        const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
         return 0.5 * (this->object(getOperand().getValue(p1)) + this->object(getOperand().getValue(p2)));
       }
 
@@ -291,9 +290,6 @@ namespace Rodin::Variational
        */
       auto getBasis(size_t local) const
       {
-        static thread_local Math::SpatialPoint s_rc1;
-        static thread_local Math::SpatialPoint s_rc2;
-
         assert(m_ip);
         const auto& p = m_ip->getPoint();
         assert(p.getPolytope().isFace());
@@ -307,10 +303,12 @@ namespace Rodin::Variational
         const auto it1 = mesh.getPolytope(d + 1, idx1);
         const auto it2 = mesh.getPolytope(d + 1, idx2);
         const auto& pc = p.getPhysicalCoordinates();
-        it1->getTransformation().inverse(s_rc1, pc);
-        it2->getTransformation().inverse(s_rc2, pc);
-        const Geometry::Point p1(std::cref(*it1), std::cref(s_rc1), pc);
-        const Geometry::Point p2(std::cref(*it2), std::cref(s_rc2), pc);
+        Math::SpatialPoint rc1;
+        Math::SpatialPoint rc2;
+        it1->getTransformation().inverse(rc1, pc);
+        it2->getTransformation().inverse(rc2, pc);
+        const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
+        const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
         const IntegrationPoint ip1(p1, m_ip->getQuadratureFormula(), m_ip->getIndex());
         const IntegrationPoint ip2(p2, m_ip->getQuadratureFormula(), m_ip->getIndex());
         m_operand->setIntegrationPoint(ip1);

--- a/src/Rodin/Variational/BoundaryNormal.h
+++ b/src/Rodin/Variational/BoundaryNormal.h
@@ -72,7 +72,7 @@ namespace Rodin::Variational
     public:
       using ScalarType = Real;
 
-      using RangeType = Math::Vector<ScalarType>;
+      using RangeType = Math::SpatialVector<ScalarType>;
 
       using SpatialVectorType = Math::SpatialVector<ScalarType>;
 

--- a/src/Rodin/Variational/BoundaryNormal.h
+++ b/src/Rodin/Variational/BoundaryNormal.h
@@ -223,10 +223,8 @@ namespace Rodin::Variational
         }
       }
 
-      decltype(auto) getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static thread_local RangeType s_res;
-
         SpatialVectorType res;
         const auto& polytope = p.getPolytope();
         const auto& polytopeMesh = polytope.getMesh();
@@ -249,8 +247,7 @@ namespace Rodin::Variational
           res.setConstant(Math::nan<ScalarType>());
           assert(false);
         }
-        s_res = res.getData().head(m_sdim);
-        return s_res;
+        return res;
       }
 
       constexpr
@@ -271,4 +268,3 @@ namespace Rodin::Variational
 }
 
 #endif
-

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -117,7 +117,7 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->getOperand().getValue(p).coeff(m_idx);
+        return this->getOperand().getValue(p)(m_idx);
       }
 
       constexpr
@@ -214,7 +214,7 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->getOperand().getValue(p).coeff(m_i, m_j);
+        return this->getOperand().getValue(p)(m_i, m_j);
       }
 
       constexpr
@@ -317,7 +317,7 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return m_u.get().getValue(p).coeff(m_idx);
+        return m_u.get().getValue(p)(m_idx);
       }
 
       constexpr
@@ -463,7 +463,7 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto basis = this->getOperand().getBasis(local);
-        return basis.coeff(m_idx);
+        return basis(m_idx);
       }
 
       constexpr
@@ -491,4 +491,3 @@ namespace Rodin::Variational
 }
 
 #endif
-

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -369,7 +369,7 @@ namespace Rodin::Variational
 
       using Parent = ShapeFunctionBase<Component<OperandType>, FES, Space>;
 
-      static_assert(std::is_same_v<OperandRangeType, Math::Vector<ScalarType>>);
+      static_assert(FormLanguage::IsVectorRange<OperandRangeType>::value);
 
       /**
        * @brief Constructs component extractor for ShapeFunction.

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -12,6 +12,7 @@
 
 #include "ForwardDecls.h"
 #include "Rodin/Variational/IntegrationPoint.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::FormLanguage
 {

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -370,7 +370,7 @@ namespace Rodin::Variational
 
       using Parent = ShapeFunctionBase<Component<OperandType>, FES, Space>;
 
-      static_assert(FormLanguage::IsVectorRange<OperandRangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<OperandRangeType>::Value);
 
       /**
        * @brief Constructs component extractor for ShapeFunction.

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -462,7 +462,8 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        return this->object(this->getOperand().getBasis(local)).coeff(m_idx);
+        const auto basis = this->getOperand().getBasis(local);
+        return basis.coeff(m_idx);
       }
 
       constexpr

--- a/src/Rodin/Variational/Conjugate.h
+++ b/src/Rodin/Variational/Conjugate.h
@@ -98,7 +98,8 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return Math::conj(this->object(getOperand().getValue(p)));
+        const auto v = getOperand().getValue(p);
+        return Math::conj(v);
       }
 
       /**
@@ -238,7 +239,8 @@ namespace Rodin::Variational
       constexpr
       decltype(auto) getBasis(size_t local) const
       {
-        return Math::conj(this->object(this->getOperand().getBasis(local)));
+        const auto v = this->getOperand().getBasis(local);
+        return Math::conj(v);
       }
 
       /**

--- a/src/Rodin/Variational/Derivative.h
+++ b/src/Rodin/Variational/Derivative.h
@@ -118,9 +118,9 @@ namespace Rodin::Variational
         return m_u.get().getFiniteElementSpace().getMesh().getSpaceDimension();
       }
 
-      decltype(auto) getValue(const Geometry::Point& p) const
+      ScalarType getValue(const Geometry::Point& p) const
       {
-        static thread_local ScalarType s_out;
+        ScalarType out{};
         const auto& polytope = p.getPolytope();
         const auto& polytopeMesh = polytope.getMesh();
         const auto& gf = getOperand();
@@ -128,23 +128,23 @@ namespace Rodin::Variational
         const auto& fesMesh = fes.getMesh();
         if (polytopeMesh == fesMesh)
         {
-          this->interpolate(s_out, p);
+          this->interpolate(out, p);
         }
         else if (const auto inclusion = fesMesh.inclusion(p))
         {
-          this->interpolate(s_out, *inclusion);
+          this->interpolate(out, *inclusion);
         }
         else if (fesMesh.isSubMesh())
         {
           const auto& submesh = fesMesh.asSubMesh();
           const auto restriction = submesh.restriction(p);
-          interpolate(s_out, *restriction);
+          interpolate(out, *restriction);
         }
         else
         {
           assert(false);
         }
-        return s_out;
+        return out;
       }
 
       /**

--- a/src/Rodin/Variational/Division.h
+++ b/src/Rodin/Variational/Division.h
@@ -125,7 +125,9 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->object(getLHS().getValue(p)) / this->object(getRHS().getValue(p));
+        const auto lhs = getLHS().getValue(p);
+        const auto rhs = getRHS().getValue(p);
+        return lhs / rhs;
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const noexcept

--- a/src/Rodin/Variational/Dot.h
+++ b/src/Rodin/Variational/Dot.h
@@ -231,7 +231,9 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return Math::dot(this->object(getLHS().getValue(p)), this->object(getRHS().getValue(p)));
+        const auto lhs = getLHS().getValue(p);
+        const auto rhs = getRHS().getValue(p);
+        return Math::dot(lhs, rhs);
       }
 
       constexpr
@@ -387,7 +389,9 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& ip = this->getRHS().getIntegrationPoint();
-        return Math::dot(this->object(getLHS().getValue(ip.getPoint())), this->object(getRHS().getBasis(local)));
+        const auto lhs = getLHS().getValue(ip.getPoint());
+        const auto rhs = getRHS().getBasis(local);
+        return Math::dot(lhs, rhs);
       }
 
       constexpr
@@ -523,7 +527,9 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& p = getLHS().getIntegrationPoint();
-        return Math::dot(this->object(getLHS().getBasis(local)), this->object(getRHS().getValue(p.getPoint())));
+        const auto lhs = getLHS().getBasis(local);
+        const auto rhs = getRHS().getValue(p.getPoint());
+        return Math::dot(lhs, rhs);
       }
 
       constexpr
@@ -641,7 +647,9 @@ namespace Rodin::Variational
       constexpr
       auto operator()(size_t tr, size_t te)
       {
-        return Math::dot(this->object(getLHS().getBasis(tr)), this->object(getRHS().getBasis(te)));
+        const auto lhs = getLHS().getBasis(tr);
+        const auto rhs = getRHS().getBasis(te);
+        return Math::dot(lhs, rhs);
       }
 
       constexpr

--- a/src/Rodin/Variational/FaceNormal.h
+++ b/src/Rodin/Variational/FaceNormal.h
@@ -167,10 +167,8 @@ namespace Rodin::Variational
         return m_sdim;
       }
 
-      decltype(auto) getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static thread_local RangeType s_res;
-
         const auto& polytope = p.getPolytope();
         const auto& vs = polytope.getVertices();
         const auto  d = polytope.getDimension();
@@ -289,8 +287,7 @@ namespace Rodin::Variational
           }
         }
 
-        s_res = res.getData().head(static_cast<Eigen::Index>(m_sdim));
-        return s_res;
+        return res;
       }
 
       constexpr

--- a/src/Rodin/Variational/FaceNormal.h
+++ b/src/Rodin/Variational/FaceNormal.h
@@ -134,7 +134,7 @@ namespace Rodin::Variational
   {
     public:
       using ScalarType = Real;
-      using RangeType = Math::Vector<ScalarType>;
+      using RangeType = Math::SpatialVector<ScalarType>;
       using SpatialVectorType = Math::SpatialVector<ScalarType>;
       using Parent = VectorFunctionBase<ScalarType, FaceNormal>;
 

--- a/src/Rodin/Variational/Flow.h
+++ b/src/Rodin/Variational/Flow.h
@@ -381,9 +381,15 @@ namespace Rodin::Variational
         // Normalize the velocity return type in one place.
         auto vphysOf = [&](const Geometry::Point& qp) -> Math::SpatialVector<Real>
         {
-          // If m_velocity(qp) is already vector-like, replace the next line by:
-          // return m_velocity(qp);
-          return m_velocity(qp).col(0);
+          const auto v = m_velocity(qp);
+          if constexpr (requires { v.col(0); })
+          {
+            return v.col(0);
+          }
+          else
+          {
+            return v;
+          }
         };
 
         // Thread-local scratch buffers to reduce temporary allocations.

--- a/src/Rodin/Variational/Frobenius.h
+++ b/src/Rodin/Variational/Frobenius.h
@@ -102,9 +102,8 @@ namespace Rodin::Variational
         }
         else
         {
-          static thread_local OperandRangeType s_v;
-          s_v = this->getOperand().getValue(p);
-          return s_v.norm();
+          const auto v = this->getOperand().getValue(p);
+          return v.norm();
         }
       }
 

--- a/src/Rodin/Variational/Grad.h
+++ b/src/Rodin/Variational/Grad.h
@@ -17,6 +17,8 @@
 
 #include "ForwardDecls.h"
 
+#include "Rodin/Math/SpatialVector.h"
+
 #include "VectorFunction.h"
 
 namespace Rodin::FormLanguage
@@ -28,7 +30,7 @@ namespace Rodin::FormLanguage
 
     using OperandType = Variational::GridFunction<FESType, Data>;
 
-    using RangeType = Math::Vector<typename FormLanguage::Traits<FESType>::ScalarType>;
+    using RangeType = Math::SpatialVector<typename FormLanguage::Traits<FESType>::ScalarType>;
   };
 
   template <class NestedDerived, class FES, Variational::ShapeFunctionSpaceType Space>
@@ -40,7 +42,7 @@ namespace Rodin::FormLanguage
 
     using OperandType = Variational::ShapeFunction<NestedDerived, FESType, SpaceType>;
 
-    using RangeType = Math::Vector<typename FormLanguage::Traits<FESType>::ScalarType>;
+    using RangeType = Math::SpatialVector<typename FormLanguage::Traits<FESType>::ScalarType>;
   };
 }
 
@@ -106,7 +108,7 @@ namespace Rodin::Variational
       using FESType = FES;
 
       /// @brief Type of the output range
-      using RangeType = Math::Vector<typename FormLanguage::Traits<FESType>::ScalarType>;
+      using RangeType = Math::SpatialVector<typename FormLanguage::Traits<FESType>::ScalarType>;
 
       /// @brief Scalar type for computations
       using ScalarType = typename FormLanguage::Traits<FESType>::ScalarType;
@@ -209,11 +211,7 @@ namespace Rodin::Variational
       constexpr
       void interpolate(RangeType& out, const Geometry::Point& p) const
       {
-        SpatialVectorType res;
-        this->interpolate(res, p);
-
-        out.resize(res.size());
-        std::copy(res.begin(), res.end(), out.begin());
+        this->interpolate(static_cast<SpatialVectorType&>(out), p);
       }
 
       /**

--- a/src/Rodin/Variational/Grad.h
+++ b/src/Rodin/Variational/Grad.h
@@ -208,12 +208,6 @@ namespace Rodin::Variational
         return s_res;
       }
 
-      constexpr
-      void interpolate(RangeType& out, const Geometry::Point& p) const
-      {
-        this->interpolate(static_cast<SpatialVectorType&>(out), p);
-      }
-
       /**
        * @brief Interpolates the gradient at a point (to be overridden in derived class).
        * @param[out] out Output vector for gradient result

--- a/src/Rodin/Variational/Grad.h
+++ b/src/Rodin/Variational/Grad.h
@@ -172,10 +172,8 @@ namespace Rodin::Variational
        * weighted by the degrees of freedom. Handles mesh inclusion and
        * submesh restrictions automatically.
        */
-      decltype(auto) getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static thread_local RangeType s_res;
-
         const auto& polytope = p.getPolytope();
         const auto& polytopeMesh = polytope.getMesh();
         const auto& gf = getOperand();
@@ -202,10 +200,7 @@ namespace Rodin::Variational
         {
           assert(false);
         }
-
-        s_res = out.getData().head(out.size());
-
-        return s_res;
+        return out;
       }
 
       /**

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -285,7 +285,7 @@ namespace Rodin::Variational
 
       static_assert(
           std::is_same_v<RangeType, ScalarType> ||
-          FormLanguage::IsVectorRange<RangeType>::value);
+          FormLanguage::IsVectorRange<RangeType>::Value);
 
       /**
        * @brief Constructs a grid function on the given finite element space.
@@ -358,7 +358,7 @@ namespace Rodin::Variational
       constexpr
       auto x() const
       {
-        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
         assert(m_fes.get().getVectorDimension() >= 1);
         return Component(static_cast<const Derived&>(*this), 0);
       }
@@ -373,7 +373,7 @@ namespace Rodin::Variational
       constexpr
       auto y() const
       {
-        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
         assert(m_fes.get().getVectorDimension() >= 2);
         return Component(static_cast<const Derived&>(*this), 1);
       }
@@ -388,7 +388,7 @@ namespace Rodin::Variational
       constexpr
       auto z() const
       {
-        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
         assert(m_fes.get().getVectorDimension() >= 3);
         return Component(static_cast<const Derived&>(*this), 2);
       }

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -71,6 +71,7 @@
 #include "ForwardDecls.h"
 
 #include "Function.h"
+#include "Rodin/Math/Traits.h"
 
 
 namespace Rodin::FormLanguage

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -581,20 +581,20 @@ namespace Rodin::Variational
       /**
        * @brief Gets the interpolated value at the point.
        */
-      decltype(auto) getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static thread_local RangeType s_out;
+        RangeType out;
         const auto& polytope = p.getPolytope();
         const auto& polytopeMesh = polytope.getMesh();
         const auto& fes = m_fes.get();
         const auto& fesMesh = fes.getMesh();
         if (polytopeMesh == fesMesh)
         {
-          static_cast<const Derived&>(*this).interpolate(s_out, p);
+          static_cast<const Derived&>(*this).interpolate(out, p);
         }
         else if (const auto inclusion = fesMesh.inclusion(p))
         {
-          static_cast<const Derived&>(*this).interpolate(s_out, *inclusion);
+          static_cast<const Derived&>(*this).interpolate(out, *inclusion);
         }
         else if (fesMesh.isSubMesh())
         {
@@ -602,7 +602,7 @@ namespace Rodin::Variational
           const auto restriction = submesh.restriction(p);
           if (restriction)
           {
-            static_cast<const Derived&>(*this).interpolate(s_out, *restriction);
+            static_cast<const Derived&>(*this).interpolate(out, *restriction);
           }
           else
           {
@@ -617,7 +617,7 @@ namespace Rodin::Variational
             << "Point is not contained in the finite element space mesh."
             << Alert::Raise;
         }
-        return s_out;
+        return out;
       }
 
       constexpr
@@ -706,8 +706,8 @@ namespace Rodin::Variational
       {
         return static_cast<Derived&>(*this).project(
             region,
-            [&](const Geometry::Point&) -> decltype(auto)
-            { static thread_local RangeType s_out; s_out = fn; return s_out; }, pred);
+            [&](const Geometry::Point&) -> RangeType
+            { return fn; }, pred);
       }
 
       /**

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -284,7 +284,7 @@ namespace Rodin::Variational
 
       static_assert(
           std::is_same_v<RangeType, ScalarType> ||
-          std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+          FormLanguage::IsVectorRange<RangeType>::value);
 
       /**
        * @brief Constructs a grid function on the given finite element space.
@@ -357,7 +357,7 @@ namespace Rodin::Variational
       constexpr
       auto x() const
       {
-        static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
         assert(m_fes.get().getVectorDimension() >= 1);
         return Component(static_cast<const Derived&>(*this), 0);
       }
@@ -372,7 +372,7 @@ namespace Rodin::Variational
       constexpr
       auto y() const
       {
-        static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
         assert(m_fes.get().getVectorDimension() >= 2);
         return Component(static_cast<const Derived&>(*this), 1);
       }
@@ -387,7 +387,7 @@ namespace Rodin::Variational
       constexpr
       auto z() const
       {
-        static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+        static_assert(FormLanguage::IsVectorRange<RangeType>::value);
         assert(m_fes.get().getVectorDimension() >= 3);
         return Component(static_cast<const Derived&>(*this), 2);
       }

--- a/src/Rodin/Variational/H1/H1Element.h
+++ b/src/Rodin/Variational/H1/H1Element.h
@@ -773,7 +773,13 @@ namespace Rodin::Variational
           ScalarType operator()(const T& v) const
           {
             static thread_local RangeType s_out;
-            s_out = v(H1Element<K, ScalarType>::getNodes(m_g)[m_local / m_vdim]);
+            const auto value = v(H1Element<K, ScalarType>::getNodes(m_g)[m_local / m_vdim]);
+            const Eigen::Index n = static_cast<Eigen::Index>(value.size());
+            s_out.resize(n);
+            for (Eigen::Index i = 0; i < n; i++)
+            {
+              s_out.coeffRef(i) = value(i);
+            }
             return s_out.coeff(m_local % m_vdim);
           }
 
@@ -1061,4 +1067,3 @@ namespace Rodin::Variational
 #include "H1Element.hpp"
 
 #endif
-

--- a/src/Rodin/Variational/H1/Jacobian.h
+++ b/src/Rodin/Variational/H1/Jacobian.h
@@ -92,7 +92,7 @@ namespace Rodin::Variational
 
       using Parent = JacobianBase<OperandType, Jacobian<OperandType>>;
 
-      using RangeType = Math::Matrix<Scalar>;
+      using RangeType = Math::SpatialMatrix<Scalar>;
 
       using ScalarType = typename FormLanguage::Traits<FESType>::ScalarType;
 

--- a/src/Rodin/Variational/H1/QuadratureRule.h
+++ b/src/Rodin/Variational/H1/QuadratureRule.h
@@ -9,6 +9,7 @@
 
 #include "H1.h"
 #include "H1Element.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Variational/H1/QuadratureRule.h
+++ b/src/Rodin/Variational/H1/QuadratureRule.h
@@ -143,7 +143,7 @@ namespace Rodin::Variational
             for (size_t local = 0; local < nte; ++local)
               m_vec(local) += wdet * tab.getBasis(qp, local);
           }
-          else if constexpr (std::is_same_v<IntegrandRangeType, Math::Vector<ScalarType>>)
+          else if constexpr (FormLanguage::IsVectorRange<IntegrandRangeType>::value)
           {
             const size_t vdim = fes.getVectorDimension();
             assert(nte == scalarFE.getCount() * vdim);
@@ -158,7 +158,7 @@ namespace Rodin::Variational
           {
             static_assert(
               std::is_same_v<IntegrandRangeType, ScalarType>
-              || std::is_same_v<IntegrandRangeType, Math::Vector<ScalarType>>,
+              || FormLanguage::IsVectorRange<IntegrandRangeType>::value,
               "Unsupported H1 Integral(v) range type. Expected scalar or vector-valued shape function.");
           }
         }
@@ -352,7 +352,7 @@ namespace Rodin::Variational
             for (size_t local = 0; local < nte; ++local)
               m_vec(local) += wdet * fval * tab.getBasis(qp, local);
           }
-          else if constexpr (std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>)
+          else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
           {
             const size_t vdim = fes.getVectorDimension();
             assert(nte == scalarFE.getCount() * vdim);
@@ -368,7 +368,7 @@ namespace Rodin::Variational
           {
             static_assert(
               std::is_same_v<RHSRangeType, ScalarType>
-              || std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+              || FormLanguage::IsVectorRange<RHSRangeType>::value,
               "Unsupported H1 Integral(f,v) RHS range type. Expected scalar or vector-valued shape function.");
           }
         }
@@ -858,7 +858,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
             coeff.getValue(m_cmv, p);
             for (size_t ib = 0; ib < scalarCountTe; ++ib)
@@ -1191,7 +1191,7 @@ namespace Rodin::Variational
                 row[a] += wdet * csv * Math::dot(gb, Gtr[a]);
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
             coeff.getValue(m_cmv, p);
             for (size_t b = 0; b < nte; ++b)
@@ -2349,7 +2349,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
             coeff.getValue(m_cmv, p);
 

--- a/src/Rodin/Variational/H1/QuadratureRule.h
+++ b/src/Rodin/Variational/H1/QuadratureRule.h
@@ -362,7 +362,7 @@ namespace Rodin::Variational
             {
               const size_t scalarLocal = local / vdim;
               const size_t comp = local % vdim;
-              m_vec(local) += wdet * fval.coeff(comp) * tab.getBasis(qp, scalarLocal);
+              m_vec(local) += wdet * fval(comp) * tab.getBasis(qp, scalarLocal);
             }
           }
           else

--- a/src/Rodin/Variational/H1/QuadratureRule.h
+++ b/src/Rodin/Variational/H1/QuadratureRule.h
@@ -144,7 +144,7 @@ namespace Rodin::Variational
             for (size_t local = 0; local < nte; ++local)
               m_vec(local) += wdet * tab.getBasis(qp, local);
           }
-          else if constexpr (FormLanguage::IsVectorRange<IntegrandRangeType>::value)
+          else if constexpr (FormLanguage::IsVectorRange<IntegrandRangeType>::Value)
           {
             const size_t vdim = fes.getVectorDimension();
             assert(nte == scalarFE.getCount() * vdim);
@@ -159,7 +159,7 @@ namespace Rodin::Variational
           {
             static_assert(
               std::is_same_v<IntegrandRangeType, ScalarType>
-              || FormLanguage::IsVectorRange<IntegrandRangeType>::value,
+              || FormLanguage::IsVectorRange<IntegrandRangeType>::Value,
               "Unsupported H1 Integral(v) range type. Expected scalar or vector-valued shape function.");
           }
         }
@@ -353,7 +353,7 @@ namespace Rodin::Variational
             for (size_t local = 0; local < nte; ++local)
               m_vec(local) += wdet * fval * tab.getBasis(qp, local);
           }
-          else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
+          else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::Value)
           {
             const size_t vdim = fes.getVectorDimension();
             assert(nte == scalarFE.getCount() * vdim);
@@ -369,7 +369,7 @@ namespace Rodin::Variational
           {
             static_assert(
               std::is_same_v<RHSRangeType, ScalarType>
-              || FormLanguage::IsVectorRange<RHSRangeType>::value,
+              || FormLanguage::IsVectorRange<RHSRangeType>::Value,
               "Unsupported H1 Integral(f,v) RHS range type. Expected scalar or vector-valued shape function.");
           }
         }
@@ -859,7 +859,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
             coeff.getValue(m_cmv, p);
             for (size_t ib = 0; ib < scalarCountTe; ++ib)
@@ -1192,7 +1192,7 @@ namespace Rodin::Variational
                 row[a] += wdet * csv * Math::dot(gb, Gtr[a]);
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
             coeff.getValue(m_cmv, p);
             for (size_t b = 0; b < nte; ++b)
@@ -2350,7 +2350,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
             coeff.getValue(m_cmv, p);
 

--- a/src/Rodin/Variational/H1/ShapeFunction.h
+++ b/src/Rodin/Variational/H1/ShapeFunction.h
@@ -184,7 +184,7 @@ namespace Rodin::Variational
           FESType,
           SpaceType>;
 
-      static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
 
       struct Cache
       {

--- a/src/Rodin/Variational/H1/ShapeFunction.h
+++ b/src/Rodin/Variational/H1/ShapeFunction.h
@@ -7,6 +7,7 @@
 #include "Rodin/Variational/H1/ForwardDecls.h"
 #include "Rodin/Variational/ShapeFunction.h"
 #include "Rodin/Variational/IntegrationPoint.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Variational/H1/ShapeFunction.h
+++ b/src/Rodin/Variational/H1/ShapeFunction.h
@@ -183,7 +183,7 @@ namespace Rodin::Variational
           FESType,
           SpaceType>;
 
-      static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+      static_assert(FormLanguage::IsVectorRange<RangeType>::value);
 
       struct Cache
       {

--- a/src/Rodin/Variational/Jacobian.h
+++ b/src/Rodin/Variational/Jacobian.h
@@ -154,10 +154,8 @@ namespace Rodin::Variational
        * @f$ J_{ij}(p) = \frac{\partial u_i}{\partial x_j}(p) @f$
        * Handles mesh inclusion and submesh restrictions automatically.
        */
-      decltype(auto) getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static thread_local RangeType s_res;
-
         const auto& polytope = p.getPolytope();
         const auto& polytopeMesh = polytope.getMesh();
         const auto& gf = getOperand();
@@ -183,9 +181,7 @@ namespace Rodin::Variational
         {
           assert(false);
         }
-
-        s_res = res.getData().topLeftCorner(res.rows(), res.cols());
-        return s_res;
+        return res;
       }
 
       /**

--- a/src/Rodin/Variational/Jacobian.h
+++ b/src/Rodin/Variational/Jacobian.h
@@ -198,12 +198,6 @@ namespace Rodin::Variational
         return m_u.get();
       }
 
-      constexpr
-      void interpolate(RangeType& out, const Geometry::Point& p) const
-      {
-        this->interpolate(static_cast<SpatialMatrixType&>(out), p);
-      }
-
       /**
        * @brief Interpolates the Jacobian at a point (to be overridden in derived class).
        * @param[out] out Output matrix for Jacobian result

--- a/src/Rodin/Variational/Jacobian.h
+++ b/src/Rodin/Variational/Jacobian.h
@@ -43,6 +43,7 @@
 #define RODIN_VARIATIONAL_JACOBIAN_H
 
 #include "ForwardDecls.h"
+#include "Rodin/Math/SpatialMatrix.h"
 #include "MatrixFunction.h"
 
 namespace Rodin::Variational
@@ -80,7 +81,7 @@ namespace Rodin::Variational
 
       using ScalarType = typename FormLanguage::Traits<FESType>::ScalarType;
 
-      using RangeType = Math::Matrix<ScalarType>;
+      using RangeType = Math::SpatialMatrix<ScalarType>;
 
       using SpatialMatrixType = Math::SpatialMatrix<ScalarType>;
 
@@ -200,9 +201,7 @@ namespace Rodin::Variational
       constexpr
       void interpolate(RangeType& out, const Geometry::Point& p) const
       {
-        SpatialMatrixType res;
-        this->interpolate(res, p);
-        out = res.getData().topLeftCorner(res.rows(), res.cols());
+        this->interpolate(static_cast<SpatialMatrixType&>(out), p);
       }
 
       /**

--- a/src/Rodin/Variational/Jump.h
+++ b/src/Rodin/Variational/Jump.h
@@ -147,7 +147,9 @@ namespace Rodin::Variational
         it2->getTransformation().inverse(rc2, pc);
         const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
         const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
-        return this->object(getOperand().getValue(p1)) - this->object(getOperand().getValue(p2));
+        const auto v1 = getOperand().getValue(p1);
+        const auto v2 = getOperand().getValue(p2);
+        return v1 - v2;
       }
 
       constexpr
@@ -314,9 +316,9 @@ namespace Rodin::Variational
         const IntegrationPoint ip1(p1, m_ip->getQuadratureFormula(), m_ip->getIndex());
         const IntegrationPoint ip2(p2, m_ip->getQuadratureFormula(), m_ip->getIndex());
         m_operand->setIntegrationPoint(ip1);
-        const auto& val1 = this->object(m_operand->getBasis(local));
+        const auto val1 = m_operand->getBasis(local);
         m_operand->setIntegrationPoint(ip2);
-        const auto& val2 = this->object(m_operand->getBasis(local));
+        const auto val2 = m_operand->getBasis(local);
         return val1 - val2;
       }
 

--- a/src/Rodin/Variational/Jump.h
+++ b/src/Rodin/Variational/Jump.h
@@ -130,9 +130,6 @@ namespace Rodin::Variational
        */
       auto getValue(const Geometry::Point& p) const
       {
-        static thread_local Math::SpatialPoint s_rc1;
-        static thread_local Math::SpatialPoint s_rc2;
-
         assert(p.getPolytope().isFace());
         const auto& face = p.getPolytope();
         const size_t d = face.getDimension();
@@ -144,10 +141,12 @@ namespace Rodin::Variational
         const auto it1 = mesh.getPolytope(d + 1, idx1);
         const auto it2 = mesh.getPolytope(d + 1, idx2);
         const auto& pc = p.getPhysicalCoordinates();
-        it1->getTransformation().inverse(s_rc1, pc);
-        it2->getTransformation().inverse(s_rc2, pc);
-        const Geometry::Point p1(std::cref(*it1), std::cref(s_rc1), pc);
-        const Geometry::Point p2(std::cref(*it2), std::cref(s_rc2), pc);
+        Math::SpatialPoint rc1;
+        Math::SpatialPoint rc2;
+        it1->getTransformation().inverse(rc1, pc);
+        it2->getTransformation().inverse(rc2, pc);
+        const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
+        const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
         return this->object(getOperand().getValue(p1)) - this->object(getOperand().getValue(p2));
       }
 
@@ -293,9 +292,6 @@ namespace Rodin::Variational
        */
       auto getBasis(size_t local) const
       {
-        static thread_local Math::SpatialPoint s_rc1;
-        static thread_local Math::SpatialPoint s_rc2;
-
         assert(m_ip);
         const auto& p = m_ip->getPoint();
         assert(p.getPolytope().isFace());
@@ -309,10 +305,12 @@ namespace Rodin::Variational
         const auto it1 = mesh.getPolytope(d + 1, idx1);
         const auto it2 = mesh.getPolytope(d + 1, idx2);
         const auto& pc = p.getPhysicalCoordinates();
-        it1->getTransformation().inverse(s_rc1, pc);
-        it2->getTransformation().inverse(s_rc2, pc);
-        const Geometry::Point p1(std::cref(*it1), std::cref(s_rc1), pc);
-        const Geometry::Point p2(std::cref(*it2), std::cref(s_rc2), pc);
+        Math::SpatialPoint rc1;
+        Math::SpatialPoint rc2;
+        it1->getTransformation().inverse(rc1, pc);
+        it2->getTransformation().inverse(rc2, pc);
+        const Geometry::Point p1(std::cref(*it1), std::cref(rc1), pc);
+        const Geometry::Point p2(std::cref(*it2), std::cref(rc2), pc);
         const IntegrationPoint ip1(p1, m_ip->getQuadratureFormula(), m_ip->getIndex());
         const IntegrationPoint ip2(p2, m_ip->getQuadratureFormula(), m_ip->getIndex());
         m_operand->setIntegrationPoint(ip1);

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -78,25 +78,25 @@ namespace Rodin::FormLanguage
         // Else
         std::conditional_t<
           // If
-          std::is_same_v<LHSRangeType, Math::Vector<ScalarType>>,
+          FormLanguage::IsVectorRange<LHSRangeType>::value,
           // Then <--------------------------------------------- LHS is Vector
           std::conditional_t<
             // If
             std::is_same_v<RHSRangeType, ScalarType>,
             // Then
-            Math::Vector<ScalarType>,
+            Math::SpatialVector<ScalarType>,
             // Else
             std::conditional_t<
               // If
-              std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+              FormLanguage::IsVectorRange<RHSRangeType>::value,
               // Then
               void,
               // Else
               std::conditional_t<
                 // If
-                std::is_same_v<RHSRangeType, Math::Matrix<ScalarType>>,
+                FormLanguage::IsMatrixRange<RHSRangeType>::value,
                 // Then
-                Math::Matrix<ScalarType>,
+                Math::SpatialMatrix<ScalarType>,
                 // Else
                 void
               >
@@ -106,17 +106,17 @@ namespace Rodin::FormLanguage
           // Else
           std::conditional_t<
             // If
-            std::is_same_v<LHSRangeType, Math::Matrix<ScalarType>>,
+            FormLanguage::IsMatrixRange<LHSRangeType>::value,
             // Then <------------------------------------------- LHS is Matrix
             std::conditional_t<
               std::is_same_v<RHSRangeType, ScalarType>,
-              Math::Matrix<ScalarType>,
+              Math::SpatialMatrix<ScalarType>,
               std::conditional_t<
-                std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
-                Math::Vector<ScalarType>,
+                FormLanguage::IsVectorRange<RHSRangeType>::value,
+                Math::SpatialVector<ScalarType>,
                 std::conditional_t<
-                  std::is_same_v<RHSRangeType, Math::Matrix<ScalarType>>,
-                    Math::Matrix<ScalarType>,
+                  FormLanguage::IsMatrixRange<RHSRangeType>::value,
+                    Math::SpatialMatrix<ScalarType>,
                     void
                   >
                 >

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -78,7 +78,7 @@ namespace Rodin::FormLanguage
         // Else
         std::conditional_t<
           // If
-          FormLanguage::IsVectorRange<LHSRangeType>::value,
+          FormLanguage::IsVectorRange<LHSRangeType>::Value,
           // Then <--------------------------------------------- LHS is Vector
           std::conditional_t<
             // If
@@ -88,13 +88,13 @@ namespace Rodin::FormLanguage
             // Else
             std::conditional_t<
               // If
-              FormLanguage::IsVectorRange<RHSRangeType>::value,
+              FormLanguage::IsVectorRange<RHSRangeType>::Value,
               // Then
               void,
               // Else
               std::conditional_t<
                 // If
-                FormLanguage::IsMatrixRange<RHSRangeType>::value,
+                FormLanguage::IsMatrixRange<RHSRangeType>::Value,
                 // Then
                 Math::SpatialMatrix<ScalarType>,
                 // Else
@@ -106,16 +106,16 @@ namespace Rodin::FormLanguage
           // Else
           std::conditional_t<
             // If
-            FormLanguage::IsMatrixRange<LHSRangeType>::value,
+            FormLanguage::IsMatrixRange<LHSRangeType>::Value,
             // Then <------------------------------------------- LHS is Matrix
             std::conditional_t<
               std::is_same_v<RHSRangeType, ScalarType>,
               Math::SpatialMatrix<ScalarType>,
               std::conditional_t<
-                FormLanguage::IsVectorRange<RHSRangeType>::value,
+                FormLanguage::IsVectorRange<RHSRangeType>::Value,
                 Math::SpatialVector<ScalarType>,
                 std::conditional_t<
-                  FormLanguage::IsMatrixRange<RHSRangeType>::value,
+                  FormLanguage::IsMatrixRange<RHSRangeType>::Value,
                     Math::SpatialMatrix<ScalarType>,
                     void
                   >

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -217,7 +217,9 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->object(this->getLHS().getValue(p)) * this->object(this->getRHS().getValue(p));
+        const auto lhs = this->getLHS().getValue(p);
+        const auto rhs = this->getRHS().getValue(p);
+        return lhs * rhs;
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
@@ -423,7 +425,9 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& p = this->getIntegrationPoint();
-        return this->object(getLHS().getValue(p.getPoint())) * this->object(getRHS().getBasis(local));
+        const auto lhs = getLHS().getValue(p.getPoint());
+        const auto rhs = getRHS().getBasis(local);
+        return lhs * rhs;
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
@@ -573,7 +577,9 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& p = this->getIntegrationPoint();
-        return this->object(this->getLHS().getBasis(local)) * this->object(this->getRHS().getValue(p.getPoint()));
+        const auto lhs = this->getLHS().getBasis(local);
+        const auto rhs = this->getRHS().getValue(p.getPoint());
+        return lhs * rhs;
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const

--- a/src/Rodin/Variational/P0/Grad.h
+++ b/src/Rodin/Variational/P0/Grad.h
@@ -93,14 +93,6 @@ namespace Rodin::Variational
         : Parent(std::move(other))
       {}
 
-      void interpolate(Math::Vector<Real>& out, const Geometry::Point& p) const
-      {
-        Math::SpatialVector<Real> tmp;
-        interpolate(tmp, p);
-
-        out = tmp.getData().head(tmp.size());
-      }
-
       void interpolate(Math::SpatialVector<Real>& out, const Geometry::Point& p) const
       {
         const auto& polytope = p.getPolytope();

--- a/src/Rodin/Variational/P0/P0Element.h
+++ b/src/Rodin/Variational/P0/P0Element.h
@@ -327,7 +327,13 @@ namespace Rodin::Variational
           {
             static thread_local RangeType s_out;
             const Geometry::Polytope::Traits ts(m_g);
-            s_out = v(ts.getCentroid());
+            const auto value = v(ts.getCentroid());
+            const Eigen::Index n = static_cast<Eigen::Index>(value.size());
+            s_out.resize(n);
+            for (Eigen::Index i = 0; i < n; i++)
+            {
+              s_out.coeffRef(i) = value(i);
+            }
             return s_out.coeff(m_local % m_vdim);
           }
 

--- a/src/Rodin/Variational/P0/ShapeFunction.h
+++ b/src/Rodin/Variational/P0/ShapeFunction.h
@@ -88,7 +88,7 @@ namespace Rodin::Variational
         }
         else
         {
-          static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+          static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
           return P0Element<RangeType>(polytope.getGeometry(), this->getFiniteElementSpace().getVectorDimension()).getCount();
         }
       }
@@ -132,7 +132,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
 
             m_cache.basis.resize(vdim);
             for (size_t c = 0; c < vdim; ++c)

--- a/src/Rodin/Variational/P0/ShapeFunction.h
+++ b/src/Rodin/Variational/P0/ShapeFunction.h
@@ -87,7 +87,7 @@ namespace Rodin::Variational
         }
         else
         {
-          static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+          static_assert(FormLanguage::IsVectorRange<RangeType>::value);
           return P0Element<RangeType>(polytope.getGeometry(), this->getFiniteElementSpace().getVectorDimension()).getCount();
         }
       }
@@ -131,7 +131,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
 
             m_cache.basis.resize(vdim);
             for (size_t c = 0; c < vdim; ++c)

--- a/src/Rodin/Variational/P0/ShapeFunction.h
+++ b/src/Rodin/Variational/P0/ShapeFunction.h
@@ -7,6 +7,7 @@
 #include "Rodin/Variational/P0/ForwardDecls.h"
 #include "Rodin/Variational/ShapeFunction.h"
 #include "Rodin/Variational/IntegrationPoint.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Variational/P0g/P0gElement.h
+++ b/src/Rodin/Variational/P0g/P0gElement.h
@@ -227,7 +227,13 @@ namespace Rodin::Variational
       {
         static thread_local RangeType s_out;
         const auto& xi = P0gElement<ScalarType>(m_g).getNode(m_local / m_vdim);
-        s_out = v(xi);
+        const auto value = v(xi);
+        const Eigen::Index n = static_cast<Eigen::Index>(value.size());
+        s_out.resize(n);
+        for (Eigen::Index i = 0; i < n; i++)
+        {
+          s_out.coeffRef(i) = value(i);
+        }
         return s_out.coeff(m_local % m_vdim);
       }
 

--- a/src/Rodin/Variational/P0g/ShapeFunction.h
+++ b/src/Rodin/Variational/P0g/ShapeFunction.h
@@ -32,7 +32,7 @@ namespace Rodin::Variational
           SpaceType>;
 
       static constexpr bool IsScalarRange = std::is_same_v<RangeType, ScalarType>;
-      static constexpr bool IsVectorRange = std::is_same_v<RangeType, Math::Vector<ScalarType>>;
+      static constexpr bool IsVectorRange = FormLanguage::IsVectorRange<RangeType>::value;
 
       static_assert(IsScalarRange || IsVectorRange);
 

--- a/src/Rodin/Variational/P0g/ShapeFunction.h
+++ b/src/Rodin/Variational/P0g/ShapeFunction.h
@@ -33,7 +33,7 @@ namespace Rodin::Variational
           SpaceType>;
 
       static constexpr bool IsScalarRange = std::is_same_v<RangeType, ScalarType>;
-      static constexpr bool IsVectorRange = FormLanguage::IsVectorRange<RangeType>::value;
+      static constexpr bool IsVectorRange = FormLanguage::IsVectorRange<RangeType>::Value;
 
       static_assert(IsScalarRange || IsVectorRange);
 

--- a/src/Rodin/Variational/P0g/ShapeFunction.h
+++ b/src/Rodin/Variational/P0g/ShapeFunction.h
@@ -8,6 +8,7 @@
 #include "Rodin/Variational/P0g/ForwardDecls.h"
 #include "Rodin/Variational/ShapeFunction.h"
 #include "Rodin/Variational/IntegrationPoint.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Variational/P1/Grad.h
+++ b/src/Rodin/Variational/P1/Grad.h
@@ -47,7 +47,7 @@ namespace Rodin::Variational
     public:
       using FESType = P1<Scalar, Mesh>;
 
-      using RangeType = Math::Vector<Scalar>;
+      using RangeType = Math::SpatialVector<Scalar>;
 
       using ScalarType = typename FormLanguage::Traits<RangeType>::ScalarType;
 
@@ -195,7 +195,7 @@ namespace Rodin::Variational
 
       using SpatialVectorType = Math::SpatialVector<ScalarType>;
 
-      using RangeType = Math::Vector<ScalarType>;
+      using RangeType = Math::SpatialVector<ScalarType>;
 
       using OperandType = ShapeFunction<NestedDerived, FESType, Space>;
 

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -33,6 +33,7 @@
 #include "Rodin/Variational/Jacobian.h"
 #include "Rodin/Variational/Exceptions/UndeterminedTraceDomainException.h"
 #include "Rodin/Variational/Mult.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::FormLanguage
 {

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -248,7 +248,7 @@ namespace Rodin::Variational
   class Jacobian<ShapeFunction<ShapeFunctionDerived, P1<Range, Mesh>, Space>> final
     : public ShapeFunctionBase<Jacobian<ShapeFunction<ShapeFunctionDerived, P1<Range, Mesh>, Space>>>
   {
-    static_assert(FormLanguage::IsVectorRange<Range>::value,
+    static_assert(FormLanguage::IsVectorRange<Range>::Value,
                   "Jacobian<P1> specialization is intended for vector-valued P1.");
 
     public:

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -87,7 +87,7 @@ namespace Rodin::Variational
         Jacobian<GridFunction<P1<Math::Vector<Scalar>, Mesh>, Data>>>
   {
     public:
-      using RangeType = Math::Matrix<Scalar>;
+      using RangeType = Math::SpatialMatrix<Scalar>;
 
       using FESType = P1<Math::Vector<Scalar>, Mesh>;
 
@@ -247,7 +247,7 @@ namespace Rodin::Variational
   class Jacobian<ShapeFunction<ShapeFunctionDerived, P1<Range, Mesh>, Space>> final
     : public ShapeFunctionBase<Jacobian<ShapeFunction<ShapeFunctionDerived, P1<Range, Mesh>, Space>>>
   {
-    static_assert(std::is_same_v<Range, Math::Vector<typename FormLanguage::Traits<Range>::ScalarType>>,
+    static_assert(FormLanguage::IsVectorRange<Range>::value,
                   "Jacobian<P1> specialization is intended for vector-valued P1.");
 
     public:
@@ -256,7 +256,7 @@ namespace Rodin::Variational
 
       using ScalarType = typename FormLanguage::Traits<FESType>::ScalarType;
 
-      using RangeType = Math::Matrix<ScalarType>;
+      using RangeType = Math::SpatialMatrix<ScalarType>;
 
       using SpatialMatrixType = Math::SpatialMatrix<ScalarType>;
 

--- a/src/Rodin/Variational/P1/P1Element.h
+++ b/src/Rodin/Variational/P1/P1Element.h
@@ -832,7 +832,13 @@ namespace Rodin::Variational
           {
             static thread_local RangeType s_out;
             const Geometry::Polytope::Traits ts(m_g);
-            s_out = v(ts.getVertex(m_local / m_vdim));
+            const auto value = v(ts.getVertex(m_local / m_vdim));
+            const Eigen::Index n = static_cast<Eigen::Index>(value.size());
+            s_out.resize(n);
+            for (Eigen::Index i = 0; i < n; i++)
+            {
+              s_out.coeffRef(i) = value(i);
+            }
             return s_out.coeff(m_local % m_vdim);
           }
 

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -38,6 +38,7 @@
 #include "Rodin/QF/PolytopeQuadratureFormula.h"
 
 #include "P1.h"
+#include "Rodin/Math/Traits.h"
 
 
 namespace Rodin::Variational

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -375,7 +375,7 @@ namespace Rodin::Variational
               m_vec(local) += wdet * fval * fe.getBasis(local)(rc);
           }
         }
-        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
+        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::Value)
         {
           const size_t vdim = fes.getVectorDimension();
 
@@ -398,7 +398,7 @@ namespace Rodin::Variational
         {
           static_assert(
             std::is_same_v<RHSRangeType, ScalarType>
-            || FormLanguage::IsVectorRange<RHSRangeType>::value,
+            || FormLanguage::IsVectorRange<RHSRangeType>::Value,
             "Unsupported P1 Integral(f.v) range type.");
         }
 
@@ -625,7 +625,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::value)
+          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::Value)
           {
             if (symmetric)
             {
@@ -926,10 +926,10 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
-            static_assert(FormLanguage::IsVectorRange<MultiplicandRangeType>::value);
-            static_assert(FormLanguage::IsVectorRange<RHSRangeType>::value);
+            static_assert(FormLanguage::IsVectorRange<MultiplicandRangeType>::Value);
+            static_assert(FormLanguage::IsVectorRange<RHSRangeType>::Value);
 
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -1479,7 +1479,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -1748,7 +1748,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::value)
+          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::Value)
           {
             for (size_t ib = 0; ib < nte; ++ib)
             {
@@ -2324,8 +2324,8 @@ namespace Rodin::Variational
       using Parent =
         LocalBilinearFormIntegratorBase<ScalarType>;
 
-      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::value);
-      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::Value);
+      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::Value);
 
       QuadratureRule(const IntegrandType& integrand)
         : Parent(integrand.getLHS().getLeaf(), integrand.getRHS().getLeaf()),
@@ -2629,8 +2629,8 @@ namespace Rodin::Variational
       using Parent =
         LocalBilinearFormIntegratorBase<ScalarType>;
 
-      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::value);
-      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::Value);
+      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::Value);
 
       QuadratureRule(const IntegrandType& integrand)
         : Parent(integrand.getLHS().getLeaf(), integrand.getRHS().getLeaf()),
@@ -2785,7 +2785,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::Value)
           {
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -3484,7 +3484,7 @@ namespace Rodin::Variational
             }
           }
         }
-        else if constexpr (FormLanguage::IsVectorRange<Range>::value)
+        else if constexpr (FormLanguage::IsVectorRange<Range>::Value)
         {
 
           if (trp == tep)

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -374,7 +374,7 @@ namespace Rodin::Variational
               m_vec(local) += wdet * fval * fe.getBasis(local)(rc);
           }
         }
-        else if constexpr (std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>)
+        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
         {
           const size_t vdim = fes.getVectorDimension();
 
@@ -397,7 +397,7 @@ namespace Rodin::Variational
         {
           static_assert(
             std::is_same_v<RHSRangeType, ScalarType>
-            || std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+            || FormLanguage::IsVectorRange<RHSRangeType>::value,
             "Unsupported P1 Integral(f.v) range type.");
         }
 
@@ -624,7 +624,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<LHSRangeType, Math::Vector<ScalarType>>)
+          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::value)
           {
             if (symmetric)
             {
@@ -925,10 +925,10 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
-            static_assert(std::is_same_v<MultiplicandRangeType, Math::Vector<ScalarType>>);
-            static_assert(std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>);
+            static_assert(FormLanguage::IsVectorRange<MultiplicandRangeType>::value);
+            static_assert(FormLanguage::IsVectorRange<RHSRangeType>::value);
 
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -1478,7 +1478,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -1747,7 +1747,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<LHSRangeType, Math::Vector<ScalarType>>)
+          else if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::value)
           {
             for (size_t ib = 0; ib < nte; ++ib)
             {
@@ -2323,8 +2323,8 @@ namespace Rodin::Variational
       using Parent =
         LocalBilinearFormIntegratorBase<ScalarType>;
 
-      static_assert(std::is_same_v<LHSOperandRangeType, Math::Vector<ScalarType>>);
-      static_assert(std::is_same_v<RHSOperandRangeType, Math::Vector<ScalarType>>);
+      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::value);
 
       QuadratureRule(const IntegrandType& integrand)
         : Parent(integrand.getLHS().getLeaf(), integrand.getRHS().getLeaf()),
@@ -2628,8 +2628,8 @@ namespace Rodin::Variational
       using Parent =
         LocalBilinearFormIntegratorBase<ScalarType>;
 
-      static_assert(std::is_same_v<LHSOperandRangeType, Math::Vector<ScalarType>>);
-      static_assert(std::is_same_v<RHSOperandRangeType, Math::Vector<ScalarType>>);
+      static_assert(FormLanguage::IsVectorRange<LHSOperandRangeType>::value);
+      static_assert(FormLanguage::IsVectorRange<RHSOperandRangeType>::value);
 
       QuadratureRule(const IntegrandType& integrand)
         : Parent(integrand.getLHS().getLeaf(), integrand.getRHS().getLeaf()),
@@ -2784,7 +2784,7 @@ namespace Rodin::Variational
               }
             }
           }
-          else if constexpr (std::is_same_v<CoefficientRangeType, Math::Matrix<ScalarType>>)
+          else if constexpr (FormLanguage::IsMatrixRange<CoefficientRangeType>::value)
           {
             static thread_local Math::Matrix<ScalarType> s_cmv;
             coeff.getValue(s_cmv, p);
@@ -3483,7 +3483,7 @@ namespace Rodin::Variational
             }
           }
         }
-        else if constexpr (std::is_same_v<Range, Math::Vector<ScalarType>>)
+        else if constexpr (FormLanguage::IsVectorRange<Range>::value)
         {
 
           if (trp == tep)

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -3080,7 +3080,7 @@ namespace Rodin::Variational
             for (size_t v = 0; v < nVertices; ++v)
             {
               const auto& bv = testfe.getBasis(v * vdim)(rc);
-              m_basis[v] = bv.coeff(0);
+              m_basis[v] = bv(0);
             }
           }
         }

--- a/src/Rodin/Variational/P1/ShapeFunction.h
+++ b/src/Rodin/Variational/P1/ShapeFunction.h
@@ -122,7 +122,7 @@ namespace Rodin::Variational
         }
         else
         {
-          static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+          static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
           return P1Element<RangeType>(polytope.getGeometry(), this->getFiniteElementSpace().getVectorDimension()).getCount();
         }
       }
@@ -179,7 +179,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
             const size_t ndof = nv * vdim;
             m_cache.basis.resize(ndof);
 
@@ -219,7 +219,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::Value);
 
             // Update only the one active component; others remain zero.
             for (size_t a = 0; a < nv; ++a)

--- a/src/Rodin/Variational/P1/ShapeFunction.h
+++ b/src/Rodin/Variational/P1/ShapeFunction.h
@@ -10,6 +10,7 @@
 #include "Rodin/Variational/P1/P1.h"
 #include "Rodin/Variational/ShapeFunction.h"
 #include "Rodin/Variational/IntegrationPoint.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::Variational
 {

--- a/src/Rodin/Variational/P1/ShapeFunction.h
+++ b/src/Rodin/Variational/P1/ShapeFunction.h
@@ -121,7 +121,7 @@ namespace Rodin::Variational
         }
         else
         {
-          static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+          static_assert(FormLanguage::IsVectorRange<RangeType>::value);
           return P1Element<RangeType>(polytope.getGeometry(), this->getFiniteElementSpace().getVectorDimension()).getCount();
         }
       }
@@ -178,7 +178,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
             const size_t ndof = nv * vdim;
             m_cache.basis.resize(ndof);
 
@@ -218,7 +218,7 @@ namespace Rodin::Variational
           }
           else
           {
-            static_assert(std::is_same_v<RangeType, Math::Vector<ScalarType>>);
+            static_assert(FormLanguage::IsVectorRange<RangeType>::value);
 
             // Update only the one active component; others remain zero.
             for (size_t a = 0; a < nv; ++a)

--- a/src/Rodin/Variational/Potential.h
+++ b/src/Rodin/Variational/Potential.h
@@ -93,7 +93,7 @@ namespace Rodin::FormLanguage
       // Else
       std::conditional_t<
         // If
-        FormLanguage::IsVectorRange<RHSRangeType>::value,
+        FormLanguage::IsVectorRange<RHSRangeType>::Value,
         // Then
         Math::Matrix<ScalarType>,
         // Else
@@ -137,7 +137,7 @@ namespace Rodin::FormLanguage
       // Else
       std::conditional_t<
         // If
-        FormLanguage::IsVectorRange<RHSRangeType>::value,
+        FormLanguage::IsVectorRange<RHSRangeType>::Value,
         // Then
         Math::Matrix<ScalarType>,
         // Else
@@ -184,7 +184,7 @@ namespace Rodin::Variational
         // Else
         std::conditional_t<
           // If
-          FormLanguage::IsVectorRange<RHSRangeType>::value,
+          FormLanguage::IsVectorRange<RHSRangeType>::Value,
           // Then
           Math::Matrix<ScalarType>,
           // Else
@@ -241,7 +241,7 @@ namespace Rodin::Variational
           }
           return res;
         }
-        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
+        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::Value)
         {
           Math::Vector<ScalarType> res;
           assert(false);
@@ -364,7 +364,7 @@ namespace Rodin::Variational
         // Else
         std::conditional_t<
           // If
-          FormLanguage::IsVectorRange<RHSRangeType>::value,
+          FormLanguage::IsVectorRange<RHSRangeType>::Value,
           // Then
           Math::Matrix<ScalarType>,
           // Else

--- a/src/Rodin/Variational/Potential.h
+++ b/src/Rodin/Variational/Potential.h
@@ -92,7 +92,7 @@ namespace Rodin::FormLanguage
       // Else
       std::conditional_t<
         // If
-        std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+        FormLanguage::IsVectorRange<RHSRangeType>::value,
         // Then
         Math::Matrix<ScalarType>,
         // Else
@@ -136,7 +136,7 @@ namespace Rodin::FormLanguage
       // Else
       std::conditional_t<
         // If
-        std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+        FormLanguage::IsVectorRange<RHSRangeType>::value,
         // Then
         Math::Matrix<ScalarType>,
         // Else
@@ -183,7 +183,7 @@ namespace Rodin::Variational
         // Else
         std::conditional_t<
           // If
-          std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+          FormLanguage::IsVectorRange<RHSRangeType>::value,
           // Then
           Math::Matrix<ScalarType>,
           // Else
@@ -240,7 +240,7 @@ namespace Rodin::Variational
           }
           return res;
         }
-        else if constexpr (std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>)
+        else if constexpr (FormLanguage::IsVectorRange<RHSRangeType>::value)
         {
           Math::Vector<ScalarType> res;
           assert(false);
@@ -363,7 +363,7 @@ namespace Rodin::Variational
         // Else
         std::conditional_t<
           // If
-          std::is_same_v<RHSRangeType, Math::Vector<ScalarType>>,
+          FormLanguage::IsVectorRange<RHSRangeType>::value,
           // Then
           Math::Matrix<ScalarType>,
           // Else

--- a/src/Rodin/Variational/Potential.h
+++ b/src/Rodin/Variational/Potential.h
@@ -57,6 +57,7 @@
 #include "ShapeFunction.h"
 #include "QuadratureRule.h"
 #include "LinearFormIntegrator.h"
+#include "Rodin/Math/Traits.h"
 
 namespace Rodin::FormLanguage
 {

--- a/src/Rodin/Variational/Sum.h
+++ b/src/Rodin/Variational/Sum.h
@@ -170,7 +170,9 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->object(this->getLHS().getValue(p)) + this->object(this->getRHS().getValue(p));
+        const auto lhs = this->getLHS().getValue(p);
+        const auto rhs = this->getRHS().getValue(p);
+        return lhs + rhs;
       }
 
       constexpr
@@ -373,7 +375,9 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        return this->object(getLHS().getBasis(local)) + this->object(getRHS().getBasis(local));
+        const auto lhs = getLHS().getBasis(local);
+        const auto rhs = getRHS().getBasis(local);
+        return lhs + rhs;
       }
 
       constexpr

--- a/src/Rodin/Variational/Traits.h
+++ b/src/Rodin/Variational/Traits.h
@@ -133,14 +133,22 @@ namespace Rodin::FormLanguage
   struct RangeOf<Eigen::Matrix<Scalar, Rows, 1, Options, MaxRows, MaxCols>>
   {
     using Type =
-      Math::Vector<Scalar>;
+      Math::SpatialVector<Scalar>;
   };
 
   template <class Scalar>
   struct RangeOf<Math::SpatialVector<Scalar>>
   {
     using Type =
-      Math::Vector<Scalar>;
+      Math::SpatialVector<Scalar>;
+  };
+
+
+  template <class Scalar>
+  struct RangeOf<Math::SpatialMatrix<Scalar>>
+  {
+    using Type =
+      Math::SpatialMatrix<Scalar>;
   };
 
   /**
@@ -156,7 +164,7 @@ namespace Rodin::FormLanguage
   struct RangeOf<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>>
   {
     using Type =
-      Math::Matrix<Scalar>;
+      Math::SpatialMatrix<Scalar>;
   };
 
   /**
@@ -170,10 +178,10 @@ namespace Rodin::FormLanguage
   {
     using Type =
       std::conditional_t<
-        MatrixXpr::IsVectorAtCompileTime, Math::Vector<typename MatrixXpr::Scalar>,
+        MatrixXpr::IsVectorAtCompileTime, Math::SpatialVector<typename MatrixXpr::Scalar>,
         std::conditional_t<
-          MatrixXpr::ColsAtCompileTime == 1, Math::Vector<typename MatrixXpr::Scalar>,
-          Math::Matrix<typename MatrixXpr::Scalar>
+          MatrixXpr::ColsAtCompileTime == 1, Math::SpatialVector<typename MatrixXpr::Scalar>,
+          Math::SpatialMatrix<typename MatrixXpr::Scalar>
         >
       >;
   };

--- a/src/Rodin/Variational/Transpose.h
+++ b/src/Rodin/Variational/Transpose.h
@@ -87,7 +87,8 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return this->object(getOperand().getValue(p)).transpose();
+        const auto v = getOperand().getValue(p);
+        return v.transpose();
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
@@ -209,7 +210,8 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        return this->object(getOperand().getBasis(local)).transpose();
+        const auto v = getOperand().getBasis(local);
+        return v.transpose();
       }
 
       /**

--- a/src/Rodin/Variational/UnaryMinus.h
+++ b/src/Rodin/Variational/UnaryMinus.h
@@ -99,7 +99,8 @@ namespace Rodin::Variational
       constexpr
       auto getValue(const Geometry::Point& p) const
       {
-        return -this->object(getOperand().getValue(p));
+        const auto v = getOperand().getValue(p);
+        return -v;
       }
 
       constexpr
@@ -233,7 +234,8 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        return -this->object(getOperand().getBasis(local));
+        const auto v = getOperand().getBasis(local);
+        return -v;
       }
 
       const FES& getFiniteElementSpace() const

--- a/src/Rodin/Variational/VectorFunction.h
+++ b/src/Rodin/Variational/VectorFunction.h
@@ -22,6 +22,7 @@
 #include "ForwardDecls.h"
 
 #include "Rodin/Alert.h"
+#include "Rodin/Math/SpatialVector.h"
 #include "Rodin/Utility/ForConstexpr.h"
 
 #include "Function.h"
@@ -190,6 +191,7 @@ namespace Rodin::Variational
       using ScalarType = Scalar;
 
       using VectorType = Math::Vector<ScalarType>;
+      using SpatialVectorType = Math::SpatialVector<ScalarType>;
 
       using Parent = VectorFunctionBase<ScalarType, VectorFunction<VectorType>>;
 
@@ -214,9 +216,9 @@ namespace Rodin::Variational
           m_vector(std::move(other.m_vector))
       {}
 
-      const VectorType& getValue(const Geometry::Point&) const
+      SpatialVectorType getValue(const Geometry::Point&) const
       {
-        return m_vector.get();
+        return SpatialVectorType(m_vector.get());
       }
 
       constexpr
@@ -277,6 +279,7 @@ namespace Rodin::Variational
       using ScalarType = Real;
 
       using VectorType = Math::Vector<ScalarType>;
+      using SpatialVectorType = Math::SpatialVector<ScalarType>;
 
       using FixedSizeVectorType = Math::FixedSizeVector<ScalarType, 1 + sizeof...(Values)>;
 
@@ -302,15 +305,17 @@ namespace Rodin::Variational
           m_fs(std::move(other.m_fs))
       {}
 
-      decltype(auto) getValue(const Geometry::Point& p) const
+      SpatialVectorType getValue(const Geometry::Point& p) const
       {
-        static thread_local Math::FixedSizeVector<ScalarType, 1 + sizeof...(Values)> s_res;
+        static_assert(1 + sizeof...(Values) <= Math::SpatialVector<ScalarType>::MaxSize,
+          "Variadic VectorFunction exceeds spatial vector capacity.");
+        SpatialVectorType res(1 + sizeof...(Values));
         Utility::ForIndex<1 + sizeof...(Values)>(
           [&](auto i)
           {
-            s_res.coeffRef(static_cast<Eigen::Index>(i)) = std::get<i>(m_fs).getValue(p);
+            res[static_cast<std::uint8_t>(i)] = std::get<i>(m_fs).getValue(p);
           });
-        return s_res;
+        return res;
       }
 
       constexpr

--- a/src/Rodin/Variational/VectorFunction.h
+++ b/src/Rodin/Variational/VectorFunction.h
@@ -278,10 +278,16 @@ namespace Rodin::Variational
     public:
       using ScalarType = Real;
 
+      static constexpr size_t Dimension = 1 + sizeof...(Values);
       using VectorType = Math::Vector<ScalarType>;
       using SpatialVectorType = Math::SpatialVector<ScalarType>;
+      using RangeType =
+        std::conditional_t<
+          Dimension <= Math::SpatialVector<ScalarType>::MaxSize,
+          SpatialVectorType,
+          VectorType>;
 
-      using FixedSizeVectorType = Math::FixedSizeVector<ScalarType, 1 + sizeof...(Values)>;
+      using FixedSizeVectorType = Math::FixedSizeVector<ScalarType, Dimension>;
 
       using Parent = VectorFunctionBase<ScalarType, VectorFunction<V, Values...>>;
       /**
@@ -305,23 +311,34 @@ namespace Rodin::Variational
           m_fs(std::move(other.m_fs))
       {}
 
-      SpatialVectorType getValue(const Geometry::Point& p) const
+      RangeType getValue(const Geometry::Point& p) const
       {
-        static_assert(1 + sizeof...(Values) <= Math::SpatialVector<ScalarType>::MaxSize,
-          "Variadic VectorFunction exceeds spatial vector capacity.");
-        SpatialVectorType res(1 + sizeof...(Values));
-        Utility::ForIndex<1 + sizeof...(Values)>(
-          [&](auto i)
-          {
-            res[static_cast<std::uint8_t>(i)] = std::get<i>(m_fs).getValue(p);
-          });
+        RangeType res;
+        if constexpr (Dimension <= Math::SpatialVector<ScalarType>::MaxSize)
+        {
+          res.resize(Dimension);
+          Utility::ForIndex<Dimension>(
+            [&](auto i)
+            {
+              res[static_cast<std::uint8_t>(i)] = std::get<i>(m_fs).getValue(p);
+            });
+        }
+        else
+        {
+          res.resize(Dimension);
+          Utility::ForIndex<Dimension>(
+            [&](auto i)
+            {
+              res.coeffRef(i) = std::get<i>(m_fs).getValue(p);
+            });
+        }
         return res;
       }
 
       constexpr
       size_t getDimension() const
       {
-        return 1 + sizeof...(Values);
+        return Dimension;
       }
 
       template <class ... Args>


### PR DESCRIPTION
### Motivation
- Centralize and generalize range classification so variational code treats spatial/Eigen-backed vector and matrix ranges uniformly. 
- Replace concrete `Math::Vector`/`Math::Matrix` range aliases in FormLanguage/Variational expression paths with the spatial variants that carry bounded-dimension semantics.
- Ensure compile-time branching (`if constexpr` / `static_assert`) and range-closure logic work for both spatial and Eigen types.

### Description
- Added a compile-time range classification system in `FormLanguage` by introducing `RangeKind`, `IsVectorRange`, `IsMatrixRange`, and `RangeKindOfV` in `src/Rodin/Math/Traits.h` to detect Boolean/Integer/Real/Vector/Matrix categories (accepting both `Math::Spatial*` and Eigen-backed types). 
- Reworked gradient and Jacobian traits and implementations to use `Math::SpatialVector` / `Math::SpatialMatrix` as their `RangeType` and to interpolate directly into those spatial types (`src/Rodin/Variational/Grad.h`, `src/Rodin/Variational/Jacobian.h`, `src/Rodin/Variational/P1/Grad.h`, `src/Rodin/Variational/P1/Jacobian.h`, `src/Rodin/Variational/H1/Jacobian.h`, `src/Rodin/Variational/P0/Grad.h`).
- Audited and updated range-based compile-time checks and `if constexpr` branches across core variational code to use `FormLanguage::IsVectorRange<...>::value` and `FormLanguage::IsMatrixRange<...>::value` instead of strict `std::is_same_v<..., Math::Vector/...Matrix>` checks (examples: `Mult.h`, `P1/QuadratureRule.h`, `H1/QuadratureRule.h`, `P1/ShapeFunction.h`, `P0/ShapeFunction.h`, `GridFunction.h`, `Component.h`, `FaceNormal.h`, `BoundaryNormal.h`, `Potential.h`).
- Updated multiplication/result-range deduction in `src/Rodin/Variational/Mult.h` so range closure yields `Math::SpatialVector`/`Math::SpatialMatrix` where appropriate and branches on the new predicates.
- Minor API adjustments to interpolation paths to avoid unnecessary temporary conversions by directly operating on spatial types and extracting Eigen views only where needed (e.g., `topLeftCorner`, `head`).
- Changes span multiple files (20 files updated) to keep the transformation consistent throughout variational/form-language paths.

### Testing
- Ran `git diff --check` which produced no whitespace or trivial diff issues and succeeded. 
- Attempted a full configure/build with CMake (`cmake -S . -B build && cmake --build build`), but configuration failed in this environment due to missing Boost development components (`filesystem`, `serialization`, `headers`), so a complete compile/run test could not be performed.
- Performed automated code transformations and local textual audits (search-and-replace and pattern updates) across variational headers to validate predicate usage; no `git diff --check` errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e903d089f0832ca5751d5ec31e3598)