### PR TITLE
[codex] Fix PETSc GridFunction min max calls

### DIFF
--- a/src/Rodin/PETSc/Variational/GridFunction.h
+++ b/src/Rodin/PETSc/Variational/GridFunction.h
@@ -546,11 +546,13 @@ namespace Rodin::Variational
         this->flush();
         PetscErrorCode ierr;
         auto& data = this->getData();
-        ScalarType res;
-        ierr = VecMin(data, idx, &res);
+        PetscInt pidx;
+        PetscReal res;
+        ierr = VecMin(data, &pidx, &res);
         assert(ierr == PETSC_SUCCESS);
         (void) ierr;
-        return res;
+        idx = static_cast<Index>(pidx);
+        return static_cast<ScalarType>(res);
       }
 
       /**
@@ -568,11 +570,13 @@ namespace Rodin::Variational
         this->flush();
         PetscErrorCode ierr;
         auto& data = this->getData();
-        ScalarType res;
-        ierr = VecMax(data, idx, &res);
+        PetscInt pidx;
+        PetscReal res;
+        ierr = VecMax(data, &pidx, &res);
         assert(ierr == PETSC_SUCCESS);
         (void) ierr;
-        return res;
+        idx = static_cast<Index>(pidx);
+        return static_cast<ScalarType>(res);
       }
 
       /**

--- a/tests/unit/Rodin/PETSc/GridFunctionTest.cpp
+++ b/tests/unit/Rodin/PETSc/GridFunctionTest.cpp
@@ -51,6 +51,44 @@ namespace
       EXPECT_DOUBLE_EQ(static_cast<double>(PetscRealPart(cgf[i])), 7.0);
     cgf.flush();
   }
+
+  TEST(PETSc_GridFunction, SequentialMinReturnsValueAndIndex)
+  {
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    P1 fes(mesh);
+    Rodin::PETSc::Variational::GridFunction gf(fes);
+
+    for (Index i = 0; i < gf.getSize(); ++i)
+      gf[i] = static_cast<PetscScalar>(10.0 + static_cast<Real>(i));
+
+    constexpr Index expectedIdx = 3;
+    gf[expectedIdx] = static_cast<PetscScalar>(-2.5);
+    gf.flush();
+
+    Index idx = gf.getSize();
+    const auto value = gf.min(idx);
+    EXPECT_EQ(idx, expectedIdx);
+    EXPECT_DOUBLE_EQ(static_cast<double>(PetscRealPart(value)), -2.5);
+  }
+
+  TEST(PETSc_GridFunction, SequentialMaxReturnsValueAndIndex)
+  {
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    P1 fes(mesh);
+    Rodin::PETSc::Variational::GridFunction gf(fes);
+
+    for (Index i = 0; i < gf.getSize(); ++i)
+      gf[i] = static_cast<PetscScalar>(-10.0 - static_cast<Real>(i));
+
+    constexpr Index expectedIdx = 5;
+    gf[expectedIdx] = static_cast<PetscScalar>(4.25);
+    gf.flush();
+
+    Index idx = gf.getSize();
+    const auto value = gf.max(idx);
+    EXPECT_EQ(idx, expectedIdx);
+    EXPECT_DOUBLE_EQ(static_cast<double>(PetscRealPart(value)), 4.25);
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary

- Fix `PETSc::Variational::GridFunction::min/max` to call `VecMin` and `VecMax` with PETSc index/value output variables.
- Cast the PETSc index and scalar result back to the Rodin API types after the PETSc call succeeds.
- Add PETSc GridFunction regression coverage for extrema value/index return.

## Motivation

PETSc 3.22 rejects the previous call form because `VecMin` and `VecMax` expect pointer outputs for the index and value. This is a generic PETSc compatibility fix needed before PETSc-backed Adaptation code can build cleanly on top of `develop`.

## Validation

- `git diff --check`
- `cmake --build build --target RodinPETScGridFunctionTest -j4`
- `./build/tests/unit/Rodin/PETSc/RodinPETScGridFunctionTest`
