### PR TITLE
[codex] Fix SNES assembly state reuse

### DIFF
--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -19,6 +19,8 @@
 
 #include "Rodin/Assembly/AssemblyBase.h"
 #include "Rodin/Assembly/ConstraintMap.h"
+#include "Rodin/Alert/MemberFunctionException.h"
+#include "Rodin/Alert/Raise.h"
 #include "Rodin/MPI/Assembly.h"
 
 #include "Rodin/Variational/LinearForm.h"
@@ -28,6 +30,7 @@
 #include "Rodin/PETSc/Math/Matrix.h"
 
 #include "Rodin/PETSc/Math/LinearSystem.h"
+#include "Rodin/PETSc/Assembly/MatrixPreparation.h"
 
 namespace Rodin::Assembly
 {
@@ -186,15 +189,24 @@ namespace Rodin::Assembly
         const size_t globalCols = trialFES.getSize();
 
         PetscErrorCode ierr;
-        ierr = MatSetSizes(res, localRows, localCols, globalRows, globalCols);
+        // Re-use the existing sparsity structure across assemblies (see
+        // contract in MatrixPreparation.h) so symbolic factorizations persist.
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            res, static_cast<PetscInt>(globalRows),
+            static_cast<PetscInt>(globalCols), needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(res, localRows, localCols, globalRows, globalCols);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetFromOptions(res);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetFromOptions(res);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(res);
-        assert(ierr == PETSC_SUCCESS);
-
+          ierr = MatSetUp(res);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(res);
         assert(ierr == PETSC_SUCCESS);
 
@@ -328,23 +340,37 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         // ------------------------
-        // Allocate / reset A (MPIAIJ)
+        // Allocate / reset A (MPIAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = MatSetSizes(
-            A,
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(localCols),
-            static_cast<PetscInt>(globalRows),
-            static_cast<PetscInt>(globalCols));
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            A, static_cast<PetscInt>(globalRows),
+            static_cast<PetscInt>(globalCols), needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(
+              A,
+              static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(localCols),
+              static_cast<PetscInt>(globalRows),
+              static_cast<PetscInt>(globalCols));
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetFromOptions(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetFromOptions(A);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetUp(A);
+          assert(ierr == PETSC_SUCCESS);
 
+          // Keep the nonzero structure stable across re-assemblies so the
+          // DirichletBC row/column zeroing below does not remove entries and
+          // change the pattern. This preserves PETSc's nonzero-state, hence the
+          // symbolic factorization of direct solvers (e.g. MUMPS).
+          ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(A);
         assert(ierr == PETSC_SUCCESS);
 
@@ -797,8 +823,42 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
 
         auto& pb            = input.getProblemBody();
         auto& us            = input.getTrialFunctions();
@@ -904,41 +964,61 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         // ------------------------
-        // Allocate / reset A (MPIAIJ)
+        // Allocate / reset A (MPIAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = MatSetSizes(
-            A,
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(localCols),
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols));
-        assert(ierr == PETSC_SUCCESS);
+        bool needsSetup = true;
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+              A, static_cast<PetscInt>(nrows), static_cast<PetscInt>(ncols),
+              needsSetup);
+          assert(ierr == PETSC_SUCCESS);
+          if (needsSetup)
+          {
+            ierr = MatSetSizes(
+                A,
+                static_cast<PetscInt>(localRows),
+                static_cast<PetscInt>(localCols),
+                static_cast<PetscInt>(nrows),
+                static_cast<PetscInt>(ncols));
+            assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetFromOptions(A);
-        assert(ierr == PETSC_SUCCESS);
+            ierr = MatSetFromOptions(A);
+            assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+            ierr = MatSetUp(A);
+            assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatZeroEntries(A);
-        assert(ierr == PETSC_SUCCESS);
+            // Keep the nonzero structure stable across re-assemblies so the
+            // DirichletBC row/column zeroing below does not remove entries and
+            // change the pattern. This preserves PETSc's nonzero-state, hence the
+            // symbolic factorization of direct solvers (e.g. MUMPS).
+            ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          ierr = MatZeroEntries(A);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Allocate / reset b (MPI Vec)
         // ------------------------
         assert(b);
-        ierr = VecSetSizes(
-            b,
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(nrows));
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(
+              b,
+              static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(nrows));
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -1013,6 +1093,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto ownsTrialGlobal = [&](Index g) -> bool
         {
           bool owned = false;
@@ -1075,110 +1162,44 @@ namespace Rodin::Assembly
         //   - global BFIs: owned test entity (rows owned), trial may be ghost
         // ------------------------
 
-        for (auto& bfi : pb.getLocalBFIs())
+        if (doMatrix)
         {
-          const auto uUUID = bfi.getTrialFunction().getUUID();
-          const auto vUUID = bfi.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& uFES = getTrialFESByUUID(uUUID);
-          const auto& vFES = getTestFESByUUID(vUUID);
-
-          const auto& attrs = bfi.getAttributes();
-          MPIIteration seq(mesh, bfi.getRegion());
-
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& bfi : pb.getLocalBFIs())
           {
-            const size_t d   = it->getDimension();
-            const Index  idx = it->getIndex();
+            const auto uUUID = bfi.getTrialFunction().getUUID();
+            const auto vUUID = bfi.getTestFunction().getUUID();
 
-            if (!shard.isOwned(d, idx))
-              continue;
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
 
-            if (!attrs.empty())
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& uFES = getTrialFESByUUID(uUUID);
+            const auto& vFES = getTestFESByUUID(vUUID);
+
+            const auto& attrs = bfi.getAttributes();
+            MPIIteration seq(mesh, bfi.getRegion());
+
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
+              const size_t d   = it->getDimension();
+              const Index  idx = it->getIndex();
+
+              if (!shard.isOwned(d, idx))
                 continue;
-            }
 
-            bfi.setPolytope(*it);
-
-            const auto& rows = vFES.getDOFs(d, idx);
-            const auto& cols = uFES.getDOFs(d, idx);
-
-            for (Index i = 0; i < rows.size(); ++i)
-            {
-              const PetscInt I = vOff + rows[i];
-              for (Index j = 0; j < cols.size(); ++j)
+              if (!attrs.empty())
               {
-                const PetscInt J = uOff + cols[j];
-                const PetscScalar val = bfi.integrate(j, i);
-                if (val != PetscScalar(0))
-                  matrix_entry(I, J, val);
-              }
-            }
-          }
-        }
-
-        for (auto& bfi : pb.getGlobalBFIs())
-        {
-          const auto uUUID = bfi.getTrialFunction().getUUID();
-          const auto vUUID = bfi.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& uFES = getTrialFESByUUID(uUUID);
-          const auto& vFES = getTestFESByUUID(vUUID);
-
-          const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
-
-          MPIIteration trialseq(mesh, bfi.getTrialRegion());
-          MPIIteration testseq(mesh,  bfi.getTestRegion());
-
-          for (auto teIt = testseq.getIterator(); teIt; ++teIt)
-          {
-            const size_t td   = teIt->getDimension();
-            const Index  tidx = teIt->getIndex();
-
-            if (!shard.isOwned(td, tidx))
-              continue;
-
-            if (!testAttrs.empty())
-            {
-              const auto a = teIt->getAttribute();
-              if (!a || !testAttrs.count(*a))
-                continue;
-            }
-
-            const auto& rows = vFES.getDOFs(td, tidx);
-
-            for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
-            {
-              const size_t rd   = trIt->getDimension();
-              const Index  ridx = trIt->getIndex();
-
-              if (!trialAttrs.empty())
-              {
-                const auto a = trIt->getAttribute();
-                if (!a || !trialAttrs.count(*a))
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
                   continue;
               }
 
-              // do not skip ghost trial entity: off-proc columns are fine
-              const auto& cols = uFES.getDOFs(rd, ridx);
+              bfi.setPolytope(*it);
 
-              bfi.setPolytope(*trIt, *teIt);
+              const auto& rows = vFES.getDOFs(d, idx);
+              const auto& cols = uFES.getDOFs(d, idx);
 
               for (Index i = 0; i < rows.size(); ++i)
               {
@@ -1193,124 +1214,197 @@ namespace Rodin::Assembly
               }
             }
           }
-        }
 
-        // Preassembled bilinear forms (with block offsets)
-        for (auto& bf : pb.getBFs())
-        {
-          const auto uUUID = bf.getTrialFunction().getUUID();
-          const auto vUUID = bf.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& op = bf.getOperator();
-          PetscInt rStart, rEnd;
-          ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
-          assert(ierr == PETSC_SUCCESS);
-
-          for (PetscInt i = rStart; i < rEnd; ++i)
+          for (auto& bfi : pb.getGlobalBFIs())
           {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt j = 0; j < nc; ++j)
-            {
-              matrix_entry(
-                static_cast<Index>(vOff) + static_cast<Index>(i),
-                static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
-                vals[j]);
-            }
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
-          }
-        }
+            const auto uUUID = bfi.getTrialFunction().getUUID();
+            const auto vUUID = bfi.getTestFunction().getUUID();
 
-        // Assemble A
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& uFES = getTrialFESByUUID(uUUID);
+            const auto& vFES = getTestFESByUUID(vUUID);
+
+            const auto& trialAttrs = bfi.getTrialAttributes();
+            const auto& testAttrs  = bfi.getTestAttributes();
+
+            MPIIteration trialseq(mesh, bfi.getTrialRegion());
+            MPIIteration testseq(mesh,  bfi.getTestRegion());
+
+            for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+            {
+              const size_t td   = teIt->getDimension();
+              const Index  tidx = teIt->getIndex();
+
+              if (!shard.isOwned(td, tidx))
+                continue;
+
+              if (!testAttrs.empty())
+              {
+                const auto a = teIt->getAttribute();
+                if (!a || !testAttrs.count(*a))
+                  continue;
+              }
+
+              const auto& rows = vFES.getDOFs(td, tidx);
+
+              for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+              {
+                const size_t rd   = trIt->getDimension();
+                const Index  ridx = trIt->getIndex();
+
+                if (!trialAttrs.empty())
+                {
+                  const auto a = trIt->getAttribute();
+                  if (!a || !trialAttrs.count(*a))
+                    continue;
+                }
+
+                // do not skip ghost trial entity: off-proc columns are fine
+                const auto& cols = uFES.getDOFs(rd, ridx);
+
+                bfi.setPolytope(*trIt, *teIt);
+
+                for (Index i = 0; i < rows.size(); ++i)
+                {
+                  const PetscInt I = vOff + rows[i];
+                  for (Index j = 0; j < cols.size(); ++j)
+                  {
+                    const PetscInt J = uOff + cols[j];
+                    const PetscScalar val = bfi.integrate(j, i);
+                    if (val != PetscScalar(0))
+                      matrix_entry(I, J, val);
+                  }
+                }
+              }
+            }
+          }
+
+          // Preassembled bilinear forms (with block offsets)
+          for (auto& bf : pb.getBFs())
+          {
+            const auto uUUID = bf.getTrialFunction().getUUID();
+            const auto vUUID = bf.getTestFunction().getUUID();
+
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& op = bf.getOperator();
+            PetscInt rStart, rEnd;
+            ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
+            assert(ierr == PETSC_SUCCESS);
+
+            for (PetscInt i = rStart; i < rEnd; ++i)
+            {
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt j = 0; j < nc; ++j)
+              {
+                matrix_entry(
+                  static_cast<Index>(vOff) + static_cast<Index>(i),
+                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
+                  vals[j]);
+              }
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+            }
+          }
+
+          // Assemble A
+          ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Assemble linear terms into b
         // Convention: negate each LFI value, consistent with all other assembly paths.
         // ------------------------
-        for (auto& lfi : pb.getLFIs())
+        if (doVector)
         {
-          const auto vUUID = lfi.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
-
-          const auto& vFES = getTestFESByUUID(vUUID);
-
-          const auto& attrs = lfi.getAttributes();
-          MPIIteration seq(mesh, lfi.getRegion());
-
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& lfi : pb.getLFIs())
           {
-            const size_t d   = it->getDimension();
-            const Index  idx = it->getIndex();
+            const auto vUUID = lfi.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff   = testOffsets[vBlock];
 
-            if (!shard.isOwned(d, idx))
-              continue;
+            const auto& vFES = getTestFESByUUID(vUUID);
 
-            if (!attrs.empty())
+            const auto& attrs = lfi.getAttributes();
+            MPIIteration seq(mesh, lfi.getRegion());
+
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
+              const size_t d   = it->getDimension();
+              const Index  idx = it->getIndex();
+
+              if (!shard.isOwned(d, idx))
                 continue;
-            }
 
-            lfi.setPolytope(*it);
+              if (!attrs.empty())
+              {
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
+                  continue;
+              }
 
-            const auto& dofs = vFES.getDOFs(d, idx);
-            for (Index l = 0; l < dofs.size(); ++l)
-            {
-              const PetscInt I = vOff + dofs[l];
-              const PetscScalar val = lfi.integrate(l);
-              if (val != PetscScalar(0))
-                vector_entry(I, -val);
+              lfi.setPolytope(*it);
+
+              const auto& dofs = vFES.getDOFs(d, idx);
+              for (Index l = 0; l < dofs.size(); ++l)
+              {
+                const PetscInt I = vOff + dofs[l];
+                const PetscScalar val = lfi.integrate(l);
+                if (val != PetscScalar(0))
+                  vector_entry(I, -val);
+              }
             }
           }
-        }
 
-        // Preassembled linear forms (with block offsets)
-        for (auto& lf : pb.getLFs())
-        {
-          const auto vUUID = lf.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
-
-          const auto& vec = lf.getVector();
-          PetscInt lo, hi;
-          ierr = VecGetOwnershipRange(vec, &lo, &hi);
-          assert(ierr == PETSC_SUCCESS);
-
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = lo; i < hi; ++i)
+          // Preassembled linear forms (with block offsets)
+          for (auto& lf : pb.getLFs())
           {
-            const PetscScalar val = arr[i - lo];
-            if (val != PetscScalar(0))
-              vector_entry(static_cast<Index>(vOff) + static_cast<Index>(i), val);
+            const auto vUUID = lf.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff   = testOffsets[vBlock];
+
+            const auto& vec = lf.getVector();
+            PetscInt lo, hi;
+            ierr = VecGetOwnershipRange(vec, &lo, &hi);
+            assert(ierr == PETSC_SUCCESS);
+
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = lo; i < hi; ++i)
+            {
+              const PetscScalar val = arr[i - lo];
+              if (val != PetscScalar(0))
+                vector_entry(static_cast<Index>(vOff) + static_cast<Index>(i), val);
+            }
+            ierr = VecRestoreArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
           }
-          ierr = VecRestoreArrayRead(vec, &arr);
+
+          // Assemble b
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
         }
 
-        // Assemble b
-        ierr = VecAssemblyBegin(b);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = VecAssemblyEnd(b);
-        assert(ierr == PETSC_SUCCESS);
-
+        if (doMatrix)
         {
           std::vector<PetscInt> rowsToZero;
           for (const Index gs : constraints.getIdentifiedRows())
@@ -1342,18 +1436,24 @@ namespace Rodin::Assembly
               assert(ierr == PETSC_SUCCESS);
             }
             const PetscScalar rhs = constraints.getIdentificationValue(gs);
-            ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
-            assert(ierr == PETSC_SUCCESS);
+            if (doVector)
+            {
+              ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
 
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyBegin(b);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(b);
-          assert(ierr == PETSC_SUCCESS);
+          if (doVector)
+          {
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
 
         std::vector<PetscInt> bcIdx;
@@ -1367,6 +1467,7 @@ namespace Rodin::Assembly
           }
         }
 
+        if (mode == AssemblyMode::Full)
         {
           Vec bcVec;
           ierr = VecDuplicate(b, &bcVec);
@@ -1395,10 +1496,36 @@ namespace Rodin::Assembly
           ierr = VecDestroy(&bcVec);
           assert(ierr == PETSC_SUCCESS);
         }
+        else if (mode == AssemblyMode::LHS)
+        {
+          ierr = MatZeroRows(
+              A,
+              static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(),
+              1.0,
+              nullptr,
+              nullptr);
+          assert(ierr == PETSC_SUCCESS);
+        }
+        else
+        {
+          ierr = VecSetValues(
+              b,
+              static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(),
+              bcVals.empty() ? nullptr : bcVals.data(),
+              INSERT_VALUES);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyEnd(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         (void) ierr;
       }
 
+    public:
       MPI* copy() const noexcept override
       {
         return new MPI(*this);

--- a/src/Rodin/PETSc/Assembly/MatrixPreparation.h
+++ b/src/Rodin/PETSc/Assembly/MatrixPreparation.h
@@ -1,0 +1,75 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef RODIN_PETSC_ASSEMBLY_MATRIXPREPARATION_H
+#define RODIN_PETSC_ASSEMBLY_MATRIXPREPARATION_H
+
+#include <petscmat.h>
+
+namespace Rodin::PETSc::Assembly
+{
+  /**
+   * @brief Decides whether a matrix needs its structure (sizes/type/layout)
+   *        set up before assembly, or whether the existing structure can be
+   *        re-used.
+   *
+   * ## Contract
+   *
+   * The caller guarantees that, between successive assemblies of the *same*
+   * matrix object, the sparsity pattern is unchanged. Concretely this means the
+   * trial and test finite element spaces and the mesh connectivity are fixed.
+   * Vertex coordinates may move (as in an ALE formulation) because that changes
+   * geometry, not the connectivity graph, hence not the pattern. If the
+   * contract is ever violated (adaptive remeshing, a changed constraint set that
+   * alters the eliminated structure, a resized problem) the global dimensions
+   * must differ, and this function then reports that a full setup is needed.
+   *
+   * ## Why this matters
+   *
+   * The structural calls @c MatSetSizes / @c MatSetType / @c MatSetFromOptions /
+   * @c MatSetUp re-establish the matrix internals and bump PETSc's nonzero-state
+   * counter. Preconditioners compare that counter
+   * (@c pc->matnonzerostate != Amat->nonzerostate) to decide whether to redo the
+   * symbolic factorization. Running the structural calls on every assembly
+   * forces external direct solvers (e.g. MUMPS) to recompute their
+   * ordering/analysis each time — which, inside a SNES/Newton loop, repeats the
+   * expensive symbolic factorization on every residual/Jacobian evaluation.
+   *
+   * When this function reports that no setup is needed, the caller should skip
+   * the structural calls and only @c MatZeroEntries + refill. That preserves the
+   * nonzero state, so PETSc reports @c SAME_NONZERO_PATTERN and the symbolic
+   * factorization is computed once and reused across assemblies.
+   *
+   * @param[in] A            Matrix to inspect.
+   * @param[in] globalRows   Expected global number of rows.
+   * @param[in] globalCols   Expected global number of columns.
+   * @param[out] needsSetup  Set to @c true when the structural setup must be
+   *                         performed (first assembly or dimensions changed),
+   *                         @c false when the existing structure can be re-used.
+   * @returns The first non-zero PETSc error code encountered, else
+   *          @c PETSC_SUCCESS.
+   */
+  inline PetscErrorCode matrixNeedsStructuralSetup(
+      ::Mat A, PetscInt globalRows, PetscInt globalCols, bool& needsSetup)
+  {
+    PetscInt curRows = 0;
+    PetscInt curCols = 0;
+    PetscErrorCode ierr = MatGetSize(A, &curRows, &curCols);
+    if (ierr)
+      return ierr;
+
+    PetscBool assembled = PETSC_FALSE;
+    ierr = MatAssembled(A, &assembled);
+    if (ierr)
+      return ierr;
+
+    needsSetup = !((assembled == PETSC_TRUE) && (curRows == globalRows) &&
+                   (curCols == globalCols));
+    return PETSC_SUCCESS;
+  }
+}
+
+#endif

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -19,6 +19,7 @@
 
 #include "Rodin/Assembly/OpenMP.h"
 #include "Rodin/PETSc/Math/LinearSystem.h"
+#include "Rodin/PETSc/Assembly/MatrixPreparation.h"
 
 namespace Rodin::Assembly
 {
@@ -239,15 +240,22 @@ namespace Rodin::Assembly
         const PetscInt m = input.getTestFES().getSize();
         const PetscInt n = input.getTrialFES().getSize();
 
-        ierr = MatSetSizes(res, m, n, m, n);
+        // Re-use the existing sparsity structure across assemblies (see
+        // contract in MatrixPreparation.h) so symbolic factorizations persist.
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(res, m, n, needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(res, m, n, m, n);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetFromOptions(res);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetFromOptions(res);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(res);
-        assert(ierr == PETSC_SUCCESS);
-
+          ierr = MatSetUp(res);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(res);
         assert(ierr == PETSC_SUCCESS);
 
@@ -411,18 +419,31 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         // ------------------------
-        // Allocate / reset A (SeqAIJ)
+        // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = MatSetSizes(A, nrows, ncols, nrows, ncols);
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            A, static_cast<PetscInt>(nrows), static_cast<PetscInt>(ncols),
+            needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(A, nrows, ncols, nrows, ncols);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetType(A, MATSEQAIJ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetType(A, MATSEQAIJ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetUp(A);
+          assert(ierr == PETSC_SUCCESS);
 
+          // Keep the nonzero structure stable across re-assemblies so the
+          // DirichletBC row/column zeroing below does not change the pattern,
+          // preserving the symbolic factorization for direct solvers (MUMPS).
+          ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(A);
         assert(ierr == PETSC_SUCCESS);
 
@@ -1071,22 +1092,35 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         // ------------------------
-        // Allocate / reset A (SeqAIJ)
+        // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = MatSetSizes(A,
-                           nrows,
-                           ncols,
-                           nrows,
-                           ncols);
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            A, static_cast<PetscInt>(nrows), static_cast<PetscInt>(ncols),
+            needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(A,
+                             nrows,
+                             ncols,
+                             nrows,
+                             ncols);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetType(A, MATSEQAIJ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetType(A, MATSEQAIJ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetUp(A);
+          assert(ierr == PETSC_SUCCESS);
 
+          // Keep the nonzero structure stable across re-assemblies so the
+          // DirichletBC row/column zeroing below does not change the pattern,
+          // preserving the symbolic factorization for direct solvers (MUMPS).
+          ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(A);
         assert(ierr == PETSC_SUCCESS);
 

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -18,6 +18,8 @@
 #include "Rodin/Variational/LinearForm.h"
 #include "Rodin/Variational/BilinearForm.h"
 
+#include "Rodin/PETSc/Assembly/MatrixPreparation.h"
+
 #include "Rodin/PETSc/Math/Vector.h"
 #include "Rodin/PETSc/Math/Matrix.h"
 #include "Rodin/PETSc/Math/LinearSystem.h"
@@ -150,15 +152,23 @@ namespace Rodin::Assembly
         const size_t n = input.getTrialFES().getSize();
 
         PetscErrorCode ierr;
-        ierr = MatSetSizes(res, m, n, m, n);
+        // Re-use the existing sparsity structure across assemblies (see
+        // contract in MatrixPreparation.h) so symbolic factorizations persist.
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            res, static_cast<PetscInt>(m), static_cast<PetscInt>(n), needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(res, m, n, m, n);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetFromOptions(res);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetFromOptions(res);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(res);
-        assert(ierr == PETSC_SUCCESS);
-
+          ierr = MatSetUp(res);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(res);
         assert(ierr == PETSC_SUCCESS);
 
@@ -308,17 +318,30 @@ namespace Rodin::Assembly
 
         PetscErrorCode ierr;
 
-        // Matrix setup
+        // Matrix setup; re-use structure across assemblies.
         assert(A);
-        ierr = MatSetSizes(A, rows, cols, rows, cols);
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            A, static_cast<PetscInt>(rows), static_cast<PetscInt>(cols),
+            needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(A, rows, cols, rows, cols);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetType(A, MATSEQAIJ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetType(A, MATSEQAIJ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetUp(A);
+          assert(ierr == PETSC_SUCCESS);
 
+          // Keep the nonzero structure stable across re-assemblies so the
+          // DirichletBC row/column zeroing below does not change the pattern,
+          // preserving the symbolic factorization for direct solvers (MUMPS).
+          ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(A);
         assert(ierr == PETSC_SUCCESS);
 
@@ -767,19 +790,32 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         // ------------------------
-        // Allocate / reset A (SeqAIJ)
+        // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = MatSetSizes(A, nrows, ncols, nrows, ncols);
+        bool needsSetup = true;
+        ierr = PETSc::Assembly::matrixNeedsStructuralSetup(
+            A, static_cast<PetscInt>(nrows), static_cast<PetscInt>(ncols),
+            needsSetup);
         assert(ierr == PETSC_SUCCESS);
+        if (needsSetup)
+        {
+          ierr = MatSetSizes(A, nrows, ncols, nrows, ncols);
+          assert(ierr == PETSC_SUCCESS);
 
-        // Keep it explicitly AIJ (sequential) for now
-        ierr = MatSetType(A, MATSEQAIJ);
-        assert(ierr == PETSC_SUCCESS);
+          // Keep it explicitly AIJ (sequential) for now
+          ierr = MatSetType(A, MATSEQAIJ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = MatSetUp(A);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = MatSetUp(A);
+          assert(ierr == PETSC_SUCCESS);
 
+          // Keep the nonzero structure stable across re-assemblies so the
+          // DirichletBC row/column zeroing below does not change the pattern,
+          // preserving the symbolic factorization for direct solvers (MUMPS).
+          ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
+          assert(ierr == PETSC_SUCCESS);
+        }
         ierr = MatZeroEntries(A);
         assert(ierr == PETSC_SUCCESS);
 

--- a/src/Rodin/PETSc/Solver/SNES.cpp
+++ b/src/Rodin/PETSc/Solver/SNES.cpp
@@ -1,4 +1,6 @@
 #include <cassert>
+#include <cstring>
+#include <string>
 #include <petscmat.h>
 #include <petscvec.h>
 #include <utility>
@@ -133,17 +135,20 @@ namespace Rodin::Solver
     if (self->m_update)
       self->m_update(x);
     self->m_updated = state;
-    self->m_assembled.reset();
 #else
     if (self->m_update)
       self->m_update(x);
     self->m_updated.reset();
-    self->m_assembled.reset();
 #endif
+    self->m_lhsAssembled.reset();
+    self->m_rhsAssembled.reset();
     return PETSC_SUCCESS;
   }
 
-  PetscErrorCode SNES::Assemble(::Vec x, void* ctx)
+  PetscErrorCode SNES::Assemble(
+      ::Vec x,
+      void* ctx,
+      Variational::AssemblyTarget target)
   {
     auto* self = static_cast<SNES*>(ctx);
     assert(self);
@@ -155,13 +160,18 @@ namespace Rodin::Solver
     ierr = VecGetState(x, &state);
     if (ierr)
       return ierr;
-    if (self->m_assembled && *self->m_assembled == state)
+
+    auto& assembled =
+      target == Variational::AssemblyTarget::LHS
+        ? self->m_lhsAssembled
+        : self->m_rhsAssembled;
+    if (assembled && *assembled == state)
       return PETSC_SUCCESS;
 #endif
     auto& problem = self->getProblem();
-    problem.assemble();
+    problem.assemble(target);
 #if PETSC_VERSION_GE(3, 20, 0)
-    self->m_assembled = state;
+    assembled = state;
 #endif
     return PETSC_SUCCESS;
   }
@@ -170,7 +180,7 @@ namespace Rodin::Solver
   {
     auto* self = static_cast<SNES*>(ctx);
     assert(self);
-    PetscErrorCode ierr = Assemble(x, ctx);
+    PetscErrorCode ierr = Assemble(x, ctx, Variational::AssemblyTarget::RHS);
     if (ierr)
       return ierr;
     auto& problem = self->getProblem();
@@ -188,7 +198,7 @@ namespace Rodin::Solver
     auto* self = static_cast<SNES*>(ctx);
     assert(self);
 
-    PetscErrorCode ierr = Assemble(x, ctx);
+    PetscErrorCode ierr = Assemble(x, ctx, Variational::AssemblyTarget::LHS);
     if (ierr)
       return ierr;
 
@@ -218,7 +228,8 @@ namespace Rodin::Solver
     PetscErrorCode ierr;
 
     m_updated.reset();
-    m_assembled.reset();
+    m_lhsAssembled.reset();
+    m_rhsAssembled.reset();
 
     ierr = SNESSetType(m_snes, m_type);
     assert(ierr == PETSC_SUCCESS);
@@ -229,6 +240,38 @@ namespace Rodin::Solver
     ierr = SNESSetFromOptions(m_snes);
     assert(ierr == PETSC_SUCCESS);
 
+    // Wire the stored field-split index sets into the inner KSP's PC when the
+    // runtime PC is fieldsplit. This mirrors KSP::solve so block/Schur
+    // preconditioners (e.g. -pc_type fieldsplit ...) work in the Newton path
+    // too. With any other PC type the splits are simply ignored.
+    {
+      ::KSP innerKSP = PETSC_NULLPTR;
+      ierr = SNESGetKSP(m_snes, &innerKSP);
+      assert(ierr == PETSC_SUCCESS);
+
+      ::PC pc = PETSC_NULLPTR;
+      ierr = KSPGetPC(innerKSP, &pc);
+      assert(ierr == PETSC_SUCCESS);
+
+      const char* pctype = nullptr;
+      ierr = PCGetType(pc, &pctype);
+      assert(ierr == PETSC_SUCCESS);
+
+      if (pctype && std::strcmp(pctype, PCFIELDSPLIT) == 0)
+      {
+        const auto& splits = this->getProblem().getLinearSystem().getFieldSplits();
+        for (size_t k = 0; k < splits.size(); ++k)
+        {
+          const auto& s = splits[k];
+          assert(s.is);
+          const std::string name =
+            !s.name.empty() ? s.name : std::to_string(k);
+          ierr = PCFieldSplitSetIS(pc, name.c_str(), s.is);
+          assert(ierr == PETSC_SUCCESS);
+        }
+      }
+    }
+
     ierr = SNESSolve(m_snes, PETSC_NULLPTR, x);
     assert(ierr == PETSC_SUCCESS);
 
@@ -236,7 +279,8 @@ namespace Rodin::Solver
     assert(ierr == PETSC_SUCCESS);
 
     // State is synchronized, but no assembled system should be trusted after solve.
-    m_assembled.reset();
+    m_lhsAssembled.reset();
+    m_rhsAssembled.reset();
   }
 
   ::SNES& SNES::getHandle() noexcept

--- a/src/Rodin/PETSc/Solver/SNES.h
+++ b/src/Rodin/PETSc/Solver/SNES.h
@@ -210,7 +210,8 @@ namespace Rodin::Solver
 
     private:
       static PetscErrorCode Update(::Vec x, void* ctx);
-      static PetscErrorCode Assemble(::Vec x, void* ctx);
+      static PetscErrorCode Assemble(
+          ::Vec x, void* ctx, Variational::AssemblyTarget target);
       static PetscErrorCode Residual(::SNES snes, ::Vec x, ::Vec f, void* ctx);
       static PetscErrorCode Jacobian(::SNES snes, ::Vec x, ::Mat J, ::Mat P, void* ctx);
 
@@ -223,7 +224,8 @@ namespace Rodin::Solver
       ::PetscInt m_maxIt,    ///< Maximum nonlinear iterations.
                  m_maxF;     ///< Maximum function evaluations.
       StateUpdate m_update; ///< Optional state synchronization callback.
-      Optional<::PetscObjectState> m_assembled;
+      Optional<::PetscObjectState> m_lhsAssembled;
+      Optional<::PetscObjectState> m_rhsAssembled;
       Optional<::PetscObjectState> m_updated;
   };
 }

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -231,6 +231,14 @@ namespace Rodin::Variational
         return *this;
       }
 
+      Problem& assemble(AssemblyTarget) override
+      {
+        Alert::MemberFunctionException(*this, __func__)
+          << "Targeted assembly is not implemented for PETSc two-field problems."
+          << Alert::Raise;
+        return *this;
+      }
+
       /**
        * @brief Assembles if stale, solves the linear system, and writes the
        *        result to the trial function solution.
@@ -593,6 +601,33 @@ namespace Rodin::Variational
 
         m_assembled = true;
         return *this;
+      }
+
+      Problem& assemble(AssemblyTarget target) override
+      {
+        if constexpr (std::is_same_v<U1FESMeshContextType, Context::MPI>)
+        {
+          computeOffsets();
+
+          AssemblyInput in{
+            m_pb, m_us, m_vs,
+            m_trialOffsets, m_testOffsets,
+            m_trialUUIDMap, m_testUUIDMap,
+            m_totalTrial, m_totalTest
+          };
+
+          m_assembly.execute(m_axb, in, target);
+
+          m_assembled = true;
+          return *this;
+        }
+        else
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for this PETSc problem."
+            << Alert::Raise;
+          return *this;
+        }
       }
 
       /**

--- a/src/Rodin/Variational/ForwardDecls.h
+++ b/src/Rodin/Variational/ForwardDecls.h
@@ -44,6 +44,19 @@ namespace Rodin::Variational
   };
 
   /**
+   * @brief Target for partial problem assembly.
+   *
+   * The default zero-argument Problem::assemble() assembles the full linear
+   * system. This target selects one side of the system for backends that can
+   * assemble the operator and vector independently.
+   */
+  enum class AssemblyTarget
+  {
+    LHS, ///< Assemble the left-hand-side operator only.
+    RHS  ///< Assemble the right-hand-side vector only.
+  };
+
+  /**
    * @brief Shorthand variable for ShapeFunctionSpaceType::Trial.
    */
   static constexpr const ShapeFunctionSpaceType TrialSpace = ShapeFunctionSpaceType::Trial;

--- a/src/Rodin/Variational/Problem.h
+++ b/src/Rodin/Variational/Problem.h
@@ -35,6 +35,9 @@
 #include "Rodin/Assembly/Input.h"
 #include "Rodin/Assembly/Sequential.h"
 
+#include "Rodin/Alert/MemberFunctionException.h"
+#include "Rodin/Alert/Raise.h"
+
 #include "Rodin/Solver/LinearSolver.h"
 
 #include "Rodin/FormLanguage/Base.h"
@@ -171,6 +174,14 @@ namespace Rodin::Variational
        * discrete linear system @f$ Au = b @f$.
        */
       virtual ProblemBase& assemble() = 0;
+
+      virtual ProblemBase& assemble(AssemblyTarget)
+      {
+        Alert::MemberFunctionException(*this, __func__)
+          << "Targeted assembly is not implemented for this problem."
+          << Alert::Raise;
+        return *this;
+      }
 
       /**
        * @brief Gets the assembled linear system.
@@ -429,6 +440,14 @@ namespace Rodin::Variational
       {
         m_assembly.execute(m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() });
         m_assembled = true;
+        return *this;
+      }
+
+      Problem& assemble(AssemblyTarget) override
+      {
+        Alert::MemberFunctionException(*this, __func__)
+          << "Targeted assembly is not implemented for this problem."
+          << Alert::Raise;
         return *this;
       }
 
@@ -791,6 +810,14 @@ namespace Rodin::Variational
 
         m_assembled = true;
 
+        return *this;
+      }
+
+      virtual ProblemUsBase& assemble(AssemblyTarget) override
+      {
+        Alert::MemberFunctionException(*this, __func__)
+          << "Targeted assembly is not implemented for this problem."
+          << Alert::Raise;
         return *this;
       }
 


### PR DESCRIPTION
## Summary

Extracts the SNES/PETSc assembly fixes from `CoronaryFSI` and `fix/NewtonDoubleAssembly` while leaving example, resource, and heart-model changes out of scope.

## What changed

- Add targeted problem assembly (`AssemblyTarget::LHS` / `RHS`) so SNES residual and Jacobian callbacks no longer force a full Newton assembly every time.
- Track PETSc vector object state inside `Solver::SNES` to avoid repeated state updates and duplicate RHS/LHS assembly for the same iterate.
- Add PETSc matrix-structure preparation logic so repeated assemblies reuse existing matrix structure when dimensions are unchanged.
- Preserve nonzero pattern state across PETSc sequential, OpenMP, and MPI assembly paths to avoid unnecessary symbolic factorization churn.

## Validation

- `cmake --build build --target RodinPETSc -j4`
- `cmake --build build --target PETSc_Seq_BDF1_ALE_FSI PETSc_Seq_BDF1_ALE_FSI_Monolithic PETSc_Seq_Poisson PETSc_MPI_Poisson -j4`

The example builds emitted existing duplicate-library linker warnings, but completed successfully.