### PR TITLE
Add Codex setup and maintenance scripts aligned with CI

### DIFF
--- a/dev/codex/README.md
+++ b/dev/codex/README.md
@@ -1,0 +1,49 @@
+# Codex setup + maintenance scripts
+
+This folder provides local scripts that mirror the CI workflow conventions in `.github/workflows/` so Codex (and humans) can bootstrap and maintain a consistent Rodin dev environment.
+
+## Repository audit highlights
+
+The scripts were derived from these workflow patterns:
+
+- **Compiler/toolchain setup** from `.github/workflows/copilot-setup-steps.yml`.
+- **Ubuntu dependency package set** from Build/Tests/Installation workflows.
+- **macOS dependency package set** from Build/Installation workflows.
+- **CMake flags and test labels** from `.github/workflows/Build.yml` and `.github/workflows/Tests.yml`.
+
+## Scripts
+
+### `setup_codex_env.sh`
+
+Bootstraps a machine for Codex work:
+
+- Initializes submodules.
+- Optionally installs OS dependencies (`--install-deps`).
+- Configures a dedicated build directory (`build/codex` by default) with unit/manufactured tests enabled.
+
+Example:
+
+```bash
+bash dev/codex/setup_codex_env.sh --install-deps
+```
+
+### `maintenance.sh`
+
+Runs periodic maintenance tasks aligned with CI:
+
+- Submodule refresh.
+- CMake reconfigure.
+- Build.
+- Unit/manufactured test labels (excluding `slow`).
+- Optional installation smoke test (`--installation-check`).
+
+Example:
+
+```bash
+bash dev/codex/maintenance.sh
+```
+
+## Notes
+
+- These scripts are intentionally conservative and keep docs/examples/benchmarks disabled by default for faster local feedback.
+- Override `BUILD_TYPE`, `CTEST_PARALLEL_LEVEL`, or `BUILD_DIR` via environment variables or flags where supported.

--- a/dev/codex/maintenance.sh
+++ b/dev/codex/maintenance.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build/codex}"
+RUN_BUILD="1"
+RUN_TESTS="1"
+RUN_INSTALL_CHECK="0"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Run repeatable Codex maintenance tasks for Rodin.
+
+Options:
+  --build-dir <path>       Build directory (default: ${BUILD_DIR})
+  --skip-build             Skip cmake --build
+  --skip-tests             Skip ctest label suites
+  --installation-check     Run tests/installation/test_installation.sh at the end
+  -h, --help               Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-dir)
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --skip-build)
+      RUN_BUILD="0"
+      shift
+      ;;
+    --skip-tests)
+      RUN_TESTS="0"
+      shift
+      ;;
+    --installation-check)
+      RUN_INSTALL_CHECK="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+cd "${REPO_ROOT}"
+echo "[maintenance] Repository root: ${REPO_ROOT}"
+
+echo "[maintenance] Updating submodules"
+git submodule update --init --recursive
+
+echo "[maintenance] Refreshing CMake cache"
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+  -DCMAKE_BUILD_TYPE="${BUILD_TYPE:-Debug}" \
+  -DRODIN_BUILD_DOC=OFF \
+  -DRODIN_USE_MCSS=OFF \
+  -DRODIN_BUILD_SRC=ON \
+  -DRODIN_BUILD_UNIT_TESTS=ON \
+  -DRODIN_BUILD_MANUFACTURED_TESTS=ON \
+  -DRODIN_BUILD_EXAMPLES=OFF \
+  -DRODIN_BUILD_BENCHMARKS=OFF
+
+if [[ "${RUN_BUILD}" == "1" ]]; then
+  echo "[maintenance] Building project"
+  cmake --build "${BUILD_DIR}" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu || echo 4)"
+fi
+
+if [[ "${RUN_TESTS}" == "1" ]]; then
+  echo "[maintenance] Running unit tests (excluding slow)"
+  ctest --test-dir "${BUILD_DIR}/tests" -L unit -LE slow --output-on-failure -j "${CTEST_PARALLEL_LEVEL:-2}"
+
+  echo "[maintenance] Running manufactured tests (excluding slow)"
+  ctest --test-dir "${BUILD_DIR}/tests" -L manufactured -LE slow --output-on-failure -j 1
+fi
+
+if [[ "${RUN_INSTALL_CHECK}" == "1" ]]; then
+  echo "[maintenance] Running installation regression check"
+  bash "${REPO_ROOT}/tests/installation/test_installation.sh"
+fi
+
+echo "[maintenance] Completed"

--- a/dev/codex/setup_codex_env.sh
+++ b/dev/codex/setup_codex_env.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build/codex"
+BUILD_TYPE="${BUILD_TYPE:-Debug}"
+INSTALL_DEPS="0"
+RUN_CONFIGURE="1"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Prepare a Codex development environment for Rodin.
+
+Options:
+  --install-deps           Install dependencies (Ubuntu/macOS only)
+  --skip-configure         Do not run CMake configure
+  --build-dir <path>       Override build directory (default: ${BUILD_DIR})
+  --build-type <type>      CMake build type (default: ${BUILD_TYPE})
+  -h, --help               Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-deps)
+      INSTALL_DEPS="1"
+      shift
+      ;;
+    --skip-configure)
+      RUN_CONFIGURE="0"
+      shift
+      ;;
+    --build-dir)
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --build-type)
+      BUILD_TYPE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+install_ubuntu_deps() {
+  sudo apt-get update
+  sudo apt-get install -y \
+    libboost1.74-all-dev \
+    libsuitesparse-dev \
+    libeigen3-dev \
+    libscotch-dev \
+    libmetis-dev \
+    libhdf5-dev \
+    libomp-dev \
+    petsc-dev \
+    mpich \
+    lcov
+}
+
+install_macos_deps() {
+  brew update
+  brew install \
+    boost boost-mpi \
+    suitesparse \
+    eigen \
+    scotch \
+    metis \
+    hdf5-mpi \
+    libomp \
+    petsc \
+    open-mpi \
+    lcov
+}
+
+echo "[codex-setup] Repository root: ${REPO_ROOT}"
+cd "${REPO_ROOT}"
+
+echo "[codex-setup] Syncing submodules"
+git submodule update --init --recursive
+
+if [[ "${INSTALL_DEPS}" == "1" ]]; then
+  echo "[codex-setup] Installing dependencies"
+  case "$(uname -s)" in
+    Linux)
+      install_ubuntu_deps
+      ;;
+    Darwin)
+      install_macos_deps
+      ;;
+    *)
+      echo "Unsupported OS for auto-install: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "${RUN_CONFIGURE}" == "1" ]]; then
+  echo "[codex-setup] Configuring CMake in ${BUILD_DIR}"
+  cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DRODIN_BUILD_DOC=OFF \
+    -DRODIN_USE_MCSS=OFF \
+    -DRODIN_BUILD_SRC=ON \
+    -DRODIN_BUILD_UNIT_TESTS=ON \
+    -DRODIN_BUILD_MANUFACTURED_TESTS=ON \
+    -DRODIN_BUILD_EXAMPLES=OFF \
+    -DRODIN_BUILD_BENCHMARKS=OFF
+  echo "[codex-setup] Done. Build with: cmake --build ${BUILD_DIR} -j$(nproc 2>/dev/null || echo 4)"
+else
+  echo "[codex-setup] Skipped CMake configure"
+fi


### PR DESCRIPTION
### Motivation

- Provide local, repeatable Codex-friendly scripts that mirror the repository's CI build/test/install conventions from `.github/workflows` for faster developer feedback. 
- Capture CI dependency lists, CMake flags, and test-label conventions so local maintenance and Codex automation behave like GitHub Actions.

### Description

- Add `dev/codex/setup_codex_env.sh` to bootstrap a Codex development environment, including optional OS dependency installation and CMake configure with CI-aligned flags into `build/codex`.
- Add `dev/codex/maintenance.sh` to run repeatable maintenance tasks: submodule refresh, CMake reconfigure, build, labeled unit and manufactured test runs, and an optional installation regression check.
- Add `dev/codex/README.md` documenting the audit sources, usage examples, and configuration overrides for `BUILD_TYPE`, `CTEST_PARALLEL_LEVEL`, and `BUILD_DIR`.
- Scripts are executable and conservative by default (docs/examples/benchmarks disabled) and accept command-line flags to skip steps or change directories.

### Testing

- Verified script syntax with `bash -n dev/codex/setup_codex_env.sh` and `bash -n dev/codex/maintenance.sh`, both succeeding.
- Verified CLI help output with `bash dev/codex/setup_codex_env.sh --help` and `bash dev/codex/maintenance.sh --help`, which produced the expected usage text.
- Files were made executable and added to the repository; no CI test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90738afa4832c95387e310b42dd29)