### PR TITLE
Targeted assembly: full backend coverage + regression tests

### DIFF
--- a/src/Rodin/Assembly/OpenMP.h
+++ b/src/Rodin/Assembly/OpenMP.h
@@ -1484,6 +1484,24 @@ namespace Rodin::Assembly
         }
       }
 
+      // Targeted (LHS-only / RHS-only) assembly. The parallel Eigen backend
+      // assembles the full system into a scratch object and exposes only the
+      // requested side, leaving the other operand untouched (the targeted
+      // contract). This keeps the intricate parallel BC-elimination logic in a
+      // single code path instead of duplicating a gated variant.
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        LinearSystemType scratch;
+        execute(scratch, input);
+        if (target == Rodin::Variational::AssemblyTarget::LHS)
+          axb.getOperator() = std::move(scratch.getOperator());
+        else
+          axb.getVector() = std::move(scratch.getVector());
+      }
+
       OpenMP* copy() const noexcept override { return new OpenMP(*this); }
 
     private:
@@ -2164,6 +2182,22 @@ namespace Rodin::Assembly
         }
       }
 
+      // Targeted (LHS-only / RHS-only) assembly for the parallel block Eigen
+      // backend: assemble the full system into a scratch object and expose only
+      // the requested side, leaving the other operand untouched (the targeted
+      // contract). Keeps the parallel block BC-elimination logic in one path.
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        LinearSystemType scratch;
+        execute(scratch, input);
+        if (target == Rodin::Variational::AssemblyTarget::LHS)
+          axb.getOperator() = std::move(scratch.getOperator());
+        else
+          axb.getVector() = std::move(scratch.getVector());
+      }
 
       OpenMP* copy() const noexcept override { return new OpenMP(*this); }
 

--- a/src/Rodin/Assembly/Sequential.h
+++ b/src/Rodin/Assembly/Sequential.h
@@ -26,6 +26,9 @@
 #include "Rodin/Variational/ForwardDecls.h"
 #include "Rodin/Variational/IntegrationPoint.h"
 
+#include "Rodin/Alert/MemberFunctionException.h"
+#include "Rodin/Alert/Raise.h"
+
 #include "Rodin/Assembly/AssemblyBase.h"
 #include "Rodin/Assembly/ConstraintMap.h"
 
@@ -1239,6 +1242,41 @@ namespace Rodin::Assembly
 
       void execute(LinearSystemType& axb, const InputType& input) const override
       {
+        execute(axb, input, AssemblyMode::Full);
+      }
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        switch (target)
+        {
+          case Rodin::Variational::AssemblyTarget::LHS:
+            execute(axb, input, AssemblyMode::LHS);
+            break;
+          case Rodin::Variational::AssemblyTarget::RHS:
+            execute(axb, input, AssemblyMode::RHS);
+            break;
+        }
+      }
+
+    private:
+      enum class AssemblyMode
+      {
+        Full,
+        LHS,
+        RHS
+      };
+
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          AssemblyMode mode) const
+      {
+        const bool doMatrix = mode != AssemblyMode::RHS;
+        const bool doVector = mode != AssemblyMode::LHS;
+
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
 
@@ -1253,8 +1291,11 @@ namespace Rodin::Assembly
         const size_t cols = static_cast<size_t>(trialFES.getSize());
         const size_t rows = static_cast<size_t>(testFES.getSize());
 
-        b.resize(rows);
-        b.setZero();
+        if (doVector)
+        {
+          b.resize(rows);
+          b.setZero();
+        }
 
         constexpr bool IsSparse =
           std::is_base_of_v<Eigen::SparseMatrixBase<OperatorType>, OperatorType>;
@@ -1316,14 +1357,24 @@ namespace Rodin::Assembly
           }, dbc.getDOFs());
         }
 
+        if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
+        {
+          Alert::MemberFunctionException(*this, __func__)
+            << "Targeted assembly is not implemented for identification DirichletBCs."
+            << Alert::Raise;
+        }
+
         // ------------------------------------------------------------
         // Matrix init
         // ------------------------------------------------------------
         std::vector<Eigen::Triplet<ScalarType>> triplets;
-        if constexpr (!IsSparse)
+        if (doMatrix)
         {
-          A.resize(rows, cols);
-          A.setZero();
+          if constexpr (!IsSparse)
+          {
+            A.resize(rows, cols);
+            A.setZero();
+          }
         }
 
         // ------------------------------------------------------------
@@ -1375,6 +1426,8 @@ namespace Rodin::Assembly
         // ------------------------------------------------------------
         // Local BFIs
         // ------------------------------------------------------------
+        if (doMatrix)
+        {
         for (auto& bfi : pb.getLocalBFIs())
         {
           const auto& attrs = bfi.getAttributes();
@@ -1478,10 +1531,13 @@ namespace Rodin::Assembly
               }
           }
         }
+        } // doMatrix
 
         // ------------------------------------------------------------
         // Linear forms (unchanged)
         // ------------------------------------------------------------
+        if (doVector)
+        {
         for (auto& lfi : pb.getLFIs())
         {
           const auto& attrs = lfi.getAttributes();
@@ -1508,10 +1564,13 @@ namespace Rodin::Assembly
           for (Eigen::Index i = 0; i < vec.size(); ++i)
             vector_entry(static_cast<Index>(i), static_cast<ScalarType>(vec.coeff(i)));
         }
+        } // doVector
 
         // ------------------------------------------------------------
-        // Finalize: Sparse build; Dense eliminate afterwards
+        // Finalize (Full): Sparse build; Dense eliminate afterwards
         // ------------------------------------------------------------
+        if (mode == AssemblyMode::Full)
+        {
         if constexpr (IsSparse)
         {
           for (const Index gs : constraints.getIdentifiedRows())
@@ -1593,8 +1652,49 @@ namespace Rodin::Assembly
             b.coeffRef(static_cast<size_t>(idx)) = value;
           }
         }
+        } // mode == Full
+        else if (doMatrix)
+        {
+          // LHS-only: assemble the operator; fixed rows -> identity (rows only,
+          // columns kept), mirroring the PETSc MatZeroRows targeted path.
+          if constexpr (IsSparse)
+          {
+            std::vector<Eigen::Triplet<ScalarType>> filteredTriplets;
+            filteredTriplets.reserve(triplets.size() + rows);
+            for (const auto& t : triplets)
+            {
+              if (constraints.isFixed(static_cast<Index>(t.row())))
+                continue;
+              filteredTriplets.push_back(t);
+            }
+            for (Index i = 0; i < static_cast<Index>(rows); ++i)
+              if (constraints.isFixed(i))
+                filteredTriplets.emplace_back(i, i, ScalarType(1));
+            A.resize(rows, cols);
+            A.setFromTriplets(filteredTriplets.begin(), filteredTriplets.end());
+          }
+          else
+          {
+            for (Index idx = 0; idx < static_cast<Index>(rows); ++idx)
+            {
+              if (!constraints.isFixed(idx))
+                continue;
+              for (size_t c = 0; c < cols; ++c)
+                A(idx, c) = ScalarType(0);
+              A(idx, idx) = ScalarType(1);
+            }
+          }
+        }
+        else
+        {
+          // RHS-only: assemble the vector; fixed entries -> prescribed value.
+          for (Index idx = 0; idx < static_cast<Index>(rows); ++idx)
+            if (constraints.isFixed(idx))
+              b.coeffRef(static_cast<size_t>(idx)) = constraints.getFixedValue(idx);
+        }
       }
 
+    public:
       Sequential* copy() const noexcept override
       {
         return new Sequential(*this);

--- a/src/Rodin/Assembly/Sequential.h
+++ b/src/Rodin/Assembly/Sequential.h
@@ -1195,6 +1195,23 @@ namespace Rodin::Assembly
         }
       }
 
+      // Targeted (LHS-only / RHS-only) assembly for the block Eigen backend:
+      // assemble the full system into a scratch object and expose only the
+      // requested side, leaving the other operand untouched (the targeted
+      // contract). Keeps the block BC-elimination logic in one code path.
+      void execute(
+          LinearSystemType& axb,
+          const InputType& input,
+          Rodin::Variational::AssemblyTarget target) const
+      {
+        LinearSystemType scratch;
+        execute(scratch, input);
+        if (target == Rodin::Variational::AssemblyTarget::LHS)
+          axb.getOperator() = std::move(scratch.getOperator());
+        else
+          axb.getVector() = std::move(scratch.getVector());
+      }
+
       Sequential* copy() const noexcept override
         {
           return new Sequential(*this);

--- a/src/Rodin/Variational/Problem.h
+++ b/src/Rodin/Variational/Problem.h
@@ -443,11 +443,11 @@ namespace Rodin::Variational
         return *this;
       }
 
-      Problem& assemble(AssemblyTarget) override
+      Problem& assemble(AssemblyTarget target) override
       {
-        Alert::MemberFunctionException(*this, __func__)
-          << "Targeted assembly is not implemented for this problem."
-          << Alert::Raise;
+        m_assembly.execute(
+            m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() }, target);
+        m_assembled = true;
         return *this;
       }
 

--- a/src/Rodin/Variational/Problem.h
+++ b/src/Rodin/Variational/Problem.h
@@ -813,11 +813,57 @@ namespace Rodin::Variational
         return *this;
       }
 
-      virtual ProblemUsBase& assemble(AssemblyTarget) override
+      virtual ProblemUsBase& assemble(AssemblyTarget target) override
       {
-        Alert::MemberFunctionException(*this, __func__)
-          << "Targeted assembly is not implemented for this problem."
-          << Alert::Raise;
+        auto& axb = getLinearSystem();
+
+        // Compute trial offsets
+        {
+          std::array<size_t, TrialFunctionTuple::Size> sz;
+          m_us.map(
+                [](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
+              .iapply(
+                [&](const Index i, size_t s) { sz[i] = s; });
+          m_trialOffsets[0] = 0;
+          for (size_t i = 0; i < TrialFunctionTuple::Size - 1; i++)
+            m_trialOffsets[i + 1] = sz[i] + m_trialOffsets[i];
+        }
+
+        // Compute test offsets
+        {
+          std::array<size_t, TestFunctionTuple::Size> sz;
+          m_vs.map(
+                [](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
+              .iapply(
+                [&](const Index i, size_t s) { sz[i] = s; });
+          m_testOffsets[0] = 0;
+          for (size_t i = 0; i < TestFunctionTuple::Size - 1; i++)
+            m_testOffsets[i + 1] = sz[i] + m_testOffsets[i];
+        }
+
+        size_t rows =
+          m_vs
+            .map([](const auto& v)
+            {
+              return static_cast<size_t>(v.get().getFiniteElementSpace().getSize());
+            })
+            .reduce([](size_t a, size_t b) { return a + b; });
+
+        size_t cols =
+          m_us
+            .map([](const auto& u)
+            {
+              return static_cast<size_t>(u.get().getFiniteElementSpace().getSize());
+            })
+            .reduce([](size_t a, size_t b) { return a + b; });
+
+        AssemblyInput input(
+            m_pb, m_us, m_vs, m_trialOffsets, m_testOffsets,
+            m_trialUUIDMap, m_testUUIDMap, cols, rows);
+        m_assembly.execute(axb, input, target);
+
+        m_assembled = true;
+
         return *this;
       }
 

--- a/tests/manufactured/Rodin/Assembly/CMakeLists.txt
+++ b/tests/manufactured/Rodin/Assembly/CMakeLists.txt
@@ -11,3 +11,17 @@ gtest_discover_tests(RodinManufacturedAssembly
   PROPERTIES
     LABELS manufactured
 )
+
+add_executable(RodinManufacturedTargetedAssembly TargetedAssemblyTest.cpp)
+target_link_libraries(RodinManufacturedTargetedAssembly
+  PUBLIC
+  GTest::gtest
+  GTest::gtest_main
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::Solver
+)
+gtest_discover_tests(RodinManufacturedTargetedAssembly
+  PROPERTIES
+    LABELS manufactured
+)

--- a/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
@@ -17,11 +17,16 @@
  * The manufactured systems are deliberately free of Dirichlet boundary
  * conditions so that the targeted/full equivalence is exact to roundoff.
  */
+#include <array>
+
+#include <boost/bimap.hpp>
+
 #include <gtest/gtest.h>
 
 #include "Rodin/Assembly.h"
 #include "Rodin/Configure.h"
 #include "Rodin/Geometry.h"
+#include "Rodin/Tuple.h"
 #include "Rodin/Variational.h"
 
 using namespace Rodin;
@@ -115,12 +120,99 @@ namespace Rodin::Tests::Manufactured::Assembly
 #endif
 
   // -------------------------------------------------------------------------
-  // Two-field (block) targeted assembly through the high-level Problem API.
-  // The Problem routes to the Default backend (Sequential or OpenMP depending
-  // on the build), exercising the block backend + Problem::assemble(target)
-  // wiring end-to-end. BC-free so the targeted/full equivalence is exact.
+  // Two-field (block) targeted assembly, driving a specific block backend
+  // directly (so both Sequential and OpenMP block paths are exercised locally,
+  // regardless of which backend Assembly::Default resolves to). The block
+  // ProblemAssemblyInput is built the same way the high-level Problem builds
+  // it. BC-free so targeted/full equivalence is exact.
   // -------------------------------------------------------------------------
-  TEST(Eigen_TargetedAssembly, BlockProblemLHSAndRHS)
+  template <template <class, class> class Assembler>
+  LinearSystemType assembleBlock(
+      Variational::AssemblyTarget target, bool targeted)
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 vh(mesh);
+    P0 ph(mesh);
+    TrialFunction u(vh);
+    TestFunction  v(vh);
+    TrialFunction p(ph);
+    TestFunction  q(ph);
+
+    using ProblemType =
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(p), decltype(q)>;
+    typename ProblemType::ProblemBodyType body =
+      Integral(Grad(u), Grad(v)) + Integral(u, v)
+        - Integral(p, v) - Integral(u, q) + Integral(p, q)
+        - Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
+
+    // Trial blocks: [u, p]; test blocks: [v, q].
+    auto us = Tuple{ std::ref(u), std::ref(p) };
+    auto vs = Tuple{ std::ref(v), std::ref(q) };
+
+    const size_t uSize = static_cast<size_t>(vh.getSize());
+    const size_t pSize = static_cast<size_t>(ph.getSize());
+
+    std::array<size_t, 2> trialOffsets{ 0, uSize };
+    std::array<size_t, 2> testOffsets{ 0, uSize };
+
+    boost::bimap<Rodin::FormLanguage::Base::UUID, size_t> trialUUIDMap;
+    boost::bimap<Rodin::FormLanguage::Base::UUID, size_t> testUUIDMap;
+    trialUUIDMap.right.insert({ 0, u.getUUID() });
+    trialUUIDMap.right.insert({ 1, p.getUUID() });
+    testUUIDMap.right.insert({ 0, v.getUUID() });
+    testUUIDMap.right.insert({ 1, q.getUUID() });
+
+    const size_t totalTrial = uSize + pSize;
+    const size_t totalTest  = uSize + pSize;
+
+    ::Rodin::Assembly::ProblemAssemblyInput<
+      typename ProblemType::ProblemBodyType,
+      decltype(u), decltype(v), decltype(p), decltype(q)>
+      input(
+        body, us, vs, trialOffsets, testOffsets,
+        trialUUIDMap, testUUIDMap, totalTrial, totalTest);
+
+    LinearSystemType ls;
+    Assembler<LinearSystemType, ProblemType> assembler;
+    if (targeted)
+      assembler.execute(ls, input, target);
+    else
+      assembler.execute(ls, input);
+    return ls;
+  }
+
+  template <template <class, class> class Assembler>
+  void checkBlockTargeted()
+  {
+    const auto full =
+      assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, false);
+    const auto lhs =
+      assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, true);
+    const auto rhs =
+      assembleBlock<Assembler>(Variational::AssemblyTarget::RHS, true);
+
+    expectSameMatrix(full.getOperator(), lhs.getOperator());
+    expectSameVector(full.getVector(), rhs.getVector());
+  }
+
+  TEST(Eigen_TargetedAssembly, SequentialBlockLHSAndRHS)
+  {
+    checkBlockTargeted<::Rodin::Assembly::Sequential>();
+  }
+
+#ifdef RODIN_USE_OPENMP
+  TEST(Eigen_TargetedAssembly, OpenMPBlockLHSAndRHS)
+  {
+    checkBlockTargeted<::Rodin::Assembly::OpenMP>();
+  }
+#endif
+
+  // Block targeted assembly through the high-level Problem API (Default
+  // backend), covering the Problem::assemble(target) wiring end-to-end.
+  TEST(Eigen_TargetedAssembly, BlockProblemAPILHSAndRHS)
   {
     auto mesh =
       Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });

--- a/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
@@ -107,10 +107,48 @@ namespace Rodin::Tests::Manufactured::Assembly
     checkSingleFieldTargeted<::Rodin::Assembly::Sequential>();
   }
 
-#if defined(RODIN_USE_OPENMP) && defined(RODIN_TARGETED_OPENMP_READY)
+#ifdef RODIN_USE_OPENMP
   TEST(Eigen_TargetedAssembly, OpenMPSingleFieldLHSAndRHS)
   {
     checkSingleFieldTargeted<::Rodin::Assembly::OpenMP>();
   }
 #endif
+
+  // -------------------------------------------------------------------------
+  // Two-field (block) targeted assembly through the high-level Problem API.
+  // The Problem routes to the Default backend (Sequential or OpenMP depending
+  // on the build), exercising the block backend + Problem::assemble(target)
+  // wiring end-to-end. BC-free so the targeted/full equivalence is exact.
+  // -------------------------------------------------------------------------
+  TEST(Eigen_TargetedAssembly, BlockProblemLHSAndRHS)
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 vh(mesh);
+    P0 ph(mesh);
+    TrialFunction u(vh);
+    TrialFunction p(ph);
+    TestFunction  v(vh);
+    TestFunction  q(ph);
+
+    Problem prob(u, v, p, q);
+    prob = Integral(Grad(u), Grad(v)) + Integral(u, v)
+         - Integral(p, v) - Integral(u, q) + Integral(p, q)
+         - Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
+
+    prob.assemble();
+    const Math::SparseMatrix<Real> Afull = prob.getLinearSystem().getOperator();
+    const Math::Vector<Real>       bfull = prob.getLinearSystem().getVector();
+
+    prob.assemble(Variational::AssemblyTarget::LHS);
+    const Math::SparseMatrix<Real> Alhs = prob.getLinearSystem().getOperator();
+
+    prob.assemble(Variational::AssemblyTarget::RHS);
+    const Math::Vector<Real>       brhs = prob.getLinearSystem().getVector();
+
+    expectSameMatrix(Afull, Alhs);
+    expectSameVector(bfull, brhs);
+  }
 }

--- a/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
@@ -1,0 +1,116 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ *
+ * Regression tests for targeted (LHS-only / RHS-only) assembly on the core
+ * Eigen-backed assembly backends (Sequential and OpenMP), for both
+ * single-field and two-field (block) problems.
+ *
+ * Targeted assembly must satisfy:
+ *   - assembling with AssemblyTarget::LHS reproduces the operator of a full
+ *     assembly, and
+ *   - assembling with AssemblyTarget::RHS reproduces the vector of a full
+ *     assembly.
+ *
+ * The manufactured systems are deliberately free of Dirichlet boundary
+ * conditions so that the targeted/full equivalence is exact to roundoff.
+ */
+#include <gtest/gtest.h>
+
+#include "Rodin/Assembly.h"
+#include "Rodin/Configure.h"
+#include "Rodin/Geometry.h"
+#include "Rodin/Variational.h"
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace Rodin::Tests::Manufactured::Assembly
+{
+  using LinearSystemType =
+    Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>>;
+
+  void expectSameVector(const Math::Vector<Real>& expected,
+                        const Math::Vector<Real>& actual)
+  {
+    ASSERT_EQ(expected.size(), actual.size());
+    for (Eigen::Index i = 0; i < expected.size(); ++i)
+      EXPECT_LE(std::abs(expected.coeff(i) - actual.coeff(i)), 1e-12)
+        << "row " << i;
+  }
+
+  void expectSameMatrix(const Math::SparseMatrix<Real>& expected,
+                        const Math::SparseMatrix<Real>& actual)
+  {
+    ASSERT_EQ(expected.rows(), actual.rows());
+    ASSERT_EQ(expected.cols(), actual.cols());
+    const Math::SparseMatrix<Real> diff = expected - actual;
+    Real maxAbs = 0;
+    for (int k = 0; k < diff.outerSize(); ++k)
+      for (Math::SparseMatrix<Real>::InnerIterator it(diff, k); it; ++it)
+        maxAbs = std::max(maxAbs, std::abs(it.value()));
+    EXPECT_LE(maxAbs, 1e-12);
+  }
+
+  // -------------------------------------------------------------------------
+  // Single-field: -Delta u = 1 weak form (mass + stiffness), no BCs.
+  // -------------------------------------------------------------------------
+  template <template <class, class> class Assembler>
+  LinearSystemType assembleSingleField(
+      Variational::AssemblyTarget target, bool targeted)
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 fes(mesh);
+    TrialFunction u(fes);
+    TestFunction  v(fes);
+
+    using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
+    typename ProblemType::ProblemBodyType body =
+      Integral(Grad(u), Grad(v)) + Integral(u, v)
+        - Integral(RealFunction(1.0), v);
+
+    ::Rodin::Assembly::ProblemAssemblyInput<
+      typename ProblemType::ProblemBodyType,
+      decltype(u), decltype(v)> input(body, u, v);
+
+    LinearSystemType ls;
+    Assembler<LinearSystemType, ProblemType> assembler;
+    if (targeted)
+      assembler.execute(ls, input, target);
+    else
+      assembler.execute(ls, input);
+    return ls;
+  }
+
+  template <template <class, class> class Assembler>
+  void checkSingleFieldTargeted()
+  {
+    const auto full =
+      assembleSingleField<Assembler>(Variational::AssemblyTarget::LHS, false);
+    const auto lhs =
+      assembleSingleField<Assembler>(Variational::AssemblyTarget::LHS, true);
+    const auto rhs =
+      assembleSingleField<Assembler>(Variational::AssemblyTarget::RHS, true);
+
+    expectSameMatrix(full.getOperator(), lhs.getOperator());
+    expectSameVector(full.getVector(), rhs.getVector());
+  }
+
+  TEST(Eigen_TargetedAssembly, SequentialSingleFieldLHSAndRHS)
+  {
+    checkSingleFieldTargeted<::Rodin::Assembly::Sequential>();
+  }
+
+#if defined(RODIN_USE_OPENMP) && defined(RODIN_TARGETED_OPENMP_READY)
+  TEST(Eigen_TargetedAssembly, OpenMPSingleFieldLHSAndRHS)
+  {
+    checkSingleFieldTargeted<::Rodin::Assembly::OpenMP>();
+  }
+#endif
+}

--- a/tests/manufactured/Rodin/PETSc/CMakeLists.txt
+++ b/tests/manufactured/Rodin/PETSc/CMakeLists.txt
@@ -14,6 +14,22 @@ set_tests_properties(RodinManufacturedPETScPoisson PROPERTIES
 )
 rodin_suppress_external_mpi_lsan_for_test(RodinManufacturedPETScPoisson)
 
+add_executable(RodinManufacturedPETScTargetedAssemblyTest TargetedAssemblyTest.cpp)
+target_link_libraries(RodinManufacturedPETScTargetedAssemblyTest
+  PUBLIC
+  GTest::gtest
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::PETSc)
+add_test(
+  NAME RodinManufacturedPETScTargetedAssemblyTest
+  COMMAND $<TARGET_FILE:RodinManufacturedPETScTargetedAssemblyTest>
+)
+set_tests_properties(RodinManufacturedPETScTargetedAssemblyTest PROPERTIES
+  LABELS "manufactured;petsc"
+)
+rodin_suppress_external_mpi_lsan_for_test(RodinManufacturedPETScTargetedAssemblyTest)
+
 if (RODIN_USE_MPI)
   add_subdirectory(MPI)
 endif()

--- a/tests/manufactured/Rodin/PETSc/MPI/CMakeLists.txt
+++ b/tests/manufactured/Rodin/PETSc/MPI/CMakeLists.txt
@@ -34,3 +34,25 @@ foreach(np 1 2 4)
     RodinManufacturedPETScMPIPoissonTest_np${np}
     "HDF5_USE_FILE_LOCKING=FALSE")
 endforeach()
+
+add_executable(RodinManufacturedPETScMPITargetedAssemblyTest TargetedAssemblyTest.cpp)
+target_link_libraries(RodinManufacturedPETScMPITargetedAssemblyTest
+  PUBLIC
+  GTest::gtest
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::MPI
+  Rodin::PETSc)
+
+foreach(np 1 2 4)
+  add_test(
+    NAME RodinManufacturedPETScMPITargetedAssemblyTest_np${np}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np}
+            ${_RODIN_MPI_OVERSUBSCRIBE_FLAG}
+            $<TARGET_FILE:RodinManufacturedPETScMPITargetedAssemblyTest>)
+  set_tests_properties(RodinManufacturedPETScMPITargetedAssemblyTest_np${np} PROPERTIES
+    LABELS "manufactured;petsc;distributed"
+  )
+  rodin_suppress_external_mpi_lsan_for_test(
+    RodinManufacturedPETScMPITargetedAssemblyTest_np${np})
+endforeach()

--- a/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
@@ -1,0 +1,189 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <cassert>
+
+#include <gtest/gtest.h>
+
+#include <petsc.h>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+
+#include <Rodin/Geometry.h>
+#include <Rodin/Geometry/BalancedCompactPartitioner.h>
+#include <Rodin/Variational.h>
+#include <Rodin/MPI/Context/MPI.h>
+#include <Rodin/MPI/Geometry/Sharder.h>
+#include <Rodin/MPI/Geometry/Mesh.h>
+#include <Rodin/MPI/Variational/P1.h>
+#include <Rodin/PETSc.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+static boost::mpi::environment*  g_env = nullptr;
+static boost::mpi::communicator* g_world = nullptr;
+
+namespace
+{
+  Mesh<Context::Local> makeShardableMesh()
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 5, 5 });
+    const size_t D = mesh.getDimension();
+    mesh.getConnectivity().compute(D, D);
+    mesh.getConnectivity().compute(D, 0);
+    return mesh;
+  }
+
+  Mesh<Context::MPI> distributeFromRoot(const Context::MPI& ctx)
+  {
+    const auto& comm = ctx.getCommunicator();
+    Sharder<Context::MPI> sharder(ctx);
+
+    if (comm.rank() == 0)
+    {
+      auto localMesh = makeShardableMesh();
+      BalancedCompactPartitioner partitioner(localMesh);
+      partitioner.partition(static_cast<size_t>(comm.size()));
+      sharder.shard(partitioner);
+      sharder.scatter(0);
+    }
+
+    return sharder.gather(0);
+  }
+
+  void expectSameOwnedVector(Vec expected, Vec actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt begin = 0;
+    PetscInt end = 0;
+    ierr = VecGetOwnershipRange(expected, &begin, &end);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    PetscInt actualBegin = 0;
+    PetscInt actualEnd = 0;
+    ierr = VecGetOwnershipRange(actual, &actualBegin, &actualEnd);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(begin, actualBegin);
+    ASSERT_EQ(end, actualEnd);
+
+    for (PetscInt i = begin; i < end; i++)
+    {
+      PetscScalar a = 0;
+      PetscScalar b = 0;
+      ierr = VecGetValues(expected, 1, &i, &a);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      ierr = VecGetValues(actual, 1, &i, &b);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "row " << i;
+    }
+  }
+
+  void expectSameOwnedMatrix(Mat expected, Mat actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt expectedRows = 0;
+    PetscInt expectedCols = 0;
+    PetscInt actualRows = 0;
+    PetscInt actualCols = 0;
+    ierr = MatGetSize(expected, &expectedRows, &expectedCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatGetSize(actual, &actualRows, &actualCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(expectedRows, actualRows);
+    ASSERT_EQ(expectedCols, actualCols);
+
+    PetscInt begin = 0;
+    PetscInt end = 0;
+    ierr = MatGetOwnershipRange(expected, &begin, &end);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    PetscInt actualBegin = 0;
+    PetscInt actualEnd = 0;
+    ierr = MatGetOwnershipRange(actual, &actualBegin, &actualEnd);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(begin, actualBegin);
+    ASSERT_EQ(end, actualEnd);
+
+    for (PetscInt i = begin; i < end; i++)
+    {
+      for (PetscInt j = 0; j < expectedCols; j++)
+      {
+        PetscScalar a = 0;
+        PetscScalar b = 0;
+        ierr = MatGetValues(expected, 1, &i, 1, &j, &a);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
+          << "entry (" << i << ", " << j << ")";
+      }
+    }
+  }
+}
+
+namespace Rodin::Tests::Manufactured::PETSc::MPI
+{
+  namespace PETSc = ::Rodin::PETSc;
+
+  TEST(PETSc_MPI_TargetedAssembly, AssemblesLHSAndRHS)
+  {
+    const auto& world = *g_world;
+    if (world.size() > 4)
+      GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
+
+    Context::MPI ctx(*g_env, world);
+    auto mesh = distributeFromRoot(ctx);
+
+    P1<Real, Mesh<Context::MPI>> fullFES(mesh);
+    PETSc::Variational::TrialFunction uFull(fullFES);
+    PETSc::Variational::TestFunction  vFull(fullFES);
+    Problem full(uFull, vFull);
+    full = Integral(uFull, vFull) - Integral(RealFunction(1.0), vFull);
+    full.assemble();
+
+    P1<Real, Mesh<Context::MPI>> lhsFES(mesh);
+    PETSc::Variational::TrialFunction uLHS(lhsFES);
+    PETSc::Variational::TestFunction  vLHS(lhsFES);
+    Problem lhs(uLHS, vLHS);
+    lhs = Integral(uLHS, vLHS) - Integral(RealFunction(1.0), vLHS);
+    lhs.assemble(Variational::AssemblyTarget::LHS);
+
+    P1<Real, Mesh<Context::MPI>> rhsFES(mesh);
+    PETSc::Variational::TrialFunction uRHS(rhsFES);
+    PETSc::Variational::TestFunction  vRHS(rhsFES);
+    Problem rhs(uRHS, vRHS);
+    rhs = Integral(uRHS, vRHS) - Integral(RealFunction(1.0), vRHS);
+    rhs.assemble(Variational::AssemblyTarget::RHS);
+
+    expectSameOwnedMatrix(
+        full.getLinearSystem().getOperator(),
+        lhs.getLinearSystem().getOperator());
+    expectSameOwnedVector(
+        full.getLinearSystem().getVector(),
+        rhs.getLinearSystem().getVector());
+  }
+}
+
+int main(int argc, char** argv)
+{
+  boost::mpi::environment env(argc, argv);
+  boost::mpi::communicator world;
+  g_env = &env;
+  g_world = &world;
+
+  [[maybe_unused]] PetscErrorCode ierr =
+    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  assert(ierr == PETSC_SUCCESS);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+
+  PetscFinalize();
+  return result;
+}

--- a/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
@@ -1,0 +1,147 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <cassert>
+
+#include <gtest/gtest.h>
+
+#include <petsc.h>
+
+#include <Rodin/Assembly.h>
+#include <Rodin/Configure.h>
+#include <Rodin/Geometry.h>
+#include <Rodin/PETSc.h>
+#include <Rodin/Variational.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace
+{
+  template <template <class, class> class Assembler>
+  PETSc::Math::LinearSystem assembleLocal(
+      Variational::AssemblyTarget target,
+      bool targeted)
+  {
+    auto mesh =
+      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 3, 3 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 fes(mesh);
+    PETSc::Variational::TrialFunction u(fes);
+    PETSc::Variational::TestFunction  v(fes);
+
+    using LinearSystemType = PETSc::Math::LinearSystem;
+    using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
+    typename ProblemType::ProblemBodyType body =
+      Integral(u, v) - Integral(RealFunction(1.0), v);
+
+    Assembly::ProblemAssemblyInput<
+      typename ProblemType::ProblemBodyType,
+      decltype(u), decltype(v)> input(body, u, v);
+
+    LinearSystemType ls(PETSC_COMM_SELF);
+    Assembler<LinearSystemType, ProblemType> assembler;
+    if (targeted)
+      assembler.execute(ls, input, target);
+    else
+      assembler.execute(ls, input);
+    return ls;
+  }
+
+  void expectSameVector(Vec expected, Vec actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt nExpected = 0;
+    PetscInt nActual = 0;
+    ierr = VecGetSize(expected, &nExpected);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecGetSize(actual, &nActual);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(nExpected, nActual);
+
+    for (PetscInt i = 0; i < nExpected; i++)
+    {
+      PetscScalar a = 0;
+      PetscScalar b = 0;
+      ierr = VecGetValues(expected, 1, &i, &a);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      ierr = VecGetValues(actual, 1, &i, &b);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "row " << i;
+    }
+  }
+
+  void expectSameMatrix(Mat expected, Mat actual)
+  {
+    PetscErrorCode ierr;
+    PetscInt expectedRows = 0;
+    PetscInt expectedCols = 0;
+    PetscInt actualRows = 0;
+    PetscInt actualCols = 0;
+    ierr = MatGetSize(expected, &expectedRows, &expectedCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatGetSize(actual, &actualRows, &actualCols);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ASSERT_EQ(expectedRows, actualRows);
+    ASSERT_EQ(expectedCols, actualCols);
+
+    for (PetscInt i = 0; i < expectedRows; i++)
+    {
+      for (PetscInt j = 0; j < expectedCols; j++)
+      {
+        PetscScalar a = 0;
+        PetscScalar b = 0;
+        ierr = MatGetValues(expected, 1, &i, 1, &j, &a);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
+          << "entry (" << i << ", " << j << ")";
+      }
+    }
+  }
+
+  template <template <class, class> class Assembler>
+  void checkLocalBackendTargetedAssembly()
+  {
+    auto full = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::LHS, false);
+    auto lhs = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::LHS, true);
+    auto rhs = assembleLocal<Assembler>(
+        Variational::AssemblyTarget::RHS, true);
+
+    expectSameMatrix(full.getOperator(), lhs.getOperator());
+    expectSameVector(full.getVector(), rhs.getVector());
+  }
+
+  TEST(PETSc_TargetedAssembly, SequentialBackendAssemblesLHSAndRHS)
+  {
+    checkLocalBackendTargetedAssembly<Assembly::Sequential>();
+  }
+
+#ifdef RODIN_USE_OPENMP
+  TEST(PETSc_TargetedAssembly, OpenMPBackendAssemblesLHSAndRHS)
+  {
+    checkLocalBackendTargetedAssembly<Assembly::OpenMP>();
+  }
+#endif
+}
+
+int main(int argc, char** argv)
+{
+  [[maybe_unused]] PetscErrorCode ierr =
+    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  assert(ierr == PETSC_SUCCESS);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+
+  PetscFinalize();
+  return result;
+}


### PR DESCRIPTION
## Summary

Gives **full backend coverage** of targeted (LHS-only / RHS-only) assembly, callable from tests on every backend, plus regression tests. Supersedes #300 (which covered only the PETSc backends).

Targeted assembly lets a solver assemble just the operator (`AssemblyTarget::LHS`) or just the right-hand side (`AssemblyTarget::RHS`). It is used in production by the PETSc `SNES` Newton path; this PR makes it **callable and tested on all backends**, including the Eigen-backed ones (which nothing calls in production yet, but which we want covered).

## What changed

**Eigen / core backends — new `execute(axb, input, AssemblyTarget)` overloads:**
- **Sequential single-field**: true selective assembly — `doMatrix`/`doVector` gating, identification Dirichlet BCs rejected in targeted mode, Full/LHS/RHS finalize (mirrors the PETSc backends).
- **OpenMP single-field, Sequential block, OpenMP block**: assemble the full system into a scratch object and expose only the requested side, leaving the other operand untouched (the targeted contract). This keeps the intricate parallel/block Dirichlet-BC elimination in one code path instead of duplicating a gated variant four times.
- Wired both single-field and block `Problem::assemble(AssemblyTarget)` overrides (previously threw "not implemented").

## Tests

New manufactured regression tests (BC-free, so targeted/full equivalence is exact):
- `tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp` — Eigen Sequential single-field, OpenMP single-field, and two-field block.
- PETSc Sequential, OpenMP, and MPI targeted tests (carried over from #300).

Each asserts that targeted **LHS reproduces the full operator** and targeted **RHS reproduces the full vector**.

All pass locally:

| Backend | single-field | block |
|---|---|---|
| Eigen Sequential | ✅ | ✅ (via Default) |
| Eigen OpenMP | ✅ | ✅ (via Default) |
| PETSc Sequential | ✅ | — |
| PETSc OpenMP | ✅ | — |
| PETSc MPI | ✅ (2 ranks) | — |

## Note on the Eigen contract

For the parallel and block Eigen backends, "targeted" means *the requested operand is produced and the other is preserved* — they do not skip the bilinear/linear compute the way the PETSc backends do. Eigen targeting is for coverage/parity (no production caller), so correctness + the preserve-other-side contract were prioritized over compute savings. Happy to convert these to fully-gated variants if you'd prefer exact stylistic parity with PETSc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
