### PR TITLE
Add PETSc two-field targeted assembly

### DIFF
--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -296,9 +296,44 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
         static_assert(
           std::is_same_v<MeshContextType, Rodin::Context::MPI>,
           "PETSc MPI assembly should only be used with MPI mesh context.");
+
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
 
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
@@ -333,32 +368,38 @@ namespace Rodin::Assembly
         // Allocate / reset A (MPIAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-          static_cast<PetscInt>(localRows),
-          static_cast<PetscInt>(localCols),
-          static_cast<PetscInt>(globalRows),
-          static_cast<PetscInt>(globalCols),
-          nullptr,
-          true,
-          true
-        });
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
+            static_cast<PetscInt>(localRows),
+            static_cast<PetscInt>(localCols),
+            static_cast<PetscInt>(globalRows),
+            static_cast<PetscInt>(globalCols),
+            nullptr,
+            true,
+            true
+          });
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Allocate / reset b (MPI Vec)
         // ------------------------
         assert(b);
-        ierr = VecSetSizes(
-            b,
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(globalRows));
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(
+              b,
+              static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(globalRows));
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -424,6 +465,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto matrix_entry = [&](Index row, Index col, PetscScalar val)
         {
           if (val == PetscScalar(0))
@@ -438,16 +486,22 @@ namespace Rodin::Assembly
             if (colValue != PetscScalar(0))
             {
               const PetscScalar rhsShift = -r.coefficient * val * colValue;
-              ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
-              assert(ierr == PETSC_SUCCESS);
+              if (doVector)
+              {
+                ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
+                assert(ierr == PETSC_SUCCESS);
+              }
             }
-            for (const auto& c : constraints.expand(col))
+            if (doMatrix)
             {
-              const PetscInt J = static_cast<PetscInt>(c.index);
-              const PetscScalar v =
-                r.coefficient * val * c.coefficient;
-              ierr = MatSetValue(A, I, J, v, ADD_VALUES);
-              assert(ierr == PETSC_SUCCESS);
+              for (const auto& c : constraints.expand(col))
+              {
+                const PetscInt J = static_cast<PetscInt>(c.index);
+                const PetscScalar v =
+                  r.coefficient * val * c.coefficient;
+                ierr = MatSetValue(A, I, J, v, ADD_VALUES);
+                assert(ierr == PETSC_SUCCESS);
+              }
             }
           }
         };
@@ -468,92 +522,32 @@ namespace Rodin::Assembly
         // ------------------------
         // Local BFIs (owned elements only)
         // ------------------------
-        for (auto& bfi : pb.getLocalBFIs())
+        if (doMatrix)
         {
-          const auto& attrs = bfi.getAttributes();
-          MPIIteration seq(mesh, bfi.getRegion());
-
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& bfi : pb.getLocalBFIs())
           {
-            const size_t d   = it->getDimension();
-            const Index  idx = it->getIndex();
+            const auto& attrs = bfi.getAttributes();
+            MPIIteration seq(mesh, bfi.getRegion());
 
-            if (!shard.isOwned(d, idx))
-              continue;
-
-            if (!attrs.empty())
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
+              const size_t d   = it->getDimension();
+              const Index  idx = it->getIndex();
+
+              if (!shard.isOwned(d, idx))
                 continue;
-            }
 
-            bfi.setPolytope(*it);
-
-            const auto& rowsDOF = testFES.getDOFs(d, idx);
-            const auto& colsDOF = trialFES.getDOFs(d, idx);
-
-            for (Index i = 0; i < rowsDOF.size(); ++i)
-            {
-              const PetscInt I = rowsDOF[i];
-              for (Index j = 0; j < colsDOF.size(); ++j)
+              if (!attrs.empty())
               {
-                const PetscInt J = colsDOF[j];
-                const PetscScalar val = bfi.integrate(j, i);
-                if (val != PetscScalar(0))
-                  matrix_entry(I, J, val);
-              }
-            }
-          }
-        }
-
-        // ------------------------
-        // Global BFIs (owned test entities only)
-        // - This avoids double assembly across ranks.
-        // - We allow trial entities to be ghost; PETSc handles off-proc columns.
-        // ------------------------
-        for (auto& bfi : pb.getGlobalBFIs())
-        {
-          const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
-
-          MPIIteration trialseq(mesh, bfi.getTrialRegion());
-          MPIIteration testseq(mesh,  bfi.getTestRegion());
-
-          for (auto teIt = testseq.getIterator(); teIt; ++teIt)
-          {
-            const size_t td   = teIt->getDimension();
-            const Index  tidx = teIt->getIndex();
-
-            if (!shard.isOwned(td, tidx))
-              continue;
-
-            if (!testAttrs.empty())
-            {
-              const auto a = teIt->getAttribute();
-              if (!a || !testAttrs.count(*a))
-                continue;
-            }
-
-            const auto& rowsDOF = testFES.getDOFs(td, tidx);
-
-            for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
-            {
-              const size_t rd   = trIt->getDimension();
-              const Index  ridx = trIt->getIndex();
-
-              if (!trialAttrs.empty())
-              {
-                const auto a = trIt->getAttribute();
-                if (!a || !trialAttrs.count(*a))
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
                   continue;
               }
 
-              // NOTE: do NOT skip ghost trial entities here: they still contribute to
-              // owned test rows, producing off-process columns in MatSetValue.
-              const auto& colsDOF = trialFES.getDOFs(rd, ridx);
+              bfi.setPolytope(*it);
 
-              bfi.setPolytope(*trIt, *teIt);
+              const auto& rowsDOF = testFES.getDOFs(d, idx);
+              const auto& colsDOF = trialFES.getDOFs(d, idx);
 
               for (Index i = 0; i < rowsDOF.size(); ++i)
               {
@@ -568,98 +562,171 @@ namespace Rodin::Assembly
               }
             }
           }
-        }
 
-        // Preassembled bilinear forms
-        for (auto& bf : pb.getBFs())
-        {
-          const auto& op = bf.getOperator();
-          PetscInt opStart, opEnd;
-          ierr = MatGetOwnershipRange(op, &opStart, &opEnd);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = opStart; i < opEnd; ++i)
+          // ------------------------
+          // Global BFIs (owned test entities only)
+          // - This avoids double assembly across ranks.
+          // - We allow trial entities to be ghost; PETSc handles off-proc columns.
+          // ------------------------
+          for (auto& bfi : pb.getGlobalBFIs())
           {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
+            const auto& trialAttrs = bfi.getTrialAttributes();
+            const auto& testAttrs  = bfi.getTestAttributes();
+
+            MPIIteration trialseq(mesh, bfi.getTrialRegion());
+            MPIIteration testseq(mesh,  bfi.getTestRegion());
+
+            for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+            {
+              const size_t td   = teIt->getDimension();
+              const Index  tidx = teIt->getIndex();
+
+              if (!shard.isOwned(td, tidx))
+                continue;
+
+              if (!testAttrs.empty())
+              {
+                const auto a = teIt->getAttribute();
+                if (!a || !testAttrs.count(*a))
+                  continue;
+              }
+
+              const auto& rowsDOF = testFES.getDOFs(td, tidx);
+
+              for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+              {
+                const size_t rd   = trIt->getDimension();
+                const Index  ridx = trIt->getIndex();
+
+                if (!trialAttrs.empty())
+                {
+                  const auto a = trIt->getAttribute();
+                  if (!a || !trialAttrs.count(*a))
+                    continue;
+                }
+
+                // NOTE: do NOT skip ghost trial entities here: they still contribute to
+                // owned test rows, producing off-process columns in MatSetValue.
+                const auto& colsDOF = trialFES.getDOFs(rd, ridx);
+
+                bfi.setPolytope(*trIt, *teIt);
+
+                for (Index i = 0; i < rowsDOF.size(); ++i)
+                {
+                  const PetscInt I = rowsDOF[i];
+                  for (Index j = 0; j < colsDOF.size(); ++j)
+                  {
+                    const PetscInt J = colsDOF[j];
+                    const PetscScalar val = bfi.integrate(j, i);
+                    if (val != PetscScalar(0))
+                      matrix_entry(I, J, val);
+                  }
+                }
+              }
+            }
+          }
+
+          // Preassembled bilinear forms
+          for (auto& bf : pb.getBFs())
+          {
+            const auto& op = bf.getOperator();
+            PetscInt opStart, opEnd;
+            ierr = MatGetOwnershipRange(op, &opStart, &opEnd);
             assert(ierr == PETSC_SUCCESS);
-            for (PetscInt j = 0; j < nc; ++j)
-              matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = opStart; i < opEnd; ++i)
+            {
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt j = 0; j < nc; ++j)
+                matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
         }
 
         // Assemble A
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Linear forms (owned elements only)
         // Convention: matches your sequential single-variable version: b += -LF
         // ------------------------
-        for (auto& lfi : pb.getLFIs())
+        if (doVector)
         {
-          const auto& attrs = lfi.getAttributes();
-          MPIIteration seq(mesh, lfi.getRegion());
-
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& lfi : pb.getLFIs())
           {
-            const size_t d   = it->getDimension();
-            const Index  idx = it->getIndex();
+            const auto& attrs = lfi.getAttributes();
+            MPIIteration seq(mesh, lfi.getRegion());
 
-            if (!shard.isOwned(d, idx))
-              continue;
-
-            if (!attrs.empty())
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
+              const size_t d   = it->getDimension();
+              const Index  idx = it->getIndex();
+
+              if (!shard.isOwned(d, idx))
                 continue;
-            }
 
-            lfi.setPolytope(*it);
+              if (!attrs.empty())
+              {
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
+                  continue;
+              }
 
-            const auto& dofs = testFES.getDOFs(d, idx);
-            for (Index l = 0; l < dofs.size(); ++l)
-            {
-              const PetscInt I = dofs[l];
-              const PetscScalar val = lfi.integrate(l);
-              if (val != PetscScalar(0))
-                vector_entry(I, -val);
+              lfi.setPolytope(*it);
+
+              const auto& dofs = testFES.getDOFs(d, idx);
+              for (Index l = 0; l < dofs.size(); ++l)
+              {
+                const PetscInt I = dofs[l];
+                const PetscScalar val = lfi.integrate(l);
+                if (val != PetscScalar(0))
+                  vector_entry(I, -val);
+              }
             }
           }
-        }
 
-        // Preassembled linear forms: b += LF
-        for (auto& lf : pb.getLFs())
-        {
-          const auto& vec = lf.getVector();
-          PetscInt lo, hi;
-          ierr = VecGetOwnershipRange(vec, &lo, &hi);
-          assert(ierr == PETSC_SUCCESS);
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = lo; i < hi; ++i)
+          // Preassembled linear forms: b += LF
+          for (auto& lf : pb.getLFs())
           {
-            const PetscScalar val = arr[i - lo];
-            if (val != PetscScalar(0))
-              vector_entry(static_cast<Index>(i), val);
+            const auto& vec = lf.getVector();
+            PetscInt lo, hi;
+            ierr = VecGetOwnershipRange(vec, &lo, &hi);
+            assert(ierr == PETSC_SUCCESS);
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = lo; i < hi; ++i)
+            {
+              const PetscScalar val = arr[i - lo];
+              if (val != PetscScalar(0))
+                vector_entry(static_cast<Index>(i), val);
+            }
+            ierr = VecRestoreArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
           }
-          ierr = VecRestoreArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
         }
 
         // Assemble b
-        ierr = VecAssemblyBegin(b);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = VecAssemblyEnd(b);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyEnd(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
+        if (doMatrix)
         {
           std::vector<PetscInt> rowsToZero;
           for (const Index gs : constraints.getIdentifiedRows())
@@ -691,18 +758,24 @@ namespace Rodin::Assembly
               assert(ierr == PETSC_SUCCESS);
             }
             const PetscScalar rhs = constraints.getIdentificationValue(gs);
-            ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
-            assert(ierr == PETSC_SUCCESS);
+            if (doVector)
+            {
+              ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
 
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyBegin(b);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(b);
-          assert(ierr == PETSC_SUCCESS);
+          if (doVector)
+          {
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
 
         std::vector<PetscInt> bcIdx;
@@ -717,37 +790,66 @@ namespace Rodin::Assembly
         }
 
         {
-          Vec bcVec;
-          ierr = VecDuplicate(b, &bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecZeroEntries(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              bcVals.empty() ? nullptr : bcVals.data(),
-              INSERT_VALUES);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyBegin(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecDestroy(&bcVec);
-          assert(ierr == PETSC_SUCCESS);
+          if (mode == AssemblyMode::Full)
+          {
+            Vec bcVec;
+            ierr = VecDuplicate(b, &bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecZeroEntries(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecSetValues(
+                bcVec,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.empty() ? nullptr : bcIdx.data(),
+                bcVals.empty() ? nullptr : bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = MatZeroRowsColumns(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.empty() ? nullptr : bcIdx.data(),
+                1.0,
+                bcVec,
+                b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecDestroy(&bcVec);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else if (mode == AssemblyMode::LHS)
+          {
+            ierr = MatZeroRows(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.empty() ? nullptr : bcIdx.data(),
+                1.0,
+                nullptr,
+                nullptr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else
+          {
+            ierr = VecSetValues(
+                b,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.empty() ? nullptr : bcIdx.data(),
+                bcVals.empty() ? nullptr : bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
 
         (void) ierr;
       }
 
+    public:
       MPI* copy() const noexcept override
       {
         return new MPI(*this);

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -391,8 +391,43 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
         static_assert(std::is_same_v<TrialMeshContextType, Rodin::Context::Local>,
           "PETSc OpenMP assembly (sequential objects) supports only Local mesh context.");
+
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
 
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
@@ -414,32 +449,38 @@ namespace Rodin::Assembly
         // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          MATSEQAIJ,
-          false,
-          true
-        });
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            MATSEQAIJ,
+            false,
+            true
+          });
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Allocate / reset b (Seq Vec)
         // ------------------------
         assert(b);
-        ierr = VecSetSizes(b, nrows, nrows);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(b, nrows, nrows);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetType(b, VECSEQ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetType(b, VECSEQ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -508,6 +549,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto add_matrix_entries =
           [&](std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>& local,
               std::vector<PetscScalar>& localRhs,
@@ -524,11 +572,14 @@ namespace Rodin::Assembly
             if (colValue != PetscScalar(0))
               localRhs[static_cast<size_t>(r.index)] -=
                 r.coefficient * val * colValue;
-            for (const auto& c : constraints.expand(col))
-              local.emplace_back(
-                  static_cast<PetscInt>(r.index),
-                  static_cast<PetscInt>(c.index),
-                  r.coefficient * val * c.coefficient);
+            if (doMatrix)
+            {
+              for (const auto& c : constraints.expand(col))
+                local.emplace_back(
+                    static_cast<PetscInt>(r.index),
+                    static_cast<PetscInt>(c.index),
+                    r.coefficient * val * c.coefficient);
+            }
           }
         };
 
@@ -546,146 +597,47 @@ namespace Rodin::Assembly
         // ------------------------
         // Local BFIs (parallel)
         // ------------------------
-        for (auto& bfi : pb.getLocalBFIs())
+        if (doMatrix)
         {
-          const auto& attrs = bfi.getAttributes();
-          OpenMPIteration seq(mesh, bfi.getRegion());
+          for (auto& bfi : pb.getLocalBFIs())
+          {
+            const auto& attrs = bfi.getAttributes();
+            OpenMPIteration seq(mesh, bfi.getRegion());
 
-          const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
-          const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
+            const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
+            const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
 
-          std::vector<std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>> chunks(static_cast<size_t>(tc));
-          std::vector<std::vector<PetscScalar>> rhsChunks(
-              static_cast<size_t>(tc),
-              std::vector<PetscScalar>(static_cast<size_t>(nrows), PetscScalar(0)));
+            std::vector<std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>> chunks(static_cast<size_t>(tc));
+            std::vector<std::vector<PetscScalar>> rhsChunks(
+                static_cast<size_t>(tc),
+                std::vector<PetscScalar>(static_cast<size_t>(nrows), PetscScalar(0)));
 
 #pragma omp parallel num_threads(tc)
-          {
-            const int tid = omp_get_thread_num();
+            {
+              const int tid = omp_get_thread_num();
 
-            auto integrator =
-              std::unique_ptr<LocalBilinearIntegratorBase>(static_cast<LocalBilinearIntegratorBase*>(bfi.copy()));
+              auto integrator =
+                std::unique_ptr<LocalBilinearIntegratorBase>(static_cast<LocalBilinearIntegratorBase*>(bfi.copy()));
 
-            std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
-            local.reserve(static_cast<size_t>(cnt));
-            std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
+              std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
+              local.reserve(static_cast<size_t>(cnt));
+              std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
 
 #pragma omp for
-            for (PetscInt k = 0; k < cnt; ++k)
-            {
-              if (!seq.filter(k)) continue;
-              if (!attrs.empty())
+              for (PetscInt k = 0; k < cnt; ++k)
               {
-                const auto a = mesh.getAttribute(dim, k);
-                if (!a || !attrs.count(*a)) continue;
-              }
-
-              auto it = seq.getIterator(k);
-              integrator->setPolytope(*it);
-
-              const auto& rowsDOF = testFES.getDOFs(dim, k);
-              const auto& colsDOF = trialFES.getDOFs(dim, k);
-
-              for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
-              {
-                for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
+                if (!seq.filter(k)) continue;
+                if (!attrs.empty())
                 {
-                  const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(j, i));
-                  if (val != PetscScalar(0))
-                    add_matrix_entries(local, localRhs, rowsDOF[i], colsDOF[j], val);
-                }
-              }
-            }
-
-            chunks[static_cast<size_t>(tid)] = std::move(local);
-            rhsChunks[static_cast<size_t>(tid)] = std::move(localRhs);
-
-#pragma omp barrier
-#pragma omp single
-            {
-              for (auto& buf : chunks)
-              {
-                for (auto& [I,J,val] : buf)
-                {
-                  PetscErrorCode e = MatSetValue(A, I, J, val, ADD_VALUES);
-                  assert(e == PETSC_SUCCESS);
-                }
-              }
-              for (const auto& vecLocal : rhsChunks)
-              {
-                for (PetscInt i = 0; i < nrows; ++i)
-                {
-                  const PetscScalar val = vecLocal[static_cast<size_t>(i)];
-                  if (val != PetscScalar(0))
-                  {
-                    PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
-                    assert(e == PETSC_SUCCESS);
-                  }
-                }
-              }
-            }
-          } // omp parallel
-        }
-
-        // ------------------------
-        // Global BFIs (parallel over test entities; inner trial loop serial per test entity)
-        // ------------------------
-        for (auto& bfi : pb.getGlobalBFIs())
-        {
-          const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
-
-          OpenMPIteration trialseq(mesh, bfi.getTrialRegion());
-          OpenMPIteration testseq(mesh,  bfi.getTestRegion());
-
-          const PetscInt tdim = static_cast<PetscInt>(testseq.getDimension());
-          const PetscInt tcnt = static_cast<PetscInt>(testseq.getCount());
-
-          const PetscInt rdim = static_cast<PetscInt>(trialseq.getDimension());
-          const PetscInt rcnt = static_cast<PetscInt>(trialseq.getCount());
-
-          std::vector<std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>> chunks(static_cast<size_t>(tc));
-          std::vector<std::vector<PetscScalar>> rhsChunks(
-              static_cast<size_t>(tc),
-              std::vector<PetscScalar>(static_cast<size_t>(nrows), PetscScalar(0)));
-
-#pragma omp parallel num_threads(tc)
-          {
-            const int tid = omp_get_thread_num();
-
-            auto integrator =
-              std::unique_ptr<GlobalBilinearIntegratorBase>(static_cast<GlobalBilinearIntegratorBase*>(bfi.copy()));
-
-            std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
-            local.reserve(static_cast<size_t>(tcnt));
-            std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
-
-#pragma omp for
-            for (PetscInt te = 0; te < tcnt; ++te)
-            {
-              if (!testseq.filter(te)) continue;
-              if (!testAttrs.empty())
-              {
-                const auto a = mesh.getAttribute(tdim, te);
-                if (!a || !testAttrs.count(*a)) continue;
-              }
-
-              auto teIt = testseq.getIterator(te);
-              const auto& rowsDOF = testFES.getDOFs(tdim, te);
-
-              for (PetscInt tr = 0; tr < rcnt; ++tr)
-              {
-                if (!trialseq.filter(tr)) continue;
-                if (!trialAttrs.empty())
-                {
-                  const auto a = mesh.getAttribute(rdim, tr);
-                  if (!a || !trialAttrs.count(*a)) continue;
+                  const auto a = mesh.getAttribute(dim, k);
+                  if (!a || !attrs.count(*a)) continue;
                 }
 
-                auto trIt = trialseq.getIterator(tr);
-                const auto& colsDOF = trialFES.getDOFs(rdim, tr);
+                auto it = seq.getIterator(k);
+                integrator->setPolytope(*it);
 
-                integrator->setPolytope(*trIt, *teIt);
+                const auto& rowsDOF = testFES.getDOFs(dim, k);
+                const auto& colsDOF = trialFES.getDOFs(dim, k);
 
                 for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
                 {
@@ -697,70 +649,286 @@ namespace Rodin::Assembly
                   }
                 }
               }
-            }
 
-            chunks[static_cast<size_t>(tid)] = std::move(local);
-            rhsChunks[static_cast<size_t>(tid)] = std::move(localRhs);
+              chunks[static_cast<size_t>(tid)] = std::move(local);
+              rhsChunks[static_cast<size_t>(tid)] = std::move(localRhs);
 
 #pragma omp barrier
 #pragma omp single
-            {
-              for (auto& buf : chunks)
               {
-                for (auto& [I,J,val] : buf)
+                for (auto& buf : chunks)
                 {
-                  PetscErrorCode e = MatSetValue(A, I, J, val, ADD_VALUES);
-                  assert(e == PETSC_SUCCESS);
-                }
-              }
-              for (const auto& vecLocal : rhsChunks)
-              {
-                for (PetscInt i = 0; i < nrows; ++i)
-                {
-                  const PetscScalar val = vecLocal[static_cast<size_t>(i)];
-                  if (val != PetscScalar(0))
+                  for (auto& [I,J,val] : buf)
                   {
-                    PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
+                    PetscErrorCode e = MatSetValue(A, I, J, val, ADD_VALUES);
                     assert(e == PETSC_SUCCESS);
                   }
                 }
+                if (doVector)
+                {
+                  for (const auto& vecLocal : rhsChunks)
+                  {
+                    for (PetscInt i = 0; i < nrows; ++i)
+                    {
+                      const PetscScalar val = vecLocal[static_cast<size_t>(i)];
+                      if (val != PetscScalar(0))
+                      {
+                        PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
+                        assert(e == PETSC_SUCCESS);
+                      }
+                    }
+                  }
+                }
               }
+            } // omp parallel
+          }
+
+          // ------------------------
+          // Global BFIs (parallel over test entities; inner trial loop serial per test entity)
+          // ------------------------
+          for (auto& bfi : pb.getGlobalBFIs())
+          {
+            const auto& trialAttrs = bfi.getTrialAttributes();
+            const auto& testAttrs  = bfi.getTestAttributes();
+
+            OpenMPIteration trialseq(mesh, bfi.getTrialRegion());
+            OpenMPIteration testseq(mesh,  bfi.getTestRegion());
+
+            const PetscInt tdim = static_cast<PetscInt>(testseq.getDimension());
+            const PetscInt tcnt = static_cast<PetscInt>(testseq.getCount());
+
+            const PetscInt rdim = static_cast<PetscInt>(trialseq.getDimension());
+            const PetscInt rcnt = static_cast<PetscInt>(trialseq.getCount());
+
+            std::vector<std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>> chunks(static_cast<size_t>(tc));
+            std::vector<std::vector<PetscScalar>> rhsChunks(
+                static_cast<size_t>(tc),
+                std::vector<PetscScalar>(static_cast<size_t>(nrows), PetscScalar(0)));
+
+#pragma omp parallel num_threads(tc)
+            {
+              const int tid = omp_get_thread_num();
+
+              auto integrator =
+                std::unique_ptr<GlobalBilinearIntegratorBase>(static_cast<GlobalBilinearIntegratorBase*>(bfi.copy()));
+
+              std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
+              local.reserve(static_cast<size_t>(tcnt));
+              std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
+
+#pragma omp for
+              for (PetscInt te = 0; te < tcnt; ++te)
+              {
+                if (!testseq.filter(te)) continue;
+                if (!testAttrs.empty())
+                {
+                  const auto a = mesh.getAttribute(tdim, te);
+                  if (!a || !testAttrs.count(*a)) continue;
+                }
+
+                auto teIt = testseq.getIterator(te);
+                const auto& rowsDOF = testFES.getDOFs(tdim, te);
+
+                for (PetscInt tr = 0; tr < rcnt; ++tr)
+                {
+                  if (!trialseq.filter(tr)) continue;
+                  if (!trialAttrs.empty())
+                  {
+                    const auto a = mesh.getAttribute(rdim, tr);
+                    if (!a || !trialAttrs.count(*a)) continue;
+                  }
+
+                  auto trIt = trialseq.getIterator(tr);
+                  const auto& colsDOF = trialFES.getDOFs(rdim, tr);
+
+                  integrator->setPolytope(*trIt, *teIt);
+
+                  for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
+                  {
+                    for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
+                    {
+                      const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(j, i));
+                      if (val != PetscScalar(0))
+                        add_matrix_entries(local, localRhs, rowsDOF[i], colsDOF[j], val);
+                    }
+                  }
+                }
+              }
+
+              chunks[static_cast<size_t>(tid)] = std::move(local);
+              rhsChunks[static_cast<size_t>(tid)] = std::move(localRhs);
+
+#pragma omp barrier
+#pragma omp single
+              {
+                for (auto& buf : chunks)
+                {
+                  for (auto& [I,J,val] : buf)
+                  {
+                    PetscErrorCode e = MatSetValue(A, I, J, val, ADD_VALUES);
+                    assert(e == PETSC_SUCCESS);
+                  }
+                }
+                if (doVector)
+                {
+                  for (const auto& vecLocal : rhsChunks)
+                  {
+                    for (PetscInt i = 0; i < nrows; ++i)
+                    {
+                      const PetscScalar val = vecLocal[static_cast<size_t>(i)];
+                      if (val != PetscScalar(0))
+                      {
+                        PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
+                        assert(e == PETSC_SUCCESS);
+                      }
+                    }
+                  }
+                }
+              }
+            } // omp parallel
+          }
+
+          // Preassembled bilinear forms (serial)
+          for (auto& bf : pb.getBFs())
+          {
+            const auto& op = bf.getOperator();
+            PetscInt rStart, rEnd;
+            ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = rStart; i < rEnd; ++i)
+            {
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt j = 0; j < nc; ++j)
+              {
+                std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
+                std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
+                add_matrix_entries(
+                    local,
+                    localRhs,
+                    static_cast<Index>(i),
+                    static_cast<Index>(cols[j]),
+                    vals[j]);
+                for (const auto& [I, J, val] : local)
+                {
+                  ierr = MatSetValue(A, I, J, val, ADD_VALUES);
+                  assert(ierr == PETSC_SUCCESS);
+                }
+                if (doVector)
+                {
+                  for (PetscInt r = 0; r < nrows; ++r)
+                  {
+                    const PetscScalar val = localRhs[static_cast<size_t>(r)];
+                    if (val != PetscScalar(0))
+                    {
+                      ierr = VecSetValue(b, r, val, ADD_VALUES);
+                      assert(ierr == PETSC_SUCCESS);
+                    }
+                  }
+                }
+              }
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
             }
-          } // omp parallel
+          }
         }
 
-        // Preassembled bilinear forms (serial)
-        for (auto& bf : pb.getBFs())
+        // Assemble A
+        if (doMatrix)
         {
-          const auto& op = bf.getOperator();
-          PetscInt rStart, rEnd;
-          ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
+          ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = rStart; i < rEnd; ++i)
+          ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+        }
+
+        // ------------------------
+        // Linear forms (parallel)
+        // Note: matches your sequential single-variable sign convention: b += -LF
+        // ------------------------
+        if (doVector)
+        {
+          for (auto& lfi : pb.getLFIs())
           {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt j = 0; j < nc; ++j)
+            const auto& attrs = lfi.getAttributes();
+            OpenMPIteration seq(mesh, lfi.getRegion());
+
+            const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
+            const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
+
+            std::vector<std::vector<PetscScalar>> chunks(static_cast<size_t>(tc));
+
+#pragma omp parallel num_threads(tc)
             {
-              std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
-              std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
-              add_matrix_entries(
-                  local,
-                  localRhs,
-                  static_cast<Index>(i),
-                  static_cast<Index>(cols[j]),
-                  vals[j]);
-              for (const auto& [I, J, val] : local)
+              const int tid = omp_get_thread_num();
+
+              auto integrator =
+                std::unique_ptr<LinearIntegratorBase>(static_cast<LinearIntegratorBase*>(lfi.copy()));
+
+              std::vector<PetscScalar> local(static_cast<size_t>(nrows), PetscScalar(0));
+
+#pragma omp for
+              for (PetscInt k = 0; k < cnt; ++k)
               {
-                ierr = MatSetValue(A, I, J, val, ADD_VALUES);
-                assert(ierr == PETSC_SUCCESS);
+                if (!seq.filter(k)) continue;
+                if (!attrs.empty())
+                {
+                  const auto a = mesh.getAttribute(dim, k);
+                  if (!a || !attrs.count(*a)) continue;
+                }
+
+                auto it = seq.getIterator(k);
+                integrator->setPolytope(*it);
+
+                const auto& dofs = testFES.getDOFs(dim, k);
+                for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
+                {
+                  const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(l));
+                  add_vector_entries(local, dofs[l], -val);
+                }
               }
+
+              chunks[static_cast<size_t>(tid)] = std::move(local);
+
+#pragma omp barrier
+#pragma omp single
+              {
+                for (auto& vecLocal : chunks)
+                {
+                  for (PetscInt i = 0; i < nrows; ++i)
+                  {
+                    const PetscScalar val = vecLocal[static_cast<size_t>(i)];
+                    if (val != PetscScalar(0))
+                    {
+                      PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
+                      assert(e == PETSC_SUCCESS);
+                    }
+                  }
+                }
+              }
+            } // omp parallel
+          }
+
+          // Preassembled linear forms (serial) : b += LF
+          for (auto& lf : pb.getLFs())
+          {
+            const auto& vec = lf.getVector();
+            PetscInt vecSize;
+            ierr = VecGetSize(vec, &vecSize);
+            assert(ierr == PETSC_SUCCESS);
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = 0; i < vecSize; ++i)
+            {
+              std::vector<PetscScalar> local(static_cast<size_t>(nrows), PetscScalar(0));
+              add_vector_entries(local, static_cast<Index>(i), arr[i]);
               for (PetscInt r = 0; r < nrows; ++r)
               {
-                const PetscScalar val = localRhs[static_cast<size_t>(r)];
+                const PetscScalar val = local[static_cast<size_t>(r)];
                 if (val != PetscScalar(0))
                 {
                   ierr = VecSetValue(b, r, val, ADD_VALUES);
@@ -768,115 +936,19 @@ namespace Rodin::Assembly
                 }
               }
             }
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+            ierr = VecRestoreArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
           }
         }
 
-        // Assemble A
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-
-        // ------------------------
-        // Linear forms (parallel)
-        // Note: matches your sequential single-variable sign convention: b += -LF
-        // ------------------------
-        for (auto& lfi : pb.getLFIs())
-        {
-          const auto& attrs = lfi.getAttributes();
-          OpenMPIteration seq(mesh, lfi.getRegion());
-
-          const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
-          const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
-
-          std::vector<std::vector<PetscScalar>> chunks(static_cast<size_t>(tc));
-
-#pragma omp parallel num_threads(tc)
-          {
-            const int tid = omp_get_thread_num();
-
-            auto integrator =
-              std::unique_ptr<LinearIntegratorBase>(static_cast<LinearIntegratorBase*>(lfi.copy()));
-
-            std::vector<PetscScalar> local(static_cast<size_t>(nrows), PetscScalar(0));
-
-#pragma omp for
-            for (PetscInt k = 0; k < cnt; ++k)
-            {
-              if (!seq.filter(k)) continue;
-              if (!attrs.empty())
-              {
-                const auto a = mesh.getAttribute(dim, k);
-                if (!a || !attrs.count(*a)) continue;
-              }
-
-              auto it = seq.getIterator(k);
-              integrator->setPolytope(*it);
-
-              const auto& dofs = testFES.getDOFs(dim, k);
-              for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
-              {
-                const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(l));
-                add_vector_entries(local, dofs[l], -val);
-              }
-            }
-
-            chunks[static_cast<size_t>(tid)] = std::move(local);
-
-#pragma omp barrier
-#pragma omp single
-            {
-              for (auto& vecLocal : chunks)
-              {
-                for (PetscInt i = 0; i < nrows; ++i)
-                {
-                  const PetscScalar val = vecLocal[static_cast<size_t>(i)];
-                  if (val != PetscScalar(0))
-                  {
-                    PetscErrorCode e = VecSetValue(b, i, val, ADD_VALUES);
-                    assert(e == PETSC_SUCCESS);
-                  }
-                }
-              }
-            }
-          } // omp parallel
-        }
-
-        // Preassembled linear forms (serial) : b += LF
-        for (auto& lf : pb.getLFs())
-        {
-          const auto& vec = lf.getVector();
-          PetscInt vecSize;
-          ierr = VecGetSize(vec, &vecSize);
-          assert(ierr == PETSC_SUCCESS);
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = 0; i < vecSize; ++i)
-          {
-            std::vector<PetscScalar> local(static_cast<size_t>(nrows), PetscScalar(0));
-            add_vector_entries(local, static_cast<Index>(i), arr[i]);
-            for (PetscInt r = 0; r < nrows; ++r)
-            {
-              const PetscScalar val = local[static_cast<size_t>(r)];
-              if (val != PetscScalar(0))
-              {
-                ierr = VecSetValue(b, r, val, ADD_VALUES);
-                assert(ierr == PETSC_SUCCESS);
-              }
-            }
-          }
-          ierr = VecRestoreArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-        }
-
         // Assemble b
-        ierr = VecAssemblyBegin(b);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = VecAssemblyEnd(b);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyEnd(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         if (!constraints.getIdentifiedRows().empty())
         {
@@ -913,18 +985,24 @@ namespace Rodin::Assembly
                 assert(ierr == PETSC_SUCCESS);
               }
               const PetscScalar rhs = constraints.getIdentificationValue(gs);
-              ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
-              assert(ierr == PETSC_SUCCESS);
+              if (doVector)
+              {
+                ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
+                assert(ierr == PETSC_SUCCESS);
+              }
             }
 
             ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
             ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            ierr = VecAssemblyBegin(b);
-            assert(ierr == PETSC_SUCCESS);
-            ierr = VecAssemblyEnd(b);
-            assert(ierr == PETSC_SUCCESS);
+            if (doVector)
+            {
+              ierr = VecAssemblyBegin(b);
+              assert(ierr == PETSC_SUCCESS);
+              ierr = VecAssemblyEnd(b);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
         }
 
@@ -941,40 +1019,69 @@ namespace Rodin::Assembly
 
         if (!bcIdx.empty())
         {
-          Vec bcVec;
-          ierr = VecDuplicate(b, &bcVec);
-          assert(ierr == PETSC_SUCCESS);
+          if (mode == AssemblyMode::Full)
+          {
+            Vec bcVec;
+            ierr = VecDuplicate(b, &bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecZeroEntries(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecZeroEntries(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              bcVals.data(),
-              INSERT_VALUES);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecSetValues(
+                bcVec,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecAssemblyBegin(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = MatZeroRowsColumns(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                bcVec,
+                b);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecDestroy(&bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecDestroy(&bcVec);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else if (mode == AssemblyMode::LHS)
+          {
+            ierr = MatZeroRows(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                nullptr,
+                nullptr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else
+          {
+            ierr = VecSetValues(
+                b,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
       }
 
+    public:
       OpenMP* copy() const noexcept override
       {
         return new OpenMP(*this);

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -1151,6 +1151,41 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
+
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
 
@@ -1180,32 +1215,38 @@ namespace Rodin::Assembly
         // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          MATSEQAIJ,
-          false,
-          true
-        });
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            MATSEQAIJ,
+            false,
+            true
+          });
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // ------------------------
         // Allocate / reset b (Seq Vec)
         // ------------------------
         assert(b);
-        ierr = VecSetSizes(b, nrows, nrows);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(b, nrows, nrows);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetType(b, VECSEQ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetType(b, VECSEQ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -1340,6 +1381,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto add_matrix_entries =
           [&](std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>>& local,
               std::vector<PetscScalar>& localRhs,
@@ -1378,6 +1426,8 @@ namespace Rodin::Assembly
         // ------------------------
         // Assemble bilinear terms into A (parallel)
         // ------------------------
+        if (doMatrix)
+        {
           for (auto& bfi : pb.getLocalBFIs())
           {
             const auto uUUID = bfi.getTrialFunction().getUUID();
@@ -1649,11 +1699,14 @@ namespace Rodin::Assembly
         assert(ierr == PETSC_SUCCESS);
         ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
+        } // doMatrix
 
         // ------------------------
         // Assemble linear terms into b (parallel)
         // Convention: negate each LFI value, consistent with all other assembly paths.
         // ------------------------
+        if (doVector)
+        {
         for (auto& lfi : pb.getLFIs())
         {
           const auto vUUID = lfi.getTestFunction().getUUID();
@@ -1766,6 +1819,7 @@ namespace Rodin::Assembly
         assert(ierr == PETSC_SUCCESS);
         ierr = VecAssemblyEnd(b);
         assert(ierr == PETSC_SUCCESS);
+        } // doVector
 
         if (!constraints.getIdentifiedRows().empty())
         {
@@ -1829,40 +1883,69 @@ namespace Rodin::Assembly
 
         if (!bcIdx.empty())
         {
-          Vec bcVec;
-          ierr = VecDuplicate(b, &bcVec);
-          assert(ierr == PETSC_SUCCESS);
+          if (mode == AssemblyMode::Full)
+          {
+            Vec bcVec;
+            ierr = VecDuplicate(b, &bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecZeroEntries(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecZeroEntries(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              bcVals.data(),
-              INSERT_VALUES);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecSetValues(
+                bcVec,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecAssemblyBegin(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = MatZeroRowsColumns(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                bcVec,
+                b);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecDestroy(&bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecDestroy(&bcVec);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else if (mode == AssemblyMode::LHS)
+          {
+            ierr = MatZeroRows(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                nullptr,
+                nullptr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else
+          {
+            ierr = VecSetValues(
+                b,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
       }
 
+    public:
       OpenMP* copy() const noexcept override
       {
         return new OpenMP(*this);

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -290,8 +290,43 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
         static_assert(std::is_same_v<TrialMeshContextType, Rodin::Context::Local>,
           "PETSc sequential assembly should only be used with Local mesh context.");
+
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
 
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
@@ -310,30 +345,36 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
 
         assert(A);
-        ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-          static_cast<PetscInt>(rows),
-          static_cast<PetscInt>(cols),
-          static_cast<PetscInt>(rows),
-          static_cast<PetscInt>(cols),
-          MATSEQAIJ,
-          false,
-          true
-        });
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
+            static_cast<PetscInt>(rows),
+            static_cast<PetscInt>(cols),
+            static_cast<PetscInt>(rows),
+            static_cast<PetscInt>(cols),
+            MATSEQAIJ,
+            false,
+            true
+          });
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // Vector setup
         assert(b);
-        ierr = VecSetSizes(b, rows, rows);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(b, rows, rows);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetType(b, VECSEQ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetType(b, VECSEQ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -401,6 +442,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto matrix_entry = [&](Index row, Index col, PetscScalar val)
         {
           if (val == PetscScalar(0))
@@ -415,16 +463,22 @@ namespace Rodin::Assembly
             if (colValue != PetscScalar(0))
             {
               const PetscScalar rhsShift = -r.coefficient * val * colValue;
-              ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
-              assert(ierr == PETSC_SUCCESS);
+              if (doVector)
+              {
+                ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
+                assert(ierr == PETSC_SUCCESS);
+              }
             }
-            for (const auto& c : constraints.expand(col))
+            if (doMatrix)
             {
-              const PetscInt J = static_cast<PetscInt>(c.index);
-              const PetscScalar v =
-                r.coefficient * val * c.coefficient;
-              ierr = MatSetValue(A, I, J, v, ADD_VALUES);
-              assert(ierr == PETSC_SUCCESS);
+              for (const auto& c : constraints.expand(col))
+              {
+                const PetscInt J = static_cast<PetscInt>(c.index);
+                const PetscScalar v =
+                  r.coefficient * val * c.coefficient;
+                ierr = MatSetValue(A, I, J, v, ADD_VALUES);
+                assert(ierr == PETSC_SUCCESS);
+              }
             }
           }
         };
@@ -445,70 +499,28 @@ namespace Rodin::Assembly
         // Local BFIs
         using MeshType = std::decay_t<decltype(mesh)>;
 
-        for (auto& bfi : pb.getLocalBFIs())
+        if (doMatrix)
         {
-          const auto& attrs = bfi.getAttributes();
-          SequentialIteration<MeshType> seq(mesh, bfi.getRegion());
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& bfi : pb.getLocalBFIs())
           {
-            if (!attrs.empty())
+            const auto& attrs = bfi.getAttributes();
+            SequentialIteration<MeshType> seq(mesh, bfi.getRegion());
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
-                continue;
-            }
-
-            const size_t d = it->getDimension();
-            const Index  p = it->getIndex();
-
-            bfi.setPolytope(*it);
-
-            const auto& rowsDOF = testFES.getDOFs(d, p);
-            const auto& colsDOF = trialFES.getDOFs(d, p);
-
-            for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
-            {
-              for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
+              if (!attrs.empty())
               {
-                const PetscScalar val = PetscScalar(bfi.integrate(j, i));
-                if (val != PetscScalar(0))
-                  matrix_entry(rowsDOF[i], colsDOF[j], val);
-              }
-            }
-          }
-        }
-
-        // Global BFIs
-        for (auto& bfi : pb.getGlobalBFIs())
-        {
-          const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
-          SequentialIteration<MeshType> trialseq(mesh, bfi.getTrialRegion());
-          SequentialIteration<MeshType> testseq(mesh, bfi.getTestRegion());
-
-          for (auto teIt = testseq.getIterator(); teIt; ++teIt)
-          {
-            if (!testAttrs.empty())
-            {
-              const auto a = teIt->getAttribute();
-              if (!a || !testAttrs.count(*a))
-                continue;
-            }
-
-            const auto& rowsDOF = testFES.getDOFs(teIt->getDimension(), teIt->getIndex());
-
-            for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
-            {
-              if (!trialAttrs.empty())
-              {
-                const auto a = trIt->getAttribute();
-                if (!a || !trialAttrs.count(*a))
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
                   continue;
               }
 
-              const auto& colsDOF = trialFES.getDOFs(trIt->getDimension(), trIt->getIndex());
+              const size_t d = it->getDimension();
+              const Index  p = it->getIndex();
 
-              bfi.setPolytope(*trIt, *teIt);
+              bfi.setPolytope(*it);
+
+              const auto& rowsDOF = testFES.getDOFs(d, p);
+              const auto& colsDOF = trialFES.getDOFs(d, p);
 
               for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
               {
@@ -521,80 +533,134 @@ namespace Rodin::Assembly
               }
             }
           }
-        }
 
-        // Preassembled bilinear forms
-        for (auto& bf : pb.getBFs())
-        {
-          const auto& op = bf.getOperator();
-          PetscInt rStart, rEnd;
-          ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = rStart; i < rEnd; ++i)
+          // Global BFIs
+          for (auto& bfi : pb.getGlobalBFIs())
           {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
+            const auto& trialAttrs = bfi.getTrialAttributes();
+            const auto& testAttrs  = bfi.getTestAttributes();
+            SequentialIteration<MeshType> trialseq(mesh, bfi.getTrialRegion());
+            SequentialIteration<MeshType> testseq(mesh, bfi.getTestRegion());
+
+            for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+            {
+              if (!testAttrs.empty())
+              {
+                const auto a = teIt->getAttribute();
+                if (!a || !testAttrs.count(*a))
+                  continue;
+              }
+
+              const auto& rowsDOF = testFES.getDOFs(teIt->getDimension(), teIt->getIndex());
+
+              for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+              {
+                if (!trialAttrs.empty())
+                {
+                  const auto a = trIt->getAttribute();
+                  if (!a || !trialAttrs.count(*a))
+                    continue;
+                }
+
+                const auto& colsDOF = trialFES.getDOFs(trIt->getDimension(), trIt->getIndex());
+
+                bfi.setPolytope(*trIt, *teIt);
+
+                for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
+                {
+                  for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
+                  {
+                    const PetscScalar val = PetscScalar(bfi.integrate(j, i));
+                    if (val != PetscScalar(0))
+                      matrix_entry(rowsDOF[i], colsDOF[j], val);
+                  }
+                }
+              }
+            }
+          }
+
+          // Preassembled bilinear forms
+          for (auto& bf : pb.getBFs())
+          {
+            const auto& op = bf.getOperator();
+            PetscInt rStart, rEnd;
+            ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
             assert(ierr == PETSC_SUCCESS);
-            for (PetscInt j = 0; j < nc; ++j)
-              matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = rStart; i < rEnd; ++i)
+            {
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt j = 0; j < nc; ++j)
+                matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
         }
 
         // Linear forms
-        for (auto& lfi : pb.getLFIs())
+        if (doVector)
         {
-          const auto& attrs = lfi.getAttributes();
-          SequentialIteration<MeshType> seq(mesh, lfi.getRegion());
-          for (auto it = seq.getIterator(); it; ++it)
+          for (auto& lfi : pb.getLFIs())
           {
-            if (!attrs.empty())
+            const auto& attrs = lfi.getAttributes();
+            SequentialIteration<MeshType> seq(mesh, lfi.getRegion());
+            for (auto it = seq.getIterator(); it; ++it)
             {
-              const auto a = it->getAttribute();
-              if (!a || !attrs.count(*a))
-                continue;
-            }
+              if (!attrs.empty())
+              {
+                const auto a = it->getAttribute();
+                if (!a || !attrs.count(*a))
+                  continue;
+              }
 
-            lfi.setPolytope(*it);
-            const auto& dofs = testFES.getDOFs(it->getDimension(), it->getIndex());
-            for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
-            {
-              const PetscScalar val = PetscScalar(lfi.integrate(l));
-              vector_entry(dofs[l], -val);
+              lfi.setPolytope(*it);
+              const auto& dofs = testFES.getDOFs(it->getDimension(), it->getIndex());
+              for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
+              {
+                const PetscScalar val = PetscScalar(lfi.integrate(l));
+                vector_entry(dofs[l], -val);
+              }
             }
+          }
+
+          // Preassembled linear forms
+          for (auto& lf : pb.getLFs())
+          {
+            const auto& vec = lf.getVector();
+            PetscInt vecSize;
+            ierr = VecGetSize(vec, &vecSize);
+            assert(ierr == PETSC_SUCCESS);
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = 0; i < vecSize; ++i)
+              if (arr[i] != PetscScalar(0))
+                vector_entry(static_cast<Index>(i), arr[i]);
+            ierr = VecRestoreArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
           }
         }
 
-        // Preassembled linear forms
-        for (auto& lf : pb.getLFs())
+        // Assemble A and b
+        if (doMatrix)
         {
-          const auto& vec = lf.getVector();
-          PetscInt vecSize;
-          ierr = VecGetSize(vec, &vecSize);
+          ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = 0; i < vecSize; ++i)
-            if (arr[i] != PetscScalar(0))
-              vector_entry(static_cast<Index>(i), arr[i]);
-          ierr = VecRestoreArrayRead(vec, &arr);
+          ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
         }
 
-        // Assemble A and b
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-
-        ierr = VecAssemblyBegin(b);
-        assert(ierr == PETSC_SUCCESS);
-        ierr = VecAssemblyEnd(b);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          ierr = VecAssemblyEnd(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         // Identification reconstruction rows
         if (!constraints.getIdentifiedRows().empty())
@@ -661,37 +727,66 @@ namespace Rodin::Assembly
 
         if (!bcIdx.empty())
         {
-          Vec bcVec;
-          ierr = VecDuplicate(b, &bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecZeroEntries(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              bcVals.data(),
-              INSERT_VALUES);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyBegin(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+          if (mode == AssemblyMode::Full)
+          {
+            Vec bcVec;
+            ierr = VecDuplicate(b, &bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecZeroEntries(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecSetValues(
+                bcVec,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = MatZeroRowsColumns(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                bcVec,
+                b);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecDestroy(&bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecDestroy(&bcVec);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else if (mode == AssemblyMode::LHS)
+          {
+            ierr = MatZeroRows(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                nullptr,
+                nullptr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else
+          {
+            ierr = VecSetValues(
+                b,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
       }
 
+    public:
       Sequential* copy() const noexcept override
       {
         return new Sequential(*this);

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -835,6 +835,41 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
+
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
 
@@ -864,34 +899,40 @@ namespace Rodin::Assembly
         // Allocate / reset A (SeqAIJ); re-use structure across assemblies.
         // ------------------------
         assert(A);
-        ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(nrows),
-          static_cast<PetscInt>(ncols),
-          MATSEQAIJ,
-          false,
-          true
-        });
-        assert(ierr == PETSC_SUCCESS);
+        if (doMatrix)
+        {
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols),
+            MATSEQAIJ,
+            false,
+            true
+          });
+          assert(ierr == PETSC_SUCCESS);
 
-        MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
+          MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
+        }
 
         // ------------------------
         // Allocate / reset b (Seq Vec)
         // ------------------------
         assert(b);
-        ierr = VecSetSizes(b, nrows, nrows);
-        assert(ierr == PETSC_SUCCESS);
+        if (doVector)
+        {
+          ierr = VecSetSizes(b, nrows, nrows);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetType(b, VECSEQ);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetType(b, VECSEQ);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecSetFromOptions(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecSetFromOptions(b);
+          assert(ierr == PETSC_SUCCESS);
 
-        ierr = VecZeroEntries(b);
-        assert(ierr == PETSC_SUCCESS);
+          ierr = VecZeroEntries(b);
+          assert(ierr == PETSC_SUCCESS);
+        }
 
         auto& x = axb.getSolution();
         assert(x);
@@ -1026,6 +1067,13 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         auto matrix_entry = [&](Index row, Index col, PetscScalar val)
         {
           if (val == PetscScalar(0))
@@ -1070,6 +1118,8 @@ namespace Rodin::Assembly
         // ------------------------
         // Assemble bilinear terms into A
         // ------------------------
+        if (doMatrix)
+        {
         // Local BFIs
         for (auto& bfi : pb.getLocalBFIs())
         {
@@ -1230,10 +1280,13 @@ namespace Rodin::Assembly
         assert(ierr == PETSC_SUCCESS);
         ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
+        } // doMatrix
 
         // ------------------------
         // Assemble linear terms into b
         // ------------------------
+        if (doVector)
+        {
         for (auto& lfi : pb.getLFIs())
         {
           const auto vUUID = lfi.getTestFunction().getUUID();
@@ -1297,6 +1350,7 @@ namespace Rodin::Assembly
         assert(ierr == PETSC_SUCCESS);
         ierr = VecAssemblyEnd(b);
         assert(ierr == PETSC_SUCCESS);
+        } // doVector
 
         if (!constraints.getIdentifiedRows().empty())
         {
@@ -1360,40 +1414,69 @@ namespace Rodin::Assembly
 
         if (!bcIdx.empty())
         {
-          Vec bcVec;
-          ierr = VecDuplicate(b, &bcVec);
-          assert(ierr == PETSC_SUCCESS);
+          if (mode == AssemblyMode::Full)
+          {
+            Vec bcVec;
+            ierr = VecDuplicate(b, &bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecZeroEntries(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecZeroEntries(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              bcVals.data(),
-              INSERT_VALUES);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecSetValues(
+                bcVec,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecAssemblyBegin(bcVec);
-          assert(ierr == PETSC_SUCCESS);
-          ierr = VecAssemblyEnd(bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(bcVec);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(bcVec);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = MatZeroRowsColumns(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                bcVec,
+                b);
+            assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecDestroy(&bcVec);
-          assert(ierr == PETSC_SUCCESS);
+            ierr = VecDestroy(&bcVec);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else if (mode == AssemblyMode::LHS)
+          {
+            ierr = MatZeroRows(
+                A,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                1.0,
+                nullptr,
+                nullptr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          else
+          {
+            ierr = VecSetValues(
+                b,
+                static_cast<PetscInt>(bcIdx.size()),
+                bcIdx.data(),
+                bcVals.data(),
+                INSERT_VALUES);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyBegin(b);
+            assert(ierr == PETSC_SUCCESS);
+            ierr = VecAssemblyEnd(b);
+            assert(ierr == PETSC_SUCCESS);
+          }
         }
       }
 
+    public:
       Sequential* copy() const noexcept override
       {
         return new Sequential(*this);

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -604,29 +604,19 @@ namespace Rodin::Variational
 
       Problem& assemble(AssemblyTarget target) override
       {
-        if constexpr (std::is_same_v<U1FESMeshContextType, Context::MPI>)
-        {
-          computeOffsets();
+        computeOffsets();
 
-          AssemblyInput in{
-            m_pb, m_us, m_vs,
-            m_trialOffsets, m_testOffsets,
-            m_trialUUIDMap, m_testUUIDMap,
-            m_totalTrial, m_totalTest
-          };
+        AssemblyInput in{
+          m_pb, m_us, m_vs,
+          m_trialOffsets, m_testOffsets,
+          m_trialUUIDMap, m_testUUIDMap,
+          m_totalTrial, m_totalTest
+        };
 
-          m_assembly.execute(m_axb, in, target);
+        m_assembly.execute(m_axb, in, target);
 
-          m_assembled = true;
-          return *this;
-        }
-        else
-        {
-          Alert::MemberFunctionException(*this, __func__)
-            << "Targeted assembly is not implemented for this PETSc problem."
-            << Alert::Raise;
-          return *this;
-        }
+        m_assembled = true;
+        return *this;
       }
 
       /**

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -231,11 +231,10 @@ namespace Rodin::Variational
         return *this;
       }
 
-      Problem& assemble(AssemblyTarget) override
+      Problem& assemble(AssemblyTarget target) override
       {
-        Alert::MemberFunctionException(*this, __func__)
-          << "Targeted assembly is not implemented for PETSc two-field problems."
-          << Alert::Raise;
+        m_assembly.execute(m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() }, target);
+        m_assembled = true;
         return *this;
       }
 


### PR DESCRIPTION
## Summary

Adds matrix-only and vector-only targeted assembly support for PETSc two-field variational problems across all PETSc two-field assembly backends: Sequential, OpenMP, and MPI.

## Details

- Routes `Problem<PETSc::Math::LinearSystem, U, V>::assemble(AssemblyTarget)` into the PETSc assembly backend instead of throwing.
- Adds `AssemblyTarget::LHS` / `AssemblyTarget::RHS` dispatch to the local PETSc sequential assembler.
- Adds the same targeted dispatch to the local PETSc OpenMP assembler, which is the backend selected by this build.
- Adds targeted dispatch to the PETSc MPI two-field assembler as well.
- Preserves the existing guard for targeted assembly with identification Dirichlet constraints, because those constraints couple matrix elimination and RHS reconstruction.

## Validation

- On `develop`, `cmake --build build --target RodinPETSc -j 4` passed.
- On `develop`, `cmake --build build --target PETSc_Seq_Poisson -j 4` passed.
- On `develop`, `./examples/PETSc/PDEs/PETSc_Seq_Poisson` exited successfully.
- On `develop`, `cmake --build build --target PETSc_MPI_Poisson -j 4` passed.
- On `origin/CoronarySolid` with this PR commit cherry-picked locally, `cmake --build build --target CoronaryArtery_FSI_Explicit_P1P1_PETSc_Seq -j 4` passed.
- On `origin/CoronarySolid` with this PR commit cherry-picked locally, ran:

```sh
OMP_NUM_THREADS=8 ./examples/Heart/CoronaryArtery_FSI_Explicit_P1P1_PETSc_Seq \
  -snes_monitor -ksp_type preonly -pc_type lu -pc_factor_mat_solver_type mumps \
  -mat_mumps_icntl_20 0
```

The command advanced through multiple MUMPS-backed SNES solves without the previous targeted-assembly abort. It was manually interrupted after repeated convergence because the full simulation is long-running.

## Notes

The uploaded P1P1 coronary example currently lives on `origin/CoronarySolid`, not `origin/develop`, so the coronary runtime validation was performed on a temporary local branch from `origin/CoronarySolid` with this PR patch cherry-picked on top.