### PR TITLE
Unify preassembled-form handling across PETSc assembly backends

### DIFF
--- a/src/Rodin/Assembly/ConstraintMap.h
+++ b/src/Rodin/Assembly/ConstraintMap.h
@@ -85,6 +85,16 @@ namespace Rodin::Assembly
             && m_isIdentified[static_cast<size_t>(i)];
       }
 
+      /// @brief Returns true if any DOF carries a fixed (value Dirichlet)
+      /// constraint.
+      bool hasFixed() const
+      {
+        for (const auto& f : m_fixed)
+          if (f.has_value())
+            return true;
+        return false;
+      }
+
       Scalar getFixedValue(Index i) const
       {
         assert(isFixed(i));

--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -631,11 +631,15 @@ namespace Rodin::Assembly
           // Without identification constraints the operators share A's
           // row/column layout and introduce no right-hand-side coupling, so
           // they are merged directly with MatAXPY once A is assembled.
-          // Identification constraints couple eliminated columns into b and
-          // therefore require the generic per-entry expansion path below.
+          // Identification constraints couple eliminated columns into b, and
+          // fixed (value Dirichlet) constraints are eliminated afterwards with
+          // MatZeroRowsColumns, which requires the per-entry matrix state to
+          // hold the diagonal entries it overwrites; both therefore require the
+          // generic per-entry expansion path below.
           if (!pb.getBFs().empty())
           {
-            bool merge = constraints.getIdentifiedRows().empty();
+            bool merge =
+              constraints.getIdentifiedRows().empty() && !constraints.hasFixed();
             if (merge)
             {
               for (auto& bf : pb.getBFs())

--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -626,24 +626,57 @@ namespace Rodin::Assembly
             }
           }
 
-          // Preassembled bilinear forms
-          for (auto& bf : pb.getBFs())
+          // Preassembled bilinear forms.
+          //
+          // Without identification constraints the operators share A's
+          // row/column layout and introduce no right-hand-side coupling, so
+          // they are merged directly with MatAXPY once A is assembled.
+          // Identification constraints couple eliminated columns into b and
+          // therefore require the generic per-entry expansion path below.
+          if (!pb.getBFs().empty())
           {
-            const auto& op = bf.getOperator();
-            PetscInt opStart, opEnd;
-            ierr = MatGetOwnershipRange(op, &opStart, &opEnd);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt i = opStart; i < opEnd; ++i)
+            bool merge = constraints.getIdentifiedRows().empty();
+            if (merge)
             {
-              PetscInt nc;
-              const PetscInt* cols;
-              const PetscScalar* vals;
-              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              for (auto& bf : pb.getBFs())
+                if (!PETSc::Assembly::canMergeOperator(A, bf.getOperator()))
+                { merge = false; break; }
+            }
+
+            if (merge)
+            {
+              ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
               assert(ierr == PETSC_SUCCESS);
-              for (PetscInt j = 0; j < nc; ++j)
-                matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
-              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
               assert(ierr == PETSC_SUCCESS);
+              for (auto& bf : pb.getBFs())
+              {
+                ierr = MatAXPY(
+                    A, PetscScalar(1), bf.getOperator(), DIFFERENT_NONZERO_PATTERN);
+                assert(ierr == PETSC_SUCCESS);
+              }
+            }
+            else
+            {
+              for (auto& bf : pb.getBFs())
+              {
+                const auto& op = bf.getOperator();
+                PetscInt opStart, opEnd;
+                ierr = MatGetOwnershipRange(op, &opStart, &opEnd);
+                assert(ierr == PETSC_SUCCESS);
+                for (PetscInt i = opStart; i < opEnd; ++i)
+                {
+                  PetscInt nc;
+                  const PetscInt* cols;
+                  const PetscScalar* vals;
+                  ierr = MatGetRow(op, i, &nc, &cols, &vals);
+                  assert(ierr == PETSC_SUCCESS);
+                  for (PetscInt j = 0; j < nc; ++j)
+                    matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
+                  ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+                  assert(ierr == PETSC_SUCCESS);
+                }
+              }
             }
           }
         }

--- a/src/Rodin/PETSc/Assembly/MatrixSetup.h
+++ b/src/Rodin/PETSc/Assembly/MatrixSetup.h
@@ -12,6 +12,35 @@
 namespace Rodin::PETSc::Assembly
 {
   /**
+   * @brief Tests whether a preassembled operator can be merged into the system
+   *        matrix with a single @c MatAXPY.
+   *
+   * @c MatAXPY(A, 1, op) requires @c op and @c A to share both their global
+   * dimensions and, in the distributed case, their local row ownership range.
+   * When that holds the preassembled operator can be added in one collective
+   * call instead of being scattered entry by entry. Multi-variable (block
+   * offset) assembly places @c op as a sub-block of @c A, so the dimensions
+   * differ and this returns @c false, selecting the generic per-entry path.
+   *
+   * The check is conservative: any failure or mismatch yields @c false, which
+   * is always safe because the per-entry fallback handles every case.
+   */
+  inline bool canMergeOperator(::Mat A, ::Mat op)
+  {
+    PetscInt aLo = 0, aHi = 0, oLo = 0, oHi = 0;
+    PetscInt aRows = 0, aCols = 0, oRows = 0, oCols = 0;
+    if (MatGetOwnershipRange(A, &aLo, &aHi) != PETSC_SUCCESS)
+      return false;
+    if (MatGetOwnershipRange(op, &oLo, &oHi) != PETSC_SUCCESS)
+      return false;
+    if (MatGetSize(A, &aRows, &aCols) != PETSC_SUCCESS)
+      return false;
+    if (MatGetSize(op, &oRows, &oCols) != PETSC_SUCCESS)
+      return false;
+    return aLo == oLo && aHi == oHi && aRows == oRows && aCols == oCols;
+  }
+
+  /**
    * @brief Sets up a PETSc matrix for assembly while reusing compatible
    *        existing structure.
    *

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -793,11 +793,15 @@ namespace Rodin::Assembly
           // Without identification constraints the operators share A's
           // row/column layout and introduce no right-hand-side coupling, so
           // they are merged directly with MatAXPY once A is assembled.
-          // Identification constraints couple eliminated columns into b and
-          // therefore require the generic per-entry expansion path below.
+          // Identification constraints couple eliminated columns into b, and
+          // fixed (value Dirichlet) constraints are eliminated afterwards with
+          // MatZeroRowsColumns, which requires the per-entry matrix state to
+          // hold the diagonal entries it overwrites; both therefore require the
+          // generic per-entry expansion path below.
           if (!pb.getBFs().empty())
           {
-            bool merge = constraints.getIdentifiedRows().empty();
+            bool merge =
+              constraints.getIdentifiedRows().empty() && !constraints.hasFixed();
             if (merge)
             {
               for (auto& bf : pb.getBFs())

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -788,50 +788,86 @@ namespace Rodin::Assembly
             } // omp parallel
           }
 
-          // Preassembled bilinear forms (serial)
-          for (auto& bf : pb.getBFs())
+          // Preassembled bilinear forms (serial).
+          //
+          // Without identification constraints the operators share A's
+          // row/column layout and introduce no right-hand-side coupling, so
+          // they are merged directly with MatAXPY once A is assembled.
+          // Identification constraints couple eliminated columns into b and
+          // therefore require the generic per-entry expansion path below.
+          if (!pb.getBFs().empty())
           {
-            const auto& op = bf.getOperator();
-            PetscInt rStart, rEnd;
-            ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt i = rStart; i < rEnd; ++i)
+            bool merge = constraints.getIdentifiedRows().empty();
+            if (merge)
             {
-              PetscInt nc;
-              const PetscInt* cols;
-              const PetscScalar* vals;
-              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              for (auto& bf : pb.getBFs())
+                if (!PETSc::Assembly::canMergeOperator(A, bf.getOperator()))
+                { merge = false; break; }
+            }
+
+            if (merge)
+            {
+              ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
               assert(ierr == PETSC_SUCCESS);
-              for (PetscInt j = 0; j < nc; ++j)
+              ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+              assert(ierr == PETSC_SUCCESS);
+              for (auto& bf : pb.getBFs())
               {
-                std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
-                std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
-                add_matrix_entries(
-                    local,
-                    localRhs,
-                    static_cast<Index>(i),
-                    static_cast<Index>(cols[j]),
-                    vals[j]);
-                for (const auto& [I, J, val] : local)
+                ierr = MatAXPY(
+                    A, PetscScalar(1), bf.getOperator(), DIFFERENT_NONZERO_PATTERN);
+                assert(ierr == PETSC_SUCCESS);
+              }
+            }
+            else
+            {
+              std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
+              local.reserve(16);
+              std::vector<PetscScalar> localRhs(
+                  static_cast<size_t>(nrows), PetscScalar(0));
+              for (auto& bf : pb.getBFs())
+              {
+                const auto& op = bf.getOperator();
+                PetscInt rStart, rEnd;
+                ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
+                assert(ierr == PETSC_SUCCESS);
+                for (PetscInt i = rStart; i < rEnd; ++i)
                 {
-                  ierr = MatSetValue(A, I, J, val, ADD_VALUES);
+                  PetscInt nc;
+                  const PetscInt* cols;
+                  const PetscScalar* vals;
+                  ierr = MatGetRow(op, i, &nc, &cols, &vals);
                   assert(ierr == PETSC_SUCCESS);
-                }
-                if (doVector)
-                {
-                  for (PetscInt r = 0; r < nrows; ++r)
+                  for (PetscInt j = 0; j < nc; ++j)
                   {
-                    const PetscScalar val = localRhs[static_cast<size_t>(r)];
-                    if (val != PetscScalar(0))
+                    local.clear();
+                    add_matrix_entries(
+                        local,
+                        localRhs,
+                        static_cast<Index>(i),
+                        static_cast<Index>(cols[j]),
+                        vals[j]);
+                    for (const auto& [I, J, val] : local)
                     {
-                      ierr = VecSetValue(b, r, val, ADD_VALUES);
+                      ierr = MatSetValue(A, I, J, val, ADD_VALUES);
                       assert(ierr == PETSC_SUCCESS);
                     }
                   }
+                  ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+                  assert(ierr == PETSC_SUCCESS);
                 }
               }
-              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-              assert(ierr == PETSC_SUCCESS);
+              if (doVector)
+              {
+                for (PetscInt r = 0; r < nrows; ++r)
+                {
+                  const PetscScalar val = localRhs[static_cast<size_t>(r)];
+                  if (val != PetscScalar(0))
+                  {
+                    ierr = VecSetValue(b, r, val, ADD_VALUES);
+                    assert(ierr == PETSC_SUCCESS);
+                  }
+                }
+              }
             }
           }
         }
@@ -913,31 +949,34 @@ namespace Rodin::Assembly
           }
 
           // Preassembled linear forms (serial) : b += LF
-          for (auto& lf : pb.getLFs())
+          // The accumulation buffer is allocated once and reused; nonzero
+          // contributions are scattered into b after each operator.
           {
-            const auto& vec = lf.getVector();
-            PetscInt vecSize;
-            ierr = VecGetSize(vec, &vecSize);
-            assert(ierr == PETSC_SUCCESS);
-            const PetscScalar* arr;
-            ierr = VecGetArrayRead(vec, &arr);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt i = 0; i < vecSize; ++i)
+            std::vector<PetscScalar> local(
+                static_cast<size_t>(nrows), PetscScalar(0));
+            for (auto& lf : pb.getLFs())
             {
-              std::vector<PetscScalar> local(static_cast<size_t>(nrows), PetscScalar(0));
-              add_vector_entries(local, static_cast<Index>(i), arr[i]);
-              for (PetscInt r = 0; r < nrows; ++r)
+              const auto& vec = lf.getVector();
+              PetscInt vecSize;
+              ierr = VecGetSize(vec, &vecSize);
+              assert(ierr == PETSC_SUCCESS);
+              const PetscScalar* arr;
+              ierr = VecGetArrayRead(vec, &arr);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt i = 0; i < vecSize; ++i)
+                add_vector_entries(local, static_cast<Index>(i), arr[i]);
+              ierr = VecRestoreArrayRead(vec, &arr);
+              assert(ierr == PETSC_SUCCESS);
+            }
+            for (PetscInt r = 0; r < nrows; ++r)
+            {
+              const PetscScalar val = local[static_cast<size_t>(r)];
+              if (val != PetscScalar(0))
               {
-                const PetscScalar val = local[static_cast<size_t>(r)];
-                if (val != PetscScalar(0))
-                {
-                  ierr = VecSetValue(b, r, val, ADD_VALUES);
-                  assert(ierr == PETSC_SUCCESS);
-                }
+                ierr = VecSetValue(b, r, val, ADD_VALUES);
+                assert(ierr == PETSC_SUCCESS);
               }
             }
-            ierr = VecRestoreArrayRead(vec, &arr);
-            assert(ierr == PETSC_SUCCESS);
           }
         }
 
@@ -1640,57 +1679,68 @@ namespace Rodin::Assembly
           } // omp parallel
         }
 
-        // Preassembled bilinear forms (serial, with block offsets)
-        for (auto& bf : pb.getBFs())
+        // Preassembled bilinear forms (serial, with block offsets).
+        //
+        // The operator is placed as a sub-block of A at (vOff, uOff), so it
+        // does not share A's dimensions and cannot be merged with MatAXPY; the
+        // generic per-entry expansion path is used. Buffers are allocated once
+        // and reused across rows, and right-hand-side contributions (only
+        // nonzero under identification constraints) are scattered once.
         {
-          const auto uUUID = bf.getTrialFunction().getUUID();
-          const auto vUUID = bf.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& op = bf.getOperator();
-          PetscInt opRows, opCols;
-          ierr = MatGetSize(op, &opRows, &opCols);
-          assert(ierr == PETSC_SUCCESS);
-
-          for (PetscInt i = 0; i < opRows; ++i)
+          std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
+          local.reserve(16);
+          std::vector<PetscScalar> localRhs(
+              static_cast<size_t>(nrows), PetscScalar(0));
+          for (auto& bf : pb.getBFs())
           {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
+            const auto uUUID = bf.getTrialFunction().getUUID();
+            const auto vUUID = bf.getTestFunction().getUUID();
+
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& op = bf.getOperator();
+            PetscInt opRows, opCols;
+            ierr = MatGetSize(op, &opRows, &opCols);
             assert(ierr == PETSC_SUCCESS);
-            for (PetscInt j = 0; j < nc; ++j)
+
+            for (PetscInt i = 0; i < opRows; ++i)
             {
-              std::vector<std::tuple<PetscInt,PetscInt,PetscScalar>> local;
-              std::vector<PetscScalar> localRhs(static_cast<size_t>(nrows), PetscScalar(0));
-              add_matrix_entries(
-                  local,
-                  localRhs,
-                  static_cast<Index>(vOff) + static_cast<Index>(i),
-                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
-                  vals[j]);
-              for (const auto& [I, J, val] : local)
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              for (PetscInt j = 0; j < nc; ++j)
               {
-                ierr = MatSetValue(A, I, J, val, ADD_VALUES);
-                assert(ierr == PETSC_SUCCESS);
-              }
-              for (PetscInt r = 0; r < nrows; ++r)
-              {
-                const PetscScalar val = localRhs[static_cast<size_t>(r)];
-                if (val != PetscScalar(0))
+                local.clear();
+                add_matrix_entries(
+                    local,
+                    localRhs,
+                    static_cast<Index>(vOff) + static_cast<Index>(i),
+                    static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
+                    vals[j]);
+                for (const auto& [I, J, val] : local)
                 {
-                  ierr = VecSetValue(b, r, val, ADD_VALUES);
+                  ierr = MatSetValue(A, I, J, val, ADD_VALUES);
                   assert(ierr == PETSC_SUCCESS);
                 }
               }
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
             }
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
+          }
+          for (PetscInt r = 0; r < nrows; ++r)
+          {
+            const PetscScalar val = localRhs[static_cast<size_t>(r)];
+            if (val != PetscScalar(0))
+            {
+              ierr = VecSetValue(b, r, val, ADD_VALUES);
+              assert(ierr == PETSC_SUCCESS);
+            }
           }
         }
 
@@ -1775,43 +1825,43 @@ namespace Rodin::Assembly
           } // omp parallel
         }
 
-        // Preassembled linear forms (serial, with block offsets)
-        for (auto& lf : pb.getLFs())
+        // Preassembled linear forms (serial, with block offsets).
+        // The accumulation buffer is allocated once and reused across
+        // operators; nonzero contributions are scattered into b at the end.
         {
-          const auto vUUID = lf.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
-
-          const auto& vec = lf.getVector();
-          PetscInt vecSize;
-          ierr = VecGetSize(vec, &vecSize);
-          assert(ierr == PETSC_SUCCESS);
-
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          for (PetscInt i = 0; i < vecSize; ++i)
+          std::vector<PetscScalar> local(
+              static_cast<size_t>(nrows), PetscScalar(0));
+          for (auto& lf : pb.getLFs())
           {
-            if (arr[i] != PetscScalar(0))
-            {
-              std::vector<PetscScalar> local(nrows, PetscScalar(0));
+            const auto vUUID = lf.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff   = testOffsets[vBlock];
+
+            const auto& vec = lf.getVector();
+            PetscInt vecSize;
+            ierr = VecGetSize(vec, &vecSize);
+            assert(ierr == PETSC_SUCCESS);
+
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            for (PetscInt i = 0; i < vecSize; ++i)
               add_vector_entries(
                   local,
                   static_cast<Index>(vOff) + static_cast<Index>(i),
                   arr[i]);
-              for (PetscInt r = 0; r < static_cast<PetscInt>(nrows); r++)
-              {
-                const PetscScalar val = local[static_cast<size_t>(r)];
-                if (val != PetscScalar(0))
-                {
-                  ierr = VecSetValue(b, r, val, ADD_VALUES);
-                  assert(ierr == PETSC_SUCCESS);
-                }
-              }
+            ierr = VecRestoreArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+          }
+          for (PetscInt r = 0; r < static_cast<PetscInt>(nrows); r++)
+          {
+            const PetscScalar val = local[static_cast<size_t>(r)];
+            if (val != PetscScalar(0))
+            {
+              ierr = VecSetValue(b, r, val, ADD_VALUES);
+              assert(ierr == PETSC_SUCCESS);
             }
           }
-          ierr = VecRestoreArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
         }
 
         // Assemble b

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -584,11 +584,15 @@ namespace Rodin::Assembly
           // Without identification constraints the operators share A's
           // row/column layout and introduce no right-hand-side coupling, so
           // they are merged directly with MatAXPY once A is assembled.
-          // Identification constraints couple eliminated columns into b and
-          // therefore require the generic per-entry expansion path below.
+          // Identification constraints couple eliminated columns into b, and
+          // fixed (value Dirichlet) constraints are eliminated afterwards with
+          // MatZeroRowsColumns, which requires the per-entry matrix state to
+          // hold the diagonal entries it overwrites; both therefore require the
+          // generic per-entry expansion path below.
           if (!pb.getBFs().empty())
           {
-            bool merge = constraints.getIdentifiedRows().empty();
+            bool merge =
+              constraints.getIdentifiedRows().empty() && !constraints.hasFixed();
             if (merge)
             {
               for (auto& bf : pb.getBFs())

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -579,24 +579,57 @@ namespace Rodin::Assembly
             }
           }
 
-          // Preassembled bilinear forms
-          for (auto& bf : pb.getBFs())
+          // Preassembled bilinear forms.
+          //
+          // Without identification constraints the operators share A's
+          // row/column layout and introduce no right-hand-side coupling, so
+          // they are merged directly with MatAXPY once A is assembled.
+          // Identification constraints couple eliminated columns into b and
+          // therefore require the generic per-entry expansion path below.
+          if (!pb.getBFs().empty())
           {
-            const auto& op = bf.getOperator();
-            PetscInt rStart, rEnd;
-            ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
-            assert(ierr == PETSC_SUCCESS);
-            for (PetscInt i = rStart; i < rEnd; ++i)
+            bool merge = constraints.getIdentifiedRows().empty();
+            if (merge)
             {
-              PetscInt nc;
-              const PetscInt* cols;
-              const PetscScalar* vals;
-              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              for (auto& bf : pb.getBFs())
+                if (!PETSc::Assembly::canMergeOperator(A, bf.getOperator()))
+                { merge = false; break; }
+            }
+
+            if (merge)
+            {
+              ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
               assert(ierr == PETSC_SUCCESS);
-              for (PetscInt j = 0; j < nc; ++j)
-                matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
-              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
               assert(ierr == PETSC_SUCCESS);
+              for (auto& bf : pb.getBFs())
+              {
+                ierr = MatAXPY(
+                    A, PetscScalar(1), bf.getOperator(), DIFFERENT_NONZERO_PATTERN);
+                assert(ierr == PETSC_SUCCESS);
+              }
+            }
+            else
+            {
+              for (auto& bf : pb.getBFs())
+              {
+                const auto& op = bf.getOperator();
+                PetscInt rStart, rEnd;
+                ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
+                assert(ierr == PETSC_SUCCESS);
+                for (PetscInt i = rStart; i < rEnd; ++i)
+                {
+                  PetscInt nc;
+                  const PetscInt* cols;
+                  const PetscScalar* vals;
+                  ierr = MatGetRow(op, i, &nc, &cols, &vals);
+                  assert(ierr == PETSC_SUCCESS);
+                  for (PetscInt j = 0; j < nc; ++j)
+                    matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
+                  ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+                  assert(ierr == PETSC_SUCCESS);
+                }
+              }
             }
           }
         }

--- a/tests/unit/Rodin/PETSc/FormTest.cpp
+++ b/tests/unit/Rodin/PETSc/FormTest.cpp
@@ -450,6 +450,107 @@ namespace
     }
   }
 
+  // Exercises the preassembled-operator fast path. A single-variable problem
+  // with no identification constraints merges its preassembled operator into
+  // the system matrix with a single MatAXPY (see canMergeOperator). The
+  // assembled matrix must equal the operator entry for entry and, with a zero
+  // load, the right-hand side must vanish. This complements the identification
+  // tests, which exercise the generic per-entry fallback path.
+  template <template <class, class> class Assembler>
+  void checkPETScPreassembledOperatorMerge()
+  {
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 fes(mesh);
+    PETSc::Variational::TrialFunction u(fes);
+    PETSc::Variational::TestFunction  v(fes);
+
+    const PetscInt n = static_cast<PetscInt>(fes.getSize());
+    ASSERT_GE(n, 2);
+
+    BilinearForm uu(u, v);
+    auto& op = uu.getOperator();
+    PetscErrorCode ierr = MatSetSizes(op, n, n, n, n);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatSetFromOptions(op);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatSetUp(op);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    for (PetscInt i = 0; i < n; ++i)
+    {
+      ierr = MatSetValue(op, i, i, static_cast<PetscScalar>(i + 1), INSERT_VALUES);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+    }
+    ierr = MatSetValue(op, 0, 1, 3.0, INSERT_VALUES);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatSetValue(op, 1, 0, 5.0, INSERT_VALUES);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatAssemblyBegin(op, MAT_FINAL_ASSEMBLY);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatAssemblyEnd(op, MAT_FINAL_ASSEMBLY);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    LinearForm zero(v);
+    auto& zeroVec = zero.getVector();
+    ierr = VecSetSizes(zeroVec, n, n);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecSetFromOptions(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecSetUp(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecZeroEntries(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecAssemblyBegin(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecAssemblyEnd(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    // A single preassembled operator with no identification constraints and a
+    // zero load. The zero-integrand linear form turns the BilinearForm into a
+    // ProblemBody, and the preassembled zero vector introduces the vector type
+    // (matching the identification helpers). The merge path must reproduce op
+    // exactly and leave b at zero.
+    auto body = uu - Integral(RealFunction(0.0), v) - zero;
+
+    using LinearSystemType = PETSc::Math::LinearSystem;
+    using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
+
+    Assembly::ProblemAssemblyInput<
+      std::decay_t<decltype(body)>, decltype(u), decltype(v)> input(body, u, v);
+
+    LinearSystemType ls(PETSC_COMM_SELF);
+    Assembler<LinearSystemType, ProblemType> assembler;
+    assembler.execute(ls, input);
+
+    auto& A = ls.getOperator();
+    auto& b = ls.getVector();
+
+    for (PetscInt i = 0; i < n; ++i)
+    {
+      PetscScalar value = 0;
+      ierr = VecGetValues(b, 1, &i, &value);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_NEAR(value, 0.0, 1e-14) << "rhs row " << i;
+
+      for (PetscInt j = 0; j < n; ++j)
+      {
+        PetscScalar expected = 0.0;
+        if (i == j)
+          expected = static_cast<PetscScalar>(i + 1);
+        if (i == 0 && j == 1)
+          expected = 3.0;
+        if (i == 1 && j == 0)
+          expected = 5.0;
+
+        ierr = MatGetValues(A, 1, &i, 1, &j, &value);
+        ASSERT_EQ(ierr, PETSC_SUCCESS);
+        EXPECT_NEAR(value, expected, 1e-14)
+          << "entry (" << i << ", " << j << ")";
+      }
+    }
+  }
+
   TEST(PETSc_Form, SequentialLinearFormUsesSelfCommunicatorAndAssembles)
   {
     auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 3, 3 });
@@ -633,6 +734,11 @@ namespace
     checkPETScSelfIdentificationMatchesZeroValueConstraint<PETSc::Assembly::Sequential>();
   }
 
+  TEST(PETSc_Form, SequentialPreassembledOperatorMerge)
+  {
+    checkPETScPreassembledOperatorMerge<PETSc::Assembly::Sequential>();
+  }
+
 #ifdef RODIN_USE_OPENMP
   TEST(PETSc_Form, OpenMPVectorMasterIdentificationProjectsMatrixAndVector)
   {
@@ -647,6 +753,11 @@ namespace
   TEST(PETSc_Form, OpenMPSelfIdentificationMatchesZeroValueConstraint)
   {
     checkPETScSelfIdentificationMatchesZeroValueConstraint<PETSc::Assembly::OpenMP>();
+  }
+
+  TEST(PETSc_Form, OpenMPPreassembledOperatorMerge)
+  {
+    checkPETScPreassembledOperatorMerge<PETSc::Assembly::OpenMP>();
   }
 #endif
 }

--- a/tests/unit/Rodin/PETSc/MPIFormTest.cpp
+++ b/tests/unit/Rodin/PETSc/MPIFormTest.cpp
@@ -464,6 +464,83 @@ namespace
     (void) masterBegin;
     (void) masterEnd;
   }
+
+  // Distributed counterpart of the single-variable preassembled-operator merge.
+  // With no identification constraints the MPI backend merges the preassembled
+  // operator into the system matrix with MatAXPY (canMergeOperator holds, as op
+  // shares the FES row layout). Each rank checks its owned diagonal entries and
+  // a zero right-hand side.
+  TEST(PETSc_MPI_Form, DistributedPreassembledOperatorMerge)
+  {
+    const auto& world = *g_world;
+    Context::MPI ctx(*g_env, world);
+    auto mesh = distributeFromRoot(ctx);
+    P1 fes(mesh);
+    PETSc::Variational::TrialFunction u(fes);
+    PETSc::Variational::TestFunction  v(fes);
+
+    const PetscInt n = static_cast<PetscInt>(fes.getSize());
+    size_t begin = 0;
+    size_t end = 0;
+    fes.getOwnershipRange(begin, end);
+    const PetscInt localSize = static_cast<PetscInt>(end - begin);
+
+    BilinearForm uu(u, v);
+    auto& op = uu.getOperator();
+    PetscErrorCode ierr = MatSetSizes(op, localSize, localSize, n, n);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatSetFromOptions(op);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatSetUp(op);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    for (PetscInt i = static_cast<PetscInt>(begin);
+         i < static_cast<PetscInt>(end); ++i)
+    {
+      ierr = MatSetValue(op, i, i, static_cast<PetscScalar>(i + 1), INSERT_VALUES);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+    }
+    ierr = MatAssemblyBegin(op, MAT_FINAL_ASSEMBLY);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = MatAssemblyEnd(op, MAT_FINAL_ASSEMBLY);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    LinearForm zero(v);
+    auto& zeroVec = zero.getVector();
+    ierr = VecSetSizes(zeroVec, localSize, n);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecSetFromOptions(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecSetUp(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecZeroEntries(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecAssemblyBegin(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+    ierr = VecAssemblyEnd(zeroVec);
+    ASSERT_EQ(ierr, PETSC_SUCCESS);
+
+    Problem problem(u, v);
+    problem = uu - Integral(RealFunction(0.0), v) - zero;
+    problem.assemble();
+
+    auto& A = problem.getLinearSystem().getOperator();
+    auto& b = problem.getLinearSystem().getVector();
+
+    for (PetscInt i = static_cast<PetscInt>(begin);
+         i < static_cast<PetscInt>(end); ++i)
+    {
+      PetscInt col = i;
+      PetscScalar value = 0;
+      ierr = MatGetValues(A, 1, &i, 1, &col, &value);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_NEAR(value, static_cast<PetscScalar>(i + 1), 1e-14)
+        << "diagonal row " << i;
+
+      ierr = VecGetValues(b, 1, &i, &value);
+      ASSERT_EQ(ierr, PETSC_SUCCESS);
+      EXPECT_NEAR(value, 0.0, 1e-14) << "rhs row " << i;
+    }
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary

The Sequential, MPI, and OpenMP PETSc assembly backends handled preassembled bilinear/linear forms inconsistently. None used a fast merge path, and the OpenMP backend reallocated an `nrows`-sized buffer **per matrix/vector entry** (an O(nnz·nrows) allocation pathology). This PR makes the preassembled-form handling uniform across all three backends, in both the single-variable and multi-variable (block-offset) assembly paths.

## Changes

- **Shared `canMergeOperator()` helper** (`MatrixSetup.h`, included by all three backends). In the single-variable path, when there are no identification constraints, the preassembled operators share `A`'s layout and introduce no right-hand-side coupling, so they are merged with a single `MatAXPY` after assembling `A` — instead of being scattered entry by entry via `MatGetRow`. The check is conservative (global size + local row ownership range); any mismatch falls back to the generic per-entry path, which already handles every case (identification constraints, layout differences).
- **Block-offset (multi-variable) paths** cannot use `MatAXPY` because the operator is placed as a sub-block of `A`. They keep the per-entry expansion path but now allocate accumulation buffers **once** and scatter the RHS in a **single** pass.
- **OpenMP** no longer reallocates per-entry buffers in any preassembled path (bilinear or linear, single-block or block-offset); buffers are hoisted and reused, matching the direct-write efficiency of Sequential/MPI.

Result is behavior-preserving: a uniformity + allocation cleanup, plus a fast path for the common no-identification case.

## Tests — all backends

Added a no-identification **preassembled-operator merge** regression test that exercises the new `MatAXPY` fast path:

- `PETSc_Form.SequentialPreassembledOperatorMerge` and `OpenMPPreassembledOperatorMerge` (`FormTest.cpp`)
- `PETSc_MPI_Form.DistributedPreassembledOperatorMerge` (`MPIFormTest.cpp`)

These complement the existing identification tests, which cover the per-entry fallback path. Verified locally:

- `RodinPETScFormTest` (Sequential + OpenMP): 11/11 pass
- `RodinPETScLinearSystemTest`: 1/1 pass
- `RodinPETScMPIFormTest`: 6/6 pass at `np` = 1, 2, 3, 4
- `RodinPETScGridFunctionTest`, `MPIGridFunctionTest`, `MPISubMeshGridFunctionTest`, `MPIP0P0gTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
