### PR TITLE
Add PETSc targeted assembly regression tests

### DIFF
--- a/tests/manufactured/Rodin/PETSc/CMakeLists.txt
+++ b/tests/manufactured/Rodin/PETSc/CMakeLists.txt
@@ -14,6 +14,22 @@ set_tests_properties(RodinManufacturedPETScPoisson PROPERTIES
 )
 rodin_suppress_external_mpi_lsan_for_test(RodinManufacturedPETScPoisson)
 
+add_executable(RodinManufacturedPETScTargetedAssemblyTest TargetedAssemblyTest.cpp)
+target_link_libraries(RodinManufacturedPETScTargetedAssemblyTest
+  PUBLIC
+  GTest::gtest
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::PETSc)
+add_test(
+  NAME RodinManufacturedPETScTargetedAssemblyTest
+  COMMAND $<TARGET_FILE:RodinManufacturedPETScTargetedAssemblyTest>
+)
+set_tests_properties(RodinManufacturedPETScTargetedAssemblyTest PROPERTIES
+  LABELS "manufactured;petsc"
+)
+rodin_suppress_external_mpi_lsan_for_test(RodinManufacturedPETScTargetedAssemblyTest)
+
 if (RODIN_USE_MPI)
   add_subdirectory(MPI)
 endif()

--- a/tests/manufactured/Rodin/PETSc/MPI/CMakeLists.txt
+++ b/tests/manufactured/Rodin/PETSc/MPI/CMakeLists.txt
@@ -34,3 +34,25 @@ foreach(np 1 2 4)
     RodinManufacturedPETScMPIPoissonTest_np${np}
     "HDF5_USE_FILE_LOCKING=FALSE")
 endforeach()
+
+add_executable(RodinManufacturedPETScMPITargetedAssemblyTest TargetedAssemblyTest.cpp)
+target_link_libraries(RodinManufacturedPETScMPITargetedAssemblyTest
+  PUBLIC
+  GTest::gtest
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::MPI
+  Rodin::PETSc)
+
+foreach(np 1 2 4)
+  add_test(
+    NAME RodinManufacturedPETScMPITargetedAssemblyTest_np${np}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np}
+            ${_RODIN_MPI_OVERSUBSCRIBE_FLAG}
+            $<TARGET_FILE:RodinManufacturedPETScMPITargetedAssemblyTest>)
+  set_tests_properties(RodinManufacturedPETScMPITargetedAssemblyTest_np${np} PROPERTIES
+    LABELS "manufactured;petsc;distributed"
+  )
+  rodin_suppress_external_mpi_lsan_for_test(
+    RodinManufacturedPETScMPITargetedAssemblyTest_np${np})
+endforeach()

--- a/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
@@ -1,0 +1,189 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <cassert>
+
+#include <gtest/gtest.h>
+
+#include <petsc.h>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+
+#include <Rodin/Geometry.h>
+#include <Rodin/Geometry/BalancedCompactPartitioner.h>
+#include <Rodin/Variational.h>
+#include <Rodin/MPI/Context/MPI.h>
+#include <Rodin/MPI/Geometry/Sharder.h>
+#include <Rodin/MPI/Geometry/Mesh.h>
+#include <Rodin/MPI/Variational/P1.h>
+#include <Rodin/PETSc.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+static boost::mpi::environment*  g_env = nullptr;
+static boost::mpi::communicator* g_world = nullptr;
+
+namespace
+{
+  Mesh<Context::Local> makeShardableMesh()
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 5, 5 });
+    const size_t D = mesh.getDimension();
+    mesh.getConnectivity().compute(D, D);
+    mesh.getConnectivity().compute(D, 0);
+    return mesh;
+  }
+
+  Mesh<Context::MPI> distributeFromRoot(const Context::MPI& ctx)
+  {
+    const auto& comm = ctx.getCommunicator();
+    Sharder<Context::MPI> sharder(ctx);
+
+    if (comm.rank() == 0)
+    {
+      auto localMesh = makeShardableMesh();
+      BalancedCompactPartitioner partitioner(localMesh);
+      partitioner.partition(static_cast<size_t>(comm.size()));
+      sharder.shard(partitioner);
+      sharder.scatter(0);
+    }
+
+    return sharder.gather(0);
+  }
+
+  void expectSameOwnedVector(Vec expected, Vec actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt begin = 0;
+    PetscInt end = 0;
+    ierr = VecGetOwnershipRange(expected, &begin, &end);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    PetscInt actualBegin = 0;
+    PetscInt actualEnd = 0;
+    ierr = VecGetOwnershipRange(actual, &actualBegin, &actualEnd);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(begin, actualBegin);
+    ASSERT_EQ(end, actualEnd);
+
+    for (PetscInt i = begin; i < end; i++)
+    {
+      PetscScalar a = 0;
+      PetscScalar b = 0;
+      ierr = VecGetValues(expected, 1, &i, &a);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      ierr = VecGetValues(actual, 1, &i, &b);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "row " << i;
+    }
+  }
+
+  void expectSameOwnedMatrix(Mat expected, Mat actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt expectedRows = 0;
+    PetscInt expectedCols = 0;
+    PetscInt actualRows = 0;
+    PetscInt actualCols = 0;
+    ierr = MatGetSize(expected, &expectedRows, &expectedCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatGetSize(actual, &actualRows, &actualCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(expectedRows, actualRows);
+    ASSERT_EQ(expectedCols, actualCols);
+
+    PetscInt begin = 0;
+    PetscInt end = 0;
+    ierr = MatGetOwnershipRange(expected, &begin, &end);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    PetscInt actualBegin = 0;
+    PetscInt actualEnd = 0;
+    ierr = MatGetOwnershipRange(actual, &actualBegin, &actualEnd);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(begin, actualBegin);
+    ASSERT_EQ(end, actualEnd);
+
+    for (PetscInt i = begin; i < end; i++)
+    {
+      for (PetscInt j = 0; j < expectedCols; j++)
+      {
+        PetscScalar a = 0;
+        PetscScalar b = 0;
+        ierr = MatGetValues(expected, 1, &i, 1, &j, &a);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
+          << "entry (" << i << ", " << j << ")";
+      }
+    }
+  }
+}
+
+namespace Rodin::Tests::Manufactured::PETSc::MPI
+{
+  namespace PETSc = ::Rodin::PETSc;
+
+  TEST(PETSc_MPI_TargetedAssembly, AssemblesLHSAndRHS)
+  {
+    const auto& world = *g_world;
+    if (world.size() > 4)
+      GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
+
+    Context::MPI ctx(*g_env, world);
+    auto mesh = distributeFromRoot(ctx);
+
+    P1<Real, Mesh<Context::MPI>> fullFES(mesh);
+    PETSc::Variational::TrialFunction uFull(fullFES);
+    PETSc::Variational::TestFunction  vFull(fullFES);
+    Problem full(uFull, vFull);
+    full = Integral(uFull, vFull) - Integral(RealFunction(1.0), vFull);
+    full.assemble();
+
+    P1<Real, Mesh<Context::MPI>> lhsFES(mesh);
+    PETSc::Variational::TrialFunction uLHS(lhsFES);
+    PETSc::Variational::TestFunction  vLHS(lhsFES);
+    Problem lhs(uLHS, vLHS);
+    lhs = Integral(uLHS, vLHS) - Integral(RealFunction(1.0), vLHS);
+    lhs.assemble(Variational::AssemblyTarget::LHS);
+
+    P1<Real, Mesh<Context::MPI>> rhsFES(mesh);
+    PETSc::Variational::TrialFunction uRHS(rhsFES);
+    PETSc::Variational::TestFunction  vRHS(rhsFES);
+    Problem rhs(uRHS, vRHS);
+    rhs = Integral(uRHS, vRHS) - Integral(RealFunction(1.0), vRHS);
+    rhs.assemble(Variational::AssemblyTarget::RHS);
+
+    expectSameOwnedMatrix(
+        full.getLinearSystem().getOperator(),
+        lhs.getLinearSystem().getOperator());
+    expectSameOwnedVector(
+        full.getLinearSystem().getVector(),
+        rhs.getLinearSystem().getVector());
+  }
+}
+
+int main(int argc, char** argv)
+{
+  boost::mpi::environment env(argc, argv);
+  boost::mpi::communicator world;
+  g_env = &env;
+  g_world = &world;
+
+  [[maybe_unused]] PetscErrorCode ierr =
+    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  assert(ierr == PETSC_SUCCESS);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+
+  PetscFinalize();
+  return result;
+}

--- a/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
@@ -1,0 +1,147 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <cassert>
+
+#include <gtest/gtest.h>
+
+#include <petsc.h>
+
+#include <Rodin/Assembly.h>
+#include <Rodin/Configure.h>
+#include <Rodin/Geometry.h>
+#include <Rodin/PETSc.h>
+#include <Rodin/Variational.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace
+{
+  template <template <class, class> class Assembler>
+  PETSc::Math::LinearSystem assembleLocal(
+      Variational::AssemblyTarget target,
+      bool targeted)
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 3, 3 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 fes(mesh);
+    PETSc::Variational::TrialFunction u(fes);
+    PETSc::Variational::TestFunction  v(fes);
+
+    using LinearSystemType = PETSc::Math::LinearSystem;
+    using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
+    typename ProblemType::ProblemBodyType body =
+      Integral(u, v) - Integral(RealFunction(1.0), v);
+
+    Assembly::ProblemAssemblyInput<
+      typename ProblemType::ProblemBodyType,
+      decltype(u), decltype(v)> input(body, u, v);
+
+    LinearSystemType ls(PETSC_COMM_SELF);
+    Assembler<LinearSystemType, ProblemType> assembler;
+    if (targeted)
+      assembler.execute(ls, input, target);
+    else
+      assembler.execute(ls, input);
+    return ls;
+  }
+
+  void expectSameVector(Vec expected, Vec actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt nExpected = 0;
+    PetscInt nActual = 0;
+    ierr = VecGetSize(expected, &nExpected);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecGetSize(actual, &nActual);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(nExpected, nActual);
+
+    for (PetscInt i = 0; i < nExpected; i++)
+    {
+      PetscScalar a = 0;
+      PetscScalar b = 0;
+      ierr = VecGetValues(expected, 1, &i, &a);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      ierr = VecGetValues(actual, 1, &i, &b);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "row " << i;
+    }
+  }
+
+  void expectSameMatrix(Mat expected, Mat actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt expectedRows = 0;
+    PetscInt expectedCols = 0;
+    PetscInt actualRows = 0;
+    PetscInt actualCols = 0;
+    ierr = MatGetSize(expected, &expectedRows, &expectedCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatGetSize(actual, &actualRows, &actualCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(expectedRows, actualRows);
+    ASSERT_EQ(expectedCols, actualCols);
+
+    for (PetscInt i = 0; i < expectedRows; i++)
+    {
+      for (PetscInt j = 0; j < expectedCols; j++)
+      {
+        PetscScalar a = 0;
+        PetscScalar b = 0;
+        ierr = MatGetValues(expected, 1, &i, 1, &j, &a);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
+          << "entry (" << i << ", " << j << ")";
+      }
+    }
+  }
+
+  template <template <class, class> class Assembler>
+  void checkLocalBackendTargetedAssembly()
+  {
+    auto full = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::LHS, false);
+    auto lhs = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::LHS, true);
+    auto rhs = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::RHS, true);
+
+    expectSameMatrix(full.getOperator(), lhs.getOperator());
+    expectSameVector(full.getVector(), rhs.getVector());
+  }
+
+  TEST(PETSc_TargetedAssembly, SequentialBackendAssemblesLHSAndRHS)
+  {
+    checkLocalBackendTargetedAssembly<Assembly::Sequential>();
+  }
+
+#ifdef RODIN_USE_OPENMP
+  TEST(PETSc_TargetedAssembly, OpenMPBackendAssemblesLHSAndRHS)
+  {
+    checkLocalBackendTargetedAssembly<Assembly::OpenMP>();
+  }
+#endif
+}
+
+int main(int argc, char** argv)
+{
+  [[maybe_unused]] PetscErrorCode ierr =
+    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  assert(ierr == PETSC_SUCCESS);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+
+  PetscFinalize();
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a local PETSc targeted-assembly regression test covering Sequential and OpenMP backends
- add a distributed PETSc targeted-assembly regression test registered for 1, 2, and 4 MPI ranks
- compare full assembly against LHS-only matrix assembly and RHS-only vector assembly

## Verification
- `cmake -S . -B build -DRODIN_BUILD_MANUFACTURED_TESTS=ON`
- `cmake --build build --target RodinManufacturedPETScTargetedAssemblyTest RodinManufacturedPETScMPITargetedAssemblyTest -j 4`
- `./build/tests/manufactured/Rodin/PETSc/RodinManufacturedPETScTargetedAssemblyTest`
- `/opt/local/bin/mpiexec -n 1 ./build/tests/manufactured/Rodin/PETSc/MPI/RodinManufacturedPETScMPITargetedAssemblyTest`
- `/opt/local/bin/mpiexec -n 2 ./build/tests/manufactured/Rodin/PETSc/MPI/RodinManufacturedPETScMPITargetedAssemblyTest`
- `/opt/local/bin/mpiexec -n 4 ./build/tests/manufactured/Rodin/PETSc/MPI/RodinManufacturedPETScMPITargetedAssemblyTest`

Note: enabling `BUILD_TESTING=ON` in this local build tree started unrelated third-party mmg test-data downloads, so I verified the newly built executables directly.