### PR TITLE
Add MMG required entity support

### DIFF
--- a/doc/Examples/DensityOptimization/TemperatureMinimization.dox
+++ b/doc/Examples/DensityOptimization/TemperatureMinimization.dox
@@ -54,7 +54,7 @@
 
   @subsection examples-densopt-temp-setup-mesh Mesh and Initial Density
 
-  The mesh is loaded and optimized with @ref Rodin::External::MMG
+  The mesh is loaded and optimized with @ref Rodin::MMG
   "MMG::Optimizer":
 
   @code{.cpp}

--- a/doc/Examples/IO/MEDIT.dox
+++ b/doc/Examples/IO/MEDIT.dox
@@ -20,7 +20,7 @@
   @section examples-io-medit-load Loading a MEDIT Mesh
 
   A mesh in MEDIT format can be loaded into either a standard
-  @ref Rodin::Geometry::Mesh "Mesh" or an @ref Rodin::External::MMG
+  @ref Rodin::Geometry::Mesh "Mesh" or an @ref Rodin::MMG
   "MMG::Mesh":
 
   @code{.cpp}
@@ -55,7 +55,7 @@
 
   @section examples-io-medit-mmg Using with MMG
 
-  When working with the @ref Rodin::External::MMG "MMG" module, MEDIT is the
+  When working with the @ref Rodin::MMG "MMG" module, MEDIT is the
   recommended format because it preserves MMG-specific metadata:
 
   @code{.cpp}

--- a/doc/Examples/MMG/Behavior.dox
+++ b/doc/Examples/MMG/Behavior.dox
@@ -1,0 +1,159 @@
+/**
+  @page examples-mmg-behavior MMG behavior and guarantees
+  @brief Tested behavior of Rodin's MMG wrappers, required entities, and level-set cuts
+
+  @m_keywords{MMG, Required Entities, Level Set, NoSplit, MG_REQ}
+
+  @tableofcontents
+
+  @m_footernavigation
+
+  @section examples-mmg-behavior-overview Overview
+
+  Rodin's @ref Rodin::MMG "MMG" module wraps the Mmg Platform for local mesh
+  processing. It provides three distinct workflows:
+
+  | Workflow | Rodin entry point | Expected behavior |
+  |----------|-------------------|-------------------|
+  | Mesh-quality optimization | @ref Rodin::MMG::Optimizer "MMG::Optimizer" | Improves element quality while staying close to the existing local size distribution |
+  | Metric/field adaptation | @ref Rodin::MMG::Adapt "MMG::Adapt" | Refines, coarsens, moves, and reconnects elements according to a size field |
+  | Level-set discretization | @ref Rodin::MMG::LevelSetDiscretizer "MMG::LevelSetDiscretizer" | Cuts an input mesh with an isovalue and produces a body-fitted mesh or extracted surface |
+
+  All three workflows convert @ref Rodin::MMG::Mesh "MMG::Mesh" to native MMG
+  data structures, run MMG, and convert the result back to Rodin. The returned
+  mesh is therefore a new mesh topology chosen by MMG; users should not assume
+  that every input element index still names the same geometric entity after
+  remeshing.
+
+  @section examples-mmg-behavior-required Required entity behavior
+
+  @ref Rodin::MMG::Mesh "MMG::Mesh" stores required vertices, edges,
+  triangles, and tetrahedra:
+
+  @code{.cpp}
+  mesh.setRequiredVertex(vertexIndex);
+  mesh.setRequiredEdge(edgeIndex);
+  mesh.setRequiredTriangle(triangleIndex);
+  mesh.setRequiredTetrahedron(tetrahedronIndex);
+  @endcode
+
+  These sets are:
+
+  - written to MEDIT as `RequiredVertices`, `RequiredEdges`,
+    `RequiredTriangles`, and `RequiredTetrahedra`;
+  - read back from MEDIT into the same Rodin metadata;
+  - passed to native MMG structures as `MG_REQ` tags;
+  - recovered from native MMG output when converting back to Rodin;
+  - restored by the optimizer and level-set wrappers when the original index is
+    still valid in the output.
+
+  The test suite covers this metadata path in 2D and 3D, including MEDIT I/O,
+  native MMG conversion, optimization, and level-set discretization.
+  In MMG3D, triangle metadata is boundary-surface metadata: when face-cell
+  incidence is available, Rodin exports only boundary triangles to MMG's
+  native triangle table. Interior faces of a tetrahedral mesh are not a
+  supported MMG3D `RequiredTriangles` preservation mechanism.
+
+  @subsection examples-mmg-behavior-required-uncut Uncut level-set entities
+
+  For level-set discretization, Rodin has explicit geometry-preservation tests
+  for required entities that are not crossed by the level set:
+
+  - in 2D, required vertices, edges, and triangles retain their required
+    metadata and the original entity coordinates remain present in the output;
+  - in 3D, required vertices, edges, triangles, and tetrahedra retain their
+    required metadata and the original entity coordinates remain present in the
+    output.
+
+  These tests compare geometry, not only the required index sets. This is the
+  expected behavior for required entities that are away from the level-set cut.
+
+  @subsection examples-mmg-behavior-required-cut Cut-through level-set entities
+
+  Required entities are not a hard "never cut this element" constraint when
+  MMG level-set discretization must conform the mesh to an isovalue crossing
+  that entity.
+
+  In particular, for 3D level-set discretization, if the zero level set cuts a
+  required boundary triangle face in a tetrahedral mesh, MMG may replace that
+  triangle. Interior tetrahedral faces are not passed to MMG as boundary
+  triangles. The same caveat applies to other cut-through entities. In this
+  situation MMG can emit a warning containing `Required entity ignored.`
+
+  Rodin intentionally documents and tests this behavior rather than promising a
+  stricter guarantee than MMG provides.
+
+  @section examples-mmg-behavior-nosplit NoSplit and material labels
+
+  @ref Rodin::MMG::LevelSetDiscretizer::noSplit "LevelSetDiscretizer::noSplit"
+  applies MMG's material split policy to a material reference:
+
+  @code{.cpp}
+  MMG::Mesh result = MMG::LevelSetDiscretizer()
+    .split(interior, { interior, exterior })
+    .noSplit(protectedReference)
+    .discretize(levelSet);
+  @endcode
+
+  `noSplit(ref)` means that the material with reference `ref` should not be
+  split into the configured inside/outside references. It does not mean that a
+  particular edge, triangle face, or tetrahedron is an immutable geometric
+  object.
+
+  The characterization tests cover the following cut-through combinations:
+
+  | Protected entity | Extra labels or requirements | Exact original geometry preserved? |
+  |------------------|------------------------------|------------------------------------|
+  | edge in a 2D triangle mesh | required edge and `noSplit` on containing triangles | no |
+  | triangle in a 2D mesh | individual label, with or without required triangle | no |
+  | edge in a 3D tetrahedral mesh | required edge and `noSplit` on adjacent tetrahedra | no |
+  | triangle face in a 3D tetrahedral mesh | required triangle and/or individual face label | no |
+  | triangle face in a 3D tetrahedral mesh | `noSplit` on adjacent tetrahedra | no |
+  | triangle face in a 3D tetrahedral mesh | required vertices, edges, face, and adjacent tetrahedra | no |
+  | tetrahedron in a 3D mesh | required tetrahedron and `noSplit` on its material reference | no |
+
+  The practical rule is:
+
+  - if the level set does not cut the required entity, Rodin's tested behavior
+    is preservation of the required metadata and original geometry;
+  - if the level set cuts the entity, MMG may alter it to conform the output
+    mesh to the interface, even when `MG_REQ`, individual labels, adjacent
+    tetrahedron labels, and `noSplit` are used.
+
+  @section examples-mmg-behavior-workarounds Workarounds for protected geometry
+
+  If an element or face must remain untouched, treat that requirement as an
+  input validity condition before calling MMG level-set discretization:
+
+  - preflight the level-set values on the protected entity and reject the step
+    if the isovalue crosses it;
+  - change or clamp the level set so the protected entity lies entirely on one
+    side of the cut;
+  - pre-partition the mesh so the protected surface is already part of the
+    mesh/interface rather than asking MMG to cut through it;
+  - use `noSplit(ref)` only for material-reference splitting policy, not as an
+    element-integrity guarantee.
+
+  @section examples-mmg-behavior-tests Test coverage
+
+  The MMG unit suite exercises:
+
+  - required vertex, edge, triangle, and tetrahedron API lifecycle;
+  - MEDIT I/O round trips for required entities;
+  - native MMG conversion with required entities;
+  - optimization preservation of required metadata;
+  - level-set discretization preservation for uncut required geometry in 2D and
+    3D;
+  - cut-through characterization with `MG_REQ`, labels, adjacent tetrahedra,
+    local closure requirements, and `noSplit`.
+
+  @section examples-mmg-behavior-see-also See Also
+
+  - @ref examples-mmg-simple_io "MMG I/O"
+  - @ref examples-mmg-mesh_optimization "Mesh optimization"
+  - @ref examples-mmg-mesh_adaptation "Mesh adaptation"
+  - @ref examples-shapeoptimization-levelset_cantilever "Level-set cantilever"
+  - @ref Rodin::MMG "MMG namespace"
+
+  @m_footernavigation
+  */

--- a/doc/Examples/MMG/Casting.dox
+++ b/doc/Examples/MMG/Casting.dox
@@ -10,10 +10,15 @@
 
   @section examples-mmg-cast-intro Introduction
 
-  The @ref Rodin::External::MMG "MMG::Mesh" class extends
+  The @ref Rodin::MMG "MMG::Mesh" class extends
   @ref Rodin::Geometry::Mesh "Mesh<Context::Local>" and can be used wherever
   a regular mesh is expected. This section explains how to work with both
   types interchangeably.
+
+  @note Assigning from a plain @ref Rodin::Geometry::Mesh "Geometry::Mesh" to
+  an `MMG::Mesh` keeps the topology and coordinates but clears MMG-specific
+  metadata, because the base mesh does not carry corners, ridges, or required
+  entity sets.
 
   @section examples-mmg-cast-create Creating an MMG Mesh
 
@@ -73,8 +78,9 @@
 
   @section examples-mmg-cast-see-also See Also
 
-  - @ref examples-mmg-simple_io "MMG I/O" — File I/O details
-  - @ref examples-mmg-mesh_optimization "Mesh optimization" — Remeshing
-  - @ref Rodin::External::MMG "MMG namespace"
+  - @ref examples-mmg-simple_io "MMG I/O" - File I/O details
+  - @ref examples-mmg-mesh_optimization "Mesh optimization" - Remeshing
+  - @ref examples-mmg-behavior "MMG behavior and guarantees"
+  - @ref Rodin::MMG "MMG namespace"
 
   */

--- a/doc/Examples/MMG/MeshAdaptation.dox
+++ b/doc/Examples/MMG/MeshAdaptation.dox
@@ -15,7 +15,7 @@
   or features receive finer elements, while smooth regions are coarsened.
   This produces more accurate results with fewer degrees of freedom.
 
-  The @ref Rodin::External::MMG "MMG" module supports metric-based mesh
+  The @ref Rodin::MMG "MMG" module supports metric-based mesh
   adaptation where a solution field or metric tensor guides the remesher.
 
   @section examples-mmg-adapt-workflow Typical Workflow
@@ -64,10 +64,24 @@
   }
   @endcode
 
+  @section examples-mmg-adapt-behavior Expected Behavior
+
+  `MMG::Adapt` is intended for size-map-driven remeshing. It may insert,
+  remove, and move vertices to match the requested metric subject to the
+  configured `hmin`, `hmax`, Hausdorff, and gradation constraints. For pure
+  mesh-quality cleanup without an external size map, use
+  @ref Rodin::MMG::Optimizer "MMG::Optimizer".
+
+  Required entities can be marked on @ref Rodin::MMG::Mesh "MMG::Mesh" and
+  are converted to MMG `MG_REQ` tags. See
+  @ref examples-mmg-behavior-required "Required entity behavior" for the
+  distinction between uncut entities, optimization, and level-set cuts.
+
   @section examples-mmg-adapt-see-also See Also
 
   - @ref examples-mmg-mesh_optimization "Mesh optimization"
+  - @ref examples-mmg-behavior "MMG behavior and guarantees"
   - @ref examples-pdes-poisson "Poisson equation"
-  - @ref Rodin::External::MMG "MMG namespace"
+  - @ref Rodin::MMG "MMG namespace"
 
   */

--- a/doc/Examples/MMG/MeshOptimization.dox
+++ b/doc/Examples/MMG/MeshOptimization.dox
@@ -11,9 +11,11 @@
   @section examples-mmg-meshopt-intro Introduction
 
   Mesh quality is critical for accurate finite element solutions. The
-  @ref Rodin::External::MMG "MMG::Optimizer" provides automatic mesh
-  improvement: it refines, coarsens, and improves element shapes according
-  to user-specified size parameters.
+  @ref Rodin::MMG "MMG::Optimizer" wraps MMG optimization mode: it improves
+  poorly shaped elements while keeping the mesh close to the local size
+  distribution already present in the input mesh. This is different from
+  metric-driven adaptation, where an external size map prescribes where the
+  mesh should be refined or coarsened.
 
   @section examples-mmg-meshopt-basic Basic Usage
 
@@ -53,14 +55,37 @@
 
   @section examples-mmg-meshopt-params Optimizer Parameters
 
-  The @ref Rodin::External::MMG "MMG::Optimizer" supports several parameters:
+  The @ref Rodin::MMG "MMG::Optimizer" supports several parameters:
 
   | Method | Description |
   |--------|-------------|
-  | `setHMax(h)` | Maximum edge length |
-  | `setHMin(h)` | Minimum edge length |
+  | `setHMax(h)` | Upper edge-size bound passed to MMG |
+  | `setHMin(h)` | Lower edge-size bound passed to MMG |
   | `setHausdorff(h)` | Hausdorff distance for curved boundaries |
   | `setAngleDetection(b)` | Enable/disable automatic ridge detection |
+
+  @note `MMG::Optimizer` is a quality-improvement operator. Use
+  @ref Rodin::MMG::Adapt "MMG::Adapt" when a computed size field should drive
+  refinement and coarsening.
+
+  @section examples-mmg-meshopt-required Required Entities
+
+  Required vertices, edges, triangles, and tetrahedra can be marked on
+  @ref Rodin::MMG::Mesh "MMG::Mesh" before optimization. The Rodin wrapper
+  passes them to MMG as required entities and restores the required index sets
+  after optimization when the corresponding indices still exist in the output:
+
+  @code{.cpp}
+  mesh.setRequiredVertex(vertexIndex);
+  mesh.setRequiredEdge(edgeIndex);
+  mesh.setRequiredTriangle(triangleIndex);
+  mesh.setRequiredTetrahedron(tetrahedronIndex);
+
+  MMG::Optimizer().setHMax(0.1).optimize(mesh);
+  @endcode
+
+  See @ref examples-mmg-behavior-required "Required entity behavior" for the
+  tested preservation guarantees and the important level-set limitations.
 
   Typical settings for shape optimization:
 
@@ -79,10 +104,11 @@
 
   @section examples-mmg-meshopt-see-also See Also
 
-  - @ref examples-mmg-simple_io "MMG I/O" — Loading and saving MMG meshes
+  - @ref examples-mmg-simple_io "MMG I/O" - Loading and saving MMG meshes
+  - @ref examples-mmg-behavior "MMG behavior and guarantees"
   - @ref examples-shapeoptimization-simple_cantilever "Shape optimization" —
     Uses MMG in an optimization loop
-  - @ref Rodin::External::MMG "MMG namespace"
+  - @ref Rodin::MMG "MMG namespace"
 
   @example MMG/MeshOptimization.cpp
   @m_examplenavigation{examples-mmg-mesh_optimization,MMG/}

--- a/doc/Examples/MMG/SimpleIO.dox
+++ b/doc/Examples/MMG/SimpleIO.dox
@@ -10,7 +10,7 @@
 
   @section examples-mmg-io-intro Introduction
 
-  The @ref Rodin::External::MMG "MMG" module provides a mesh class
+  The @ref Rodin::MMG "MMG" module provides a mesh class
   (`MMG::Mesh`) that extends the standard @ref Rodin::Geometry::Mesh "Mesh"
   with remeshing capabilities. This example shows how to load and save
   MMG meshes in the supported formats.
@@ -20,7 +20,8 @@
   An `MMG::Mesh` can be created using the same
   @ref Rodin::Geometry::Mesh::UniformGrid "UniformGrid()" method as a
   regular mesh. The key difference is that `MMG::Mesh` stores additional
-  metadata (corners, ridges) that MMG uses during remeshing:
+  metadata (corners, ridges, and required entities) that MMG uses during
+  remeshing:
 
   @code{.cpp}
   #include <Rodin/Geometry.h>
@@ -45,6 +46,11 @@
     for (auto it = mesh.getBoundary(); !it.end(); ++it)
       mesh.setRidge(it->getIndex());
 
+    // Required entities are serialized in MEDIT and passed to MMG as MG_REQ.
+    mesh.setRequiredVertex(0);
+    mesh.setRequiredEdge(0);
+    mesh.setRequiredTriangle(0);
+
     return 0;
   }
   @endcode
@@ -57,6 +63,10 @@
   @code{.cpp}
   mesh.save("output.medit.mesh", IO::FileFormat::MEDIT);
   @endcode
+
+  Rodin writes and reads the MMG-specific `RequiredVertices`,
+  `RequiredEdges`, `RequiredTriangles`, and `RequiredTetrahedra` sections when
+  they are present.
 
   @section examples-mmg-io-load Loading and Re-saving
 
@@ -77,9 +87,10 @@
 
   @section examples-mmg-io-see-also See Also
 
-  - @ref examples-mmg-mesh_optimization "Mesh optimization" — Remeshing with MMG
-  - @ref guides-io "I/O in Rodin" — Format reference
-  - @ref Rodin::External::MMG "MMG namespace"
+  - @ref examples-mmg-mesh_optimization "Mesh optimization" - Remeshing with MMG
+  - @ref examples-mmg-behavior "MMG behavior and guarantees"
+  - @ref guides-io "I/O in Rodin" - Format reference
+  - @ref Rodin::MMG "MMG namespace"
 
   @example MMG/MeshIO.cpp
   @m_examplenavigation{examples-mmg-simple_io,MMG/}

--- a/doc/Examples/MMGIndex.dox
+++ b/doc/Examples/MMGIndex.dox
@@ -1,10 +1,11 @@
 /**
   @page examples-mmg-index Working with MMG
-  @brief Showcases the usage of the Rodin::External::MMG module
+  @brief Showcases the usage of the Rodin::MMG module
 
   - @subpage examples-mmg-simple_io
   - @subpage examples-mmg-mesh_optimization
   - @subpage examples-mmg-mesh_adaptation
+  - @subpage examples-mmg-behavior
   - @subpage examples-mmg-casting
 
   */

--- a/doc/Examples/ShapeOptimization/LevelSetCantilever.dox
+++ b/doc/Examples/ShapeOptimization/LevelSetCantilever.dox
@@ -19,19 +19,69 @@
   changes** (create holes, merge components) by advecting a level-set
   function and recovering the implicit domain at each iteration.
 
-  The optimization minimizes compliance subject to a volume constraint:
+  The optimization minimizes compliance with a volume penalty. Let
+  @f$\Omega \subset D@f$ be the material region, let @f$\Gamma_D@f$ be the
+  clamped boundary, and let @f$\Gamma_N@f$ be the loaded boundary. The state
+  displacement @f$u : \Omega \to \mathbb{R}^d@f$ solves linear elasticity:
+
+  @f[
+    \int_\Omega A e(u) : e(v)\,dx
+      = \int_{\Gamma_N} f \cdot v\,ds
+      \qquad
+      \forall v \in H^1_{\Gamma_D}(\Omega;\mathbb{R}^d),
+  @f]
+
+  where
+
+  @f[
+    e(u) = \frac{1}{2}\left(\nabla u + \nabla u^T\right),
+    \qquad
+    A e(u) = 2\mu e(u) + \lambda \operatorname{tr}(e(u)) I.
+  @f]
+
+  The minimized functional is
 
   @f[
     \min_\Omega \; J(\Omega) = \int_\Omega A e(u) : e(u)\,dx
                                + \ell\,|\Omega_{\mathrm{int}}|
   @f]
 
+  with @f$\ell@f$ the volume penalty. The level-set function @f$\phi@f$
+  represents the material by sign:
+
+  @f[
+    \Omega = \{x \in D : \phi(x) > 0\}, \qquad
+    D \setminus \overline{\Omega} = \{x \in D : \phi(x) < 0\},
+    \qquad
+    \Gamma = \{x \in D : \phi(x) = 0\}.
+  @f]
+
+  The shape derivative is converted into a smooth vector field @f$g@f$ by a
+  Hilbertian regularization:
+
+  @f[
+    \int_D \alpha^2 \nabla g : \nabla w + g \cdot w\,dx
+      =
+    \int_\Gamma \left(A e(u):e(u) - \ell\right) n \cdot w\,ds
+      \qquad \forall w.
+  @f]
+
+  The level set is then transported by a descent velocity using the advection
+  equation
+
+  @f[
+    \partial_t \phi + g \cdot \nabla \phi = 0,
+  @f]
+
+  and the zero level set is re-discretized with
+  @ref Rodin::MMG::LevelSetDiscretizer "MMG::LevelSetDiscretizer".
+
   @section examples-shapeopt-ls-setup Problem Setup
 
   @subsection examples-shapeopt-ls-setup-includes Includes
 
   In addition to the standard Rodin modules, we need the
-  @ref Rodin::Distance "Distance" module (Eikonal solver) and the
+  @ref Rodin::Distance "Distance" module (Eikonal solver), the
   @ref Rodin::Advection "Advection" module (Lagrangian advection):
 
   @code{.cpp}
@@ -53,8 +103,7 @@
   @subsection examples-shapeopt-ls-setup-params Parameters
 
   The mesh is partitioned into `interior` (material present) and `exterior`
-  (void) regions. The level-set function is positive inside the material and
-  negative outside:
+  (void) regions. The example uses a positive-inside level-set convention:
 
   @code{.cpp}
   static constexpr Attribute interior = 1, exterior = 2;
@@ -73,8 +122,8 @@
 
   @subsection examples-shapeopt-ls-loop-remesh Step 1 — Remesh
 
-  At the start of each iteration, we remesh the current domain using
-  @ref Rodin::External::MMG "MMG::Optimizer":
+  At the start of each iteration, we improve the current body-fitted mesh
+  using @ref Rodin::MMG::Optimizer "MMG::Optimizer":
 
   @code{.cpp}
   MMG::Optimizer().setHMax(hmax)
@@ -156,8 +205,9 @@
 
   @subsection examples-shapeopt-ls-loop-recover Step 6 — Recover the Domain
 
-  The new domain is recovered by applying the @ref Rodin::External::MMG
-  "MMG::LevelSetDiscretizer" to the advected level-set function:
+  The new domain is recovered by applying
+  @ref Rodin::MMG::LevelSetDiscretizer "MMG::LevelSetDiscretizer" to the
+  advected level-set function:
 
   @code{.cpp}
   th = MMG::LevelSetDiscretizer()
@@ -198,6 +248,7 @@
 
   - @ref examples-shapeoptimization-simple_cantilever "Simple cantilever" —
     Boundary-variation approach
+  - @ref examples-mmg-behavior "MMG behavior and guarantees"
   - @ref examples-pdes-elasticity "Linear elasticity"
   - @ref gallery "Gallery"
 

--- a/doc/Examples/ShapeOptimization/SimpleCantilever.dox
+++ b/doc/Examples/ShapeOptimization/SimpleCantilever.dox
@@ -29,7 +29,7 @@
   @subsection examples-shapeopt-sc-setup-includes Includes
 
   We need the core Rodin modules plus the linear-elasticity helper and the
-  @ref Rodin::External::MMG "MMG" remesher:
+  @ref Rodin::MMG "MMG" remesher:
 
   @code{.cpp}
   #include <Rodin/Solver.h>
@@ -71,7 +71,7 @@
   @subsection examples-shapeopt-sc-setup-mesh Loading the Mesh
 
   The initial cantilever mesh is loaded from an MFEM file using the
-  @ref Rodin::External::MMG "MMG::Mesh" class, which extends
+  @ref Rodin::MMG "MMG::Mesh" class, which extends
   @ref Rodin::Geometry::Mesh "Mesh" with remeshing capabilities:
 
   @code{.cpp}
@@ -146,7 +146,7 @@
   @subsection examples-shapeopt-sc-loop-remesh Step 4 — Remeshing with MMG
 
   After displacing the mesh, we remesh with the
-  @ref Rodin::External::MMG "MMG::Optimizer" to maintain good element quality:
+  @ref Rodin::MMG "MMG::Optimizer" to maintain good element quality:
 
   @code{.cpp}
   MMG::Optimizer().setHMax(hmax).setHMin(hmin).optimize(Omega);

--- a/doc/ExamplesIndex.dox
+++ b/doc/ExamplesIndex.dox
@@ -56,7 +56,7 @@
 
   @section examples-index-mmg Working with MMG
 
-  The @ref Rodin::External::MMG "MMG" module has a wide variety of uses which
+  The @ref Rodin::MMG "MMG" module has a wide variety of uses which
   ranges from optimization of the mesh, to implicit domain meshing. It provides
   many C++ wrappers to execute the functionality of the [Mmg
   Platform](https://www.mmgtools.org/):
@@ -132,7 +132,7 @@
 
   | Problem | Kernel | Example |
   |---------|--------|---------|
-  | Newtonian potential | @f$ \frac{1}{4\pi\|\mathbf{x}-\mathbf{y}\|} @f$ | `examples/IntegralEquations/NewtonianPotential.cpp` |
+  | Newtonian potential | @f$ \frac{1}{4\pi\lVert\mathbf{x}-\mathbf{y}\rVert} @f$ | `examples/IntegralEquations/NewtonianPotential.cpp` |
   | Elastic distribution | Navier 3×3 kernel | `examples/IntegralEquations/ElasticDistribution.cpp` |
 
   @section examples-index-surfevol Surface Evolution

--- a/doc/Gallery.dox
+++ b/doc/Gallery.dox
@@ -80,7 +80,7 @@
   beam, minimizing the compliance (structural stiffness) subject to a
   volume constraint. The shape gradient is computed and regularized via the
   Hilbert extension-regularization procedure, and the mesh is updated using
-  the @ref Rodin::External::MMG "MMG" remesher.
+  the @ref Rodin::MMG "MMG" remesher.
 
   @subsection gallery-shapeopt-levelset Level-Set Shape Optimization
 
@@ -90,7 +90,7 @@
   cantilever" example combines body-fitted meshing with level-set
   techniques. The optimizer advects a signed-distance function and recovers
   the implicit domain at each iteration using the
-  @ref Rodin::External::MMG "MMG" level-set discretizer.
+  @ref Rodin::MMG "MMG" level-set discretizer.
 
   @subsection gallery-density-temp Density Optimization: Temperature
 

--- a/doc/Guides/CoreConcepts.dox
+++ b/doc/Guides/CoreConcepts.dox
@@ -193,7 +193,7 @@
   | `Jacobian(u)` | @f$ \nabla \mathbf{u} @f$ | Matrix (for vector @f$ \mathbf{u} @f$) |
   | `Transpose(A)` | @f$ A^T @f$ | Transpose of a matrix expression |
   | `Trace(A)` | @f$ \text{tr}(A) @f$ | Scalar (sum of diagonal entries) |
-  | `Frobenius(A)` | @f$ \|A\|_F @f$ | Scalar (Frobenius norm) |
+  | `Frobenius(A)` | @f$ \lVert A\rVert_F @f$ | Scalar (Frobenius norm) |
   | `Dot(a, b)` | @f$ \mathbf{a} \cdot \mathbf{b} @f$ | Scalar (inner product or double contraction) |
   | `Component(u, i)` | @f$ u_i @f$ | Scalar (i-th component of vector @f$ \mathbf{u} @f$) |
   | `BoundaryNormal(mesh)` | @f$ \mathbf{n} @f$ | Outward unit normal on @f$ \partial\Omega @f$ |
@@ -201,7 +201,7 @@
   | `IdentityMatrix(n)` | @f$ I_n @f$ | @f$ n \times n @f$ identity matrix |
   | `Potential(K, u)` | @f$ \int K(\mathbf{x}, \mathbf{y}) u(\mathbf{y}) \, d\mathbf{y} @f$ | Integral convolution (BEM/integral equations) |
   | `Flow(t, u, vel)` | @f$ u \circ \Phi_t @f$ | Flow composition (semi-Lagrangian advection) |
-  | `TraceOperator(u, attr)` | @f$ u\|_{\partial\Omega} @f$ | Boundary trace (restriction to boundary) |
+  | `TraceOperator(u, attr)` | @f$ u\vert_{\partial\Omega} @f$ | Boundary trace (restriction to boundary) |
 
   @code{.cpp}
   TrialFunction u(Vh);
@@ -513,7 +513,7 @@
   | Sine | `Sin(f)` | @f$ \sin(f) @f$ |
   | Cosine | `Cos(f)` | @f$ \cos(f) @f$ |
   | Tangent | `Tan(f)` | @f$ \tan(f) @f$ |
-  | Absolute value | `Abs(f)` | @f$ |f| @f$ |
+  | Absolute value | `Abs(f)` | @f$ \lvert f\rvert @f$ |
   | Maximum | `Max(f, g)` | @f$ \max(f, g) @f$ |
   | Minimum | `Min(f, g)` | @f$ \min(f, g) @f$ |
 

--- a/doc/Guides/IO.dox
+++ b/doc/Guides/IO.dox
@@ -348,7 +348,7 @@
   @endcode
 
   See the @ref examples-mmg-index "MMG examples" for more details on using
-  Rodin's @ref Rodin::External::MMG "MMG" integration.
+  Rodin's @ref Rodin::MMG "MMG" integration.
 
   @section guides-io-workflow Recommended Workflow
 

--- a/doc/Guides/IO/MeshFormats.dox
+++ b/doc/Guides/IO/MeshFormats.dox
@@ -53,7 +53,7 @@
   @subsection guides-io-meshformats-medit-mmg Using with MMG
 
   When working with the MMG remeshing tools through Rodin's
-  @ref Rodin::External::MMG module, the MEDIT format is used for mesh
+  @ref Rodin::MMG module, the MEDIT format is used for mesh
   exchange:
 
   @code{.cpp}

--- a/doc/Guides/Meshes/IO.dox
+++ b/doc/Guides/Meshes/IO.dox
@@ -74,7 +74,7 @@
   @subsection guides-meshes-io-saving-medit MEDIT Format
 
   The MEDIT format is commonly used with the
-  @ref Rodin::External::MMG "MMG" mesh adaptation tools:
+  @ref Rodin::MMG "MMG" mesh adaptation tools:
 
   @code{.cpp}
   mesh.save("domain.mesh", IO::FileFormat::MEDIT);
@@ -120,7 +120,7 @@
 
   [MMG](https://www.mmgtools.org/) is used for mesh adaptation and
   optimization. Rodin integrates directly with MMG through the
-  @ref Rodin::External::MMG "External::MMG" module. See the
+  @ref Rodin::MMG "MMG" module. See the
   @ref examples-mmg-index "MMG examples" for details.
 
   @section guides-meshes-io-paths File Paths

--- a/doc/Guides/Solvers.dox
+++ b/doc/Guides/Solvers.dox
@@ -187,8 +187,8 @@
   | Method | Default | Description |
   |--------|---------|-------------|
   | `setMaxIterations(n)` | 100 | Maximum Newton iterations |
-  | `setAbsoluteTolerance(tol)` | @f$ 10^{-12} @f$ | Converged when @f$ \|r\| \le \mathrm{atol} @f$ |
-  | `setRelativeTolerance(tol)` | @f$ 10^{-8} @f$ | Converged when @f$ \|r\|/\|r_0\| \le \mathrm{rtol} @f$ |
+  | `setAbsoluteTolerance(tol)` | @f$ 10^{-12} @f$ | Converged when @f$ \lVert r\rVert \le \mathrm{atol} @f$ |
+  | `setRelativeTolerance(tol)` | @f$ 10^{-8} @f$ | Converged when @f$ \lVert r\rVert/\lVert r_0\rVert \le \mathrm{rtol} @f$ |
 
   Convergence is declared when **either** criterion is satisfied (not both).
 

--- a/doc/Guides/VariationalFormulations.dox
+++ b/doc/Guides/VariationalFormulations.dox
@@ -140,7 +140,7 @@
   | Jacobian | @f$ \nabla \mathbf{u} @f$ (matrix) | @f$ d \times d @f$ matrix | `Jacobian(u)` |
   | Transpose | @f$ (\nabla \mathbf{u})^T @f$ | @f$ d \times d @f$ matrix | `Transpose(Jacobian(u))` |
   | Trace | @f$ \text{tr}(\nabla \mathbf{u}) @f$ | Scalar | `Trace(Jacobian(u))` |
-  | Frobenius norm | @f$ \| \nabla \mathbf{u} \|_F @f$ | Scalar | `Frobenius(Jacobian(u))` |
+  | Frobenius norm | @f$ \lVert \nabla \mathbf{u} \rVert_F @f$ | Scalar | `Frobenius(Jacobian(u))` |
   | Component | @f$ u_i @f$ | Scalar (from vector @f$ \mathbf{u} @f$) | `Component(u, i)` or `u.x()` |
 
   @code{.cpp}

--- a/doc/Mainpage.dox
+++ b/doc/Mainpage.dox
@@ -6,9 +6,40 @@
 
   Rodin is a lightweight and modular C++20 finite element framework designed
   for solving partial differential equations (PDEs) and performing shape and
-  topology optimization. It provides a compositional form language that lets
+  topology optimization.
+
+  @image html Images/Logo_Inverse.png width=210px
+
+  It is named after the French sculptor [Auguste
+  Rodin](https://en.wikipedia.org/wiki/Auguste_Rodin), considered the founder
+  of modern sculpture.
+
+  @section poisson-example-mainpage A simple example
+
+  Rodin provides a compositional form language that lets
   you express variational problems in C++ code that closely mirrors the
-  mathematical notation:
+  mathematical notation.
+
+  For example, the Poisson problem with homogeneous Dirichlet boundary
+  conditions, in strong form, for a domain @f$\Omega@f$ with boundary
+  @f$\partial\Omega@f$ is
+
+  @f[
+    \begin{aligned}
+      -\Delta u &= f && \text{in } \Omega,\\
+      u &= 0 && \text{on } \partial\Omega.
+    \end{aligned}
+  @f]
+
+  The corresponding weak form is: find @f$u \in H^1_0(\Omega)@f$ such that
+
+  @f[
+    \int_\Omega \nabla u \cdot \nabla v \, dx
+      = \int_\Omega f v \, dx
+      \qquad \forall v \in H^1_0(\Omega).
+  @f]
+
+  In the code one can implement it as such:
 
   @code{.cpp}
   Mesh mesh;
@@ -26,36 +57,6 @@
 
   Solver::CG(problem).solve();
   @endcode
-
-  This example solves the Poisson problem with homogeneous Dirichlet boundary
-  conditions. In strong form, for a domain @f$\Omega@f$ with boundary
-  @f$\partial\Omega@f$, it is
-
-  @f[
-    \begin{aligned}
-      -\Delta u &= f && \text{in } \Omega,\\
-      u &= 0 && \text{on } \partial\Omega.
-    \end{aligned}
-  @f]
-
-  The corresponding weak form is: find @f$u \in H^1_0(\Omega)@f$ such that
-
-  @f[
-    \int_\Omega \nabla u \cdot \nabla v \, dx
-      = \int_\Omega f v \, dx
-      \qquad \forall v \in H^1_0(\Omega).
-  @f]
-
-  The Rodin expression
-  `Integral(Grad(u), Grad(v)) - Integral(f, v) + DirichletBC(u, Zero())`
-  is the residual form of this equation, assembled and solved in the finite
-  element space `P1`.
-
-  @image html Images/Logo_Inverse.png width=210px
-
-  It is named after the French sculptor [Auguste
-  Rodin](https://en.wikipedia.org/wiki/Auguste_Rodin), considered the founder
-  of modern sculpture.
 
   @section rodin-architecture Architecture
 

--- a/doc/Mainpage.dox
+++ b/doc/Mainpage.dox
@@ -27,6 +27,30 @@
   Solver::CG(problem).solve();
   @endcode
 
+  This example solves the Poisson problem with homogeneous Dirichlet boundary
+  conditions. In strong form, for a domain @f$\Omega@f$ with boundary
+  @f$\partial\Omega@f$, it is
+
+  @f[
+    \begin{aligned}
+      -\Delta u &= f && \text{in } \Omega,\\
+      u &= 0 && \text{on } \partial\Omega.
+    \end{aligned}
+  @f]
+
+  The corresponding weak form is: find @f$u \in H^1_0(\Omega)@f$ such that
+
+  @f[
+    \int_\Omega \nabla u \cdot \nabla v \, dx
+      = \int_\Omega f v \, dx
+      \qquad \forall v \in H^1_0(\Omega).
+  @f]
+
+  The Rodin expression
+  `Integral(Grad(u), Grad(v)) - Integral(f, v) + DirichletBC(u, Zero())`
+  is the residual form of this equation, assembled and solved in the finite
+  element space `P1`.
+
   @image html Images/Logo_Inverse.png width=210px
 
   It is named after the French sculptor [Auguste
@@ -53,12 +77,12 @@
 
   | Extension | Purpose |
   |-----------|---------|
-  | @ref Rodin::External::MMG "MMG" | Mesh adaptation and optimization via the Mmg Platform |
+  | @ref Rodin::MMG "MMG" | Mesh adaptation and optimization via the Mmg Platform |
   | @ref Rodin::PETSc "PETSc" | Distributed solvers (KSP, SNES) and PETSc-backed variational forms for large-scale problems |
   | @ref Rodin::MPI "MPI" | Distributed mesh partitioning, sharding, and parallel assembly via Boost.MPI |
   | @ref Rodin::Solid "Solid" | Hyperelastic solid mechanics: NeoHookean, SaintVenantKirchhoff, MooneyRivlin constitutive laws |
   | @ref Rodin::Advection "Advection" | Semi-Lagrangian transport via characteristic tracing |
-  | @ref Rodin::Eikonal "Eikonal" | Fast Marching Method for the Eikonal equation @f$ |\nabla u| = F @f$ |
+  | @ref Rodin::Eikonal "Eikonal" | Fast Marching Method for the Eikonal equation @f$ \lvert \nabla u \rvert = F @f$ |
   | @ref Rodin::Distance "Distance" | Distance function computation (Eikonal, Poisson, level-set normalization) |
 
   @section download-and-build Download and build

--- a/doc/Namespaces.dox
+++ b/doc/Namespaces.dox
@@ -532,11 +532,11 @@
 
   | Method | Class | Equation | Properties |
   |--------|-------|----------|------------|
-  | **Eikonal** | `Distance::Eikonal` | @f$ \|\nabla d\| = 1 @f$ | Exact distances via FMM; supports signed distance with interior/interface regions |
-  | **Poisson** | `Distance::Poisson` | @f$ -\Delta u = 1, \; u\|_{\partial\Omega} = 0 @f$ | Smooth approximation; fast (one linear solve); does not give exact distances |
-  | **SignedPoisson** | `Distance::SignedPoisson` | @f$ -\Delta u = 2\chi_\Omega - 1, \; u\|_\Gamma = 0 @f$ | Region-dependent forcing yields a signed smooth distance |
-  | **Rvachev** | `Distance::Rvachev` | @f$ d = \frac{u}{\sqrt{u^2 + \|\nabla u\|^2}} @f$ | Normalizes a level-set field to approximate distance; preserves zero set and sign |
-  | **SpaldingTucker** | `Distance::SpaldingTucker` | @f$ d = \frac{2u}{\|\nabla u\| + \sqrt{\|\nabla u\|^2 + 2|u|}} @f$ | Better gradient normalization than Rvachev; more accurate near the interface |
+  | **Eikonal** | `Distance::Eikonal` | @f$ \lVert\nabla d\rVert = 1 @f$ | Exact distances via FMM; supports signed distance with interior/interface regions |
+  | **Poisson** | `Distance::Poisson` | @f$ -\Delta u = 1, \; u\vert_{\partial\Omega} = 0 @f$ | Smooth approximation; fast (one linear solve); does not give exact distances |
+  | **SignedPoisson** | `Distance::SignedPoisson` | @f$ -\Delta u = 2\chi_\Omega - 1, \; u\vert_\Gamma = 0 @f$ | Region-dependent forcing yields a signed smooth distance |
+  | **Rvachev** | `Distance::Rvachev` | @f$ d = \frac{u}{\sqrt{u^2 + \lVert\nabla u\rVert^2}} @f$ | Normalizes a level-set field to approximate distance; preserves zero set and sign |
+  | **SpaldingTucker** | `Distance::SpaldingTucker` | @f$ d = \frac{2u}{\lVert\nabla u\rVert + \sqrt{\lVert\nabla u\rVert^2 + 2\lvert u\rvert}} @f$ | Better gradient normalization than Rvachev; more accurate near the interface |
 
   All methods except `Rvachev` and `SpaldingTucker` inherit from a common CRTP
   `Base<Derived>` that provides `setInterior()` and `setInterface()` methods for
@@ -1223,43 +1223,49 @@
  */
 
 /**
-  @dir rodin/src/RodinExternal
-  @brief Namespace @ref Rodin::External
+  @dir Rodin/MMG
+  @brief Namespace @ref Rodin::MMG
  */
 
 /**
-  @namespace Rodin::External
-  @brief Third-party library integrations with Rodin
- */
-
-/**
-  @dir RodinExternal/MMG
-  @brief Namespace @ref Rodin::External::MMG
- */
-
-/**
-  @namespace Rodin::External::MMG
+  @namespace Rodin::MMG
   @brief MMG integration with Rodin
 
-  The `Rodin::External::MMG` module provides C++ wrappers for the
+  The `Rodin::MMG` module provides C++ wrappers for the
   [Mmg Platform](https://www.mmgtools.org/), enabling metric-based mesh
-  adaptation, mesh-quality optimization, and implicit-domain discretization
-  directly from Rodin objects.
+  adaptation, mesh-quality optimization, and level-set discretization directly
+  from Rodin objects.
 
   ## Key Classes
 
   | Class | Purpose |
   |-------|---------|
-  | `MMG::Mesh` | MMG-specific mesh type (extends `Geometry::Mesh<Local>`) with ridge, corner, and required-entity metadata. Loaded and saved via MEDIT format. |
-  | `MMG::Adapt` | Metric-based adaptation: remeshes a mesh according to a nodal size map. |
-  | `MMG::MeshOptimizer` | Mesh-quality optimization: improves element shapes without a metric field. |
-  | `MMG::LevelSetDiscretizer` | Implicit-domain meshing: cuts a background mesh along a level-set isovalue. |
-  | `MMG::MMG5` | Base class providing shared remeshing controls. |
+  | `MMG::Mesh` | Local mesh type extending `Geometry::Mesh<Local>` with corner, ridge, and required-entity metadata. |
+  | `MMG::Adapt` | Metric-based adaptation from a nodal size map. |
+  | `MMG::Optimizer` | Mesh-quality optimization without an external metric field. |
+  | `MMG::LevelSetDiscretizer` | Level-set meshing: cuts a background mesh along an isovalue or extracts the isosurface. |
+  | `MMG::MMG5` | Base class providing shared MMG configuration and native conversion helpers. |
+
+  ## Workflow Semantics
+
+  `Optimizer`, `Adapt`, and `LevelSetDiscretizer` are intentionally different
+  operations:
+
+  | Workflow | Expected behavior |
+  |----------|-------------------|
+  | `Optimizer` | Improves element quality while keeping the mesh close to the existing local size distribution. |
+  | `Adapt` | Refines, coarsens, moves, and reconnects elements according to a size field. |
+  | `LevelSetDiscretizer` | Alters topology as needed to conform the output mesh to the selected level-set isovalue. |
+
+  All workflows convert an `MMG::Mesh` to native MMG structures, run MMG, and
+  convert the result back. The output is a remeshed object; input element
+  indices should be treated as stable only where the wrapper or tests
+  explicitly document preservation.
 
   ## Auto-Dispatch
 
-  `Adapt`, `MeshOptimizer`, and `LevelSetDiscretizer` all auto-dispatch to the
-  appropriate MMG backend based on the mesh type:
+  The wrappers auto-dispatch to the appropriate MMG backend based on the mesh
+  type:
 
   | Mesh type | Backend |
   |-----------|---------|
@@ -1269,16 +1275,50 @@
 
   ## Shared Configuration (MMG5 base)
 
-  All three classes inherit from `MMG5` and share these configuration methods
-  (each returns `*this` for chaining):
+  The MMG wrappers inherit common configuration methods from `MMG5`; each
+  returns `*this` for chaining:
 
-  | Method | Default | Description |
-  |--------|---------|-------------|
-  | `setHMin(hmin)` | ~0.01× bounding box | Minimal allowed edge size |
-  | `setHMax(hmax)` | ~2× bounding box | Maximal allowed edge size |
-  | `setHausdorff(hausd)` | 0.01 | Hausdorff distance tolerance for boundary approximation |
-  | `setGradation(hgrad)` | 1.3 | Edge-size gradation ratio between adjacent elements |
-  | `setAngleDetection(bool)` | true | Enable ridge angle detection for feature preservation |
+  | Method | Description |
+  |--------|-------------|
+  | `setHMin(hmin)` | Minimal allowed edge size |
+  | `setHMax(hmax)` | Maximal allowed edge size |
+  | `setHausdorff(hausd)` | Hausdorff distance tolerance for boundary approximation |
+  | `setGradation(hgrad)` | Edge-size gradation ratio between adjacent elements |
+  | `setAngleDetection(bool)` | Enable ridge angle detection for feature preservation |
+
+  ## Required Entities
+
+  `MMG::Mesh` stores MMG-specific metadata:
+
+  | Method | Description |
+  |--------|-------------|
+  | `setCorner(vertexIdx)` | Mark a vertex as a geometric corner |
+  | `setRidge(edgeIdx)` | Mark an edge as a geometric ridge |
+  | `setRequiredVertex(idx)` | Mark a vertex as required (`MG_REQ`) |
+  | `setRequiredEdge(idx)` | Mark an edge as required (`MG_REQ`) |
+  | `setRequiredTriangle(idx)` | Mark a triangle as required (`MG_REQ`) |
+  | `setRequiredTetrahedron(idx)` | Mark a tetrahedron as required (`MG_REQ`) |
+
+  Required vertices, edges, triangles, and tetrahedra are serialized through
+  MEDIT, converted to native MMG `MG_REQ` tags, and restored from native MMG
+  output. The optimizer and level-set wrappers restore required index sets when
+  the original indices are still valid after remeshing.
+  In MMG3D, `setRequiredTriangle(idx)` applies to boundary triangles exported
+  to MMG's triangle table; interior faces of a tetrahedral mesh are not exported
+  as MMG boundary triangles when face-cell incidence is available.
+
+  For level-set discretization, the tested behavior is:
+
+  - required entities not crossed by the level set retain their required
+    metadata and original geometry in the 2D/3D cases covered by the test
+    suite;
+  - required entities crossed by the level set are not guaranteed to remain
+    intact. MMG may replace them to conform the mesh to the isovalue, even when
+    `MG_REQ`, individual labels, adjacent tetrahedron labels, local closure
+    requirements, or `noSplit(ref)` are used.
+
+  See @ref examples-mmg-behavior "MMG behavior and guarantees" for the full
+  characterization.
 
   ## LevelSetDiscretizer API
 
@@ -1288,54 +1328,23 @@
   |--------|-------------|
   | `setLevelSet(ls)` | Isovalue to extract (default: 0.0) |
   | `surface(bool)` | When true, discretize the isosurface; when false, discretize the subdomain volume |
-  | `setRMC(rmc)` | Removal threshold for small parasitic components (default: @f$ 10^{-5} @f$) |
-  | `setBoundaryReference(ref)` | Material reference for the discretized boundary (default: 10) |
+  | `setRMC(rmc)` | Removal threshold for small parasitic components |
+  | `setBoundaryReference(ref)` | Material reference for the discretized boundary |
   | `setBaseReferences(refs)` | Restrict level-set splitting to specified base materials |
-  | `split(ref, split)` / `noSplit(ref)` | Per-material splitting policy |
+  | `split(ref, split)` | Split one material reference into inside/outside references |
+  | `noSplit(ref)` | Keep one material reference from being split by the material policy |
 
-  The `discretize()` method takes an `MMG::RealGridFunction` and returns a
-  new `MMG::Mesh`:
-
-  @code{.cpp}
-  MMG::LevelSetDiscretizer lsd;
-  lsd.setLevelSet(0.0)
-     .setBoundaryReference(10)
-     .setHausdorff(0.005);
-  MMG::Mesh cut = lsd.discretize(phi);
-  @endcode
-
-  ## Typical Usage
+  `noSplit(ref)` is a material-reference splitting policy. It is not an
+  element-integrity guarantee for an individual edge, triangle, or tetrahedron
+  that the level set cuts.
 
   @code{.cpp}
-  #include <Rodin/MMG.h>
-
-  // Adapt: remesh from a size map
-  MMG::Mesh mesh;
-  mesh.load("domain.mesh", IO::FileFormat::MEDIT);
-  P1 Vh(mesh);
-  GridFunction sizeMap(Vh);
-  // ... define sizeMap ...
-  MMG::Adapt().setHMax(0.5).setGradation(1.2).adapt(mesh, sizeMap);
-
-  // Optimize: improve element quality
-  MMG::MeshOptimizer().setHMax(0.5).optimize(mesh);
-
-  // Level-set discretization: cut mesh along phi = 0
-  MMG::LevelSetDiscretizer lsd;
-  MMG::Mesh cut = lsd.setLevelSet(0.0).discretize(phi);
+  MMG::Mesh cut = MMG::LevelSetDiscretizer()
+    .setLevelSet(0.0)
+    .split(interior, { interior, exterior })
+    .setBoundaryReference(interface)
+    .discretize(phi);
   @endcode
-
-  ## MMG::Mesh Extras
-
-  `MMG::Mesh` extends the base `Geometry::Mesh<Local>` with MMG-specific
-  boundary metadata:
-
-  | Method | Description |
-  |--------|-------------|
-  | `setCorner(vertexIdx)` | Mark a vertex as a geometric corner |
-  | `setRidge(edgeIdx)` | Mark an edge as a geometric ridge |
-  | `setRequiredVertex(idx)` | Mark a vertex as required (fixed during remeshing) |
-  | `setRequiredEdge(idx)` | Mark an edge as required |
 
   Use `MMG::Mesh::Build()` to construct meshes programmatically via the
   builder pattern.
@@ -1343,6 +1352,7 @@
   @note Requires the MMG library and Rodin configured with `RODIN_USE_MMG=ON`.
 
   @see @ref examples-mmg-index "MMG examples"
+  @see @ref examples-mmg-behavior "MMG behavior and guarantees"
  */
 
 /**

--- a/doc/Notation.dox
+++ b/doc/Notation.dox
@@ -66,7 +66,7 @@
 | @f$ \varepsilon(\mathbf{u}) @f$ | See below | Symmetric gradient (linearized strain tensor): @f$ \frac{1}{2}(\nabla \mathbf{u} + \nabla \mathbf{u}^T) @f$. |
 | @f$ \mathrm{tr}(A) @f$ | `Trace(A)` | Trace of a matrix: @f$ \mathrm{tr}(A) = \sum_i A_{ii} @f$. |
 | @f$ A : B @f$    | `Dot(A, B)` | Frobenius (double-contraction) inner product of two matrices: @f$ A : B = \sum_{ij} A_{ij} B_{ij} @f$. |
-| @f$ \|A\|_F @f$  | `Frobenius(A)` | Frobenius norm: @f$ \|A\|_F = \sqrt{A : A} @f$. |
+| @f$ \lVert A\rVert_F @f$  | `Frobenius(A)` | Frobenius norm: @f$ \lVert A\rVert_F = \sqrt{A : A} @f$. |
 | @f$ u_i @f$      | `Component(u, i)` | The @f$ i @f$-th component of a vector function (0-indexed). Shorthand: `u.x()`, `u.y()`, `u.z()`. |
 
   @note The symmetric gradient @f$ \varepsilon(\mathbf{u}) @f$ can be built
@@ -128,4 +128,3 @@
 | @f$ \int_\Omega K(\mathbf{x}, \mathbf{y}) f(\mathbf{y}) \, d\mathbf{y} @f$ | `Potential(K, f)` | Integral convolution with kernel @f$ K @f$. |
 
   */
-

--- a/src/Rodin/IO/MEDIT.h
+++ b/src/Rodin/IO/MEDIT.h
@@ -61,6 +61,8 @@ namespace Rodin::IO::MEDIT
     SolAtHexahedra,        ///< Solution at hexahedra
     RequiredVertices,      ///< Required vertices section
     RequiredEdges,         ///< Required edges section
+    RequiredTriangles,     ///< Required triangles section
+    RequiredTetrahedra,    ///< Required tetrahedra section
     Normals,               ///< Normal vectors section
     NormalAtVertices,      ///< Normals at vertices
     Tangents,              ///< Tangent vectors section
@@ -121,6 +123,10 @@ namespace Rodin::IO::MEDIT
         return "RequiredVertices";
       case Keyword::RequiredEdges:
         return "RequiredEdges";
+      case Keyword::RequiredTriangles:
+        return "RequiredTriangles";
+      case Keyword::RequiredTetrahedra:
+        return "RequiredTetrahedra";
       case Keyword::Normals:
         return "Normals";
       case Keyword::NormalAtVertices:
@@ -236,6 +242,10 @@ namespace Rodin::IO::MEDIT
       res = Keyword::RequiredVertices;
     else if (str == Keyword::RequiredEdges)
       res = Keyword::RequiredEdges;
+    else if (str == Keyword::RequiredTriangles)
+      res = Keyword::RequiredTriangles;
+    else if (str == Keyword::RequiredTetrahedra)
+      res = Keyword::RequiredTetrahedra;
     else if (str == Keyword::Normals)
       res = Keyword::Normals;
     else if (str == Keyword::NormalAtVertices)

--- a/src/Rodin/MMG/LevelSetDiscretizer.cpp
+++ b/src/Rodin/MMG/LevelSetDiscretizer.cpp
@@ -275,13 +275,14 @@ namespace Rodin::MMG
       }
       size_t newna = ids.size();
       MMG5_pEdge edges = nullptr;
-      MMG5_SAFE_MALLOC(edges, newna + 1, MMG5_Edge,
+      MMG5_SAFE_CALLOC(edges, newna + 1, MMG5_Edge,
           Alert::MemberFunctionException(*this, __func__)
             << "Failed to reallocate edge memory." << Alert::Raise);
       for (int i = 1; i <= newna; i++)
         edges[i] = mesh->edge[ids[i - 1]];
       MMG5_SAFE_FREE(mesh->edge);
       mesh->na = newna;
+      mesh->namax = newna;
       mesh->edge = edges;
     }
     else if (mesh->dim == 3)
@@ -296,13 +297,14 @@ namespace Rodin::MMG
       }
       size_t newnt = ids.size();
       MMG5_pTria triangles = nullptr;
-      MMG5_SAFE_MALLOC(triangles, newnt + 1, MMG5_Tria,
+      MMG5_SAFE_CALLOC(triangles, newnt + 1, MMG5_Tria,
           Alert::MemberFunctionException(*this, __func__)
             << "Failed to reallocate triangles." << Alert::Raise);
       for (int i = 1; i <= newnt; i++)
         triangles[i] = mesh->tria[ids[i - 1]];
       MMG5_SAFE_FREE(mesh->tria);
       mesh->nt = newnt;
+      mesh->ntmax = newnt;
       mesh->tria = triangles;
     }
     else
@@ -315,6 +317,18 @@ namespace Rodin::MMG
   {
     const auto& fes = ls.getFiniteElementSpace();
     const auto& mesh = fes.getMesh();
+    IndexSet requiredVertices;
+    IndexSet requiredEdges;
+    IndexSet requiredTriangles;
+    IndexSet requiredTetrahedra;
+    if (const auto* inputMesh = dynamic_cast<const MMG::Mesh*>(&mesh))
+    {
+      requiredVertices = inputMesh->getRequiredVertices();
+      requiredEdges = inputMesh->getRequiredEdges();
+      requiredTriangles = inputMesh->getRequiredTriangles();
+      requiredTetrahedra = inputMesh->getRequiredTetrahedra();
+    }
+
     MMG5_pMesh mmgMesh = nullptr;
     mmgMesh = rodinToMesh(ls.getFiniteElementSpace().getMesh());
 
@@ -370,6 +384,37 @@ namespace Rodin::MMG
     // deleteBoundaryRef(mmgMesh, 0);
 
     auto rodinMesh = meshToRodin(mmgMesh);
+    rodinMesh.getRequiredVertices().clear();
+    const size_t vertexCount = rodinMesh.getVertexCount();
+    for (const auto& idx : requiredVertices)
+    {
+      if (idx < vertexCount)
+        rodinMesh.setRequiredVertex(idx);
+    }
+    rodinMesh.getRequiredEdges().clear();
+    const size_t edgeCount =
+      rodinMesh.getPolytopeCount(Geometry::Polytope::Type::Segment);
+    for (const auto& idx : requiredEdges)
+    {
+      if (idx < edgeCount)
+        rodinMesh.setRequiredEdge(idx);
+    }
+    rodinMesh.getRequiredTriangles().clear();
+    const size_t triangleCount =
+      rodinMesh.getPolytopeCount(Geometry::Polytope::Type::Triangle);
+    for (const auto& idx : requiredTriangles)
+    {
+      if (idx < triangleCount)
+        rodinMesh.setRequiredTriangle(idx);
+    }
+    rodinMesh.getRequiredTetrahedra().clear();
+    const size_t tetrahedronCount =
+      rodinMesh.getPolytopeCount(Geometry::Polytope::Type::Tetrahedron);
+    for (const auto& idx : requiredTetrahedra)
+    {
+      if (idx < tetrahedronCount)
+        rodinMesh.setRequiredTetrahedron(idx);
+    }
     destroySolution(sol);
     destroyMesh(mmgMesh);
 

--- a/src/Rodin/MMG/LevelSetDiscretizer.cpp
+++ b/src/Rodin/MMG/LevelSetDiscretizer.cpp
@@ -274,15 +274,21 @@ namespace Rodin::MMG
           ids.push_back(i);
       }
       size_t newna = ids.size();
+      // MMG treats a non-null edge array as holding at least one entry, so an
+      // empty result must leave the pointer null. Likewise, namax must stay
+      // positive as MMG uses it to size internal allocations.
       MMG5_pEdge edges = nullptr;
-      MMG5_SAFE_CALLOC(edges, newna + 1, MMG5_Edge,
-          Alert::MemberFunctionException(*this, __func__)
-            << "Failed to reallocate edge memory." << Alert::Raise);
-      for (int i = 1; i <= newna; i++)
-        edges[i] = mesh->edge[ids[i - 1]];
+      if (newna > 0)
+      {
+        MMG5_SAFE_CALLOC(edges, newna + 1, MMG5_Edge,
+            Alert::MemberFunctionException(*this, __func__)
+              << "Failed to reallocate edge memory." << Alert::Raise);
+        for (size_t i = 1; i <= newna; i++)
+          edges[i] = mesh->edge[ids[i - 1]];
+        mesh->namax = newna;
+      }
       MMG5_SAFE_FREE(mesh->edge);
       mesh->na = newna;
-      mesh->namax = newna;
       mesh->edge = edges;
     }
     else if (mesh->dim == 3)
@@ -296,15 +302,21 @@ namespace Rodin::MMG
           ids.push_back(i);
       }
       size_t newnt = ids.size();
+      // MMG treats a non-null triangle array as holding at least one entry,
+      // so an empty result must leave the pointer null. Likewise, ntmax must
+      // stay positive as MMG5_bdrySet sizes xtetra from it.
       MMG5_pTria triangles = nullptr;
-      MMG5_SAFE_CALLOC(triangles, newnt + 1, MMG5_Tria,
-          Alert::MemberFunctionException(*this, __func__)
-            << "Failed to reallocate triangles." << Alert::Raise);
-      for (int i = 1; i <= newnt; i++)
-        triangles[i] = mesh->tria[ids[i - 1]];
+      if (newnt > 0)
+      {
+        MMG5_SAFE_CALLOC(triangles, newnt + 1, MMG5_Tria,
+            Alert::MemberFunctionException(*this, __func__)
+              << "Failed to reallocate triangles." << Alert::Raise);
+        for (size_t i = 1; i <= newnt; i++)
+          triangles[i] = mesh->tria[ids[i - 1]];
+        mesh->ntmax = newnt;
+      }
       MMG5_SAFE_FREE(mesh->tria);
       mesh->nt = newnt;
-      mesh->ntmax = newnt;
       mesh->tria = triangles;
     }
     else

--- a/src/Rodin/MMG/LevelSetDiscretizer.h
+++ b/src/Rodin/MMG/LevelSetDiscretizer.h
@@ -30,6 +30,13 @@ namespace Rodin::MMG
    * multi-material meshes can be split into interior/exterior regions with
    * user-defined labels.
    *
+   * The output topology is chosen by MMG. In particular, required entities
+   * and `noSplit()` material policies do not force an entity crossed by the
+   * level set to remain geometrically untouched. Rodin's tested behavior is
+   * that required vertices, edges, triangles, and tetrahedra away from the cut
+   * keep their metadata and original geometry in the covered 2D/3D cases.
+   * Cut-through required entities may be replaced by MMG.
+   *
    * The canonical signed-distance interpretation is:
    * @f[
    *  \left\{
@@ -43,6 +50,8 @@ namespace Rodin::MMG
    *
    * Inherits common remeshing controls from @ref MMG5 (hmin/hmax/hausdorff/
    * gradation/angle detection).
+   *
+   * @see @ref examples-mmg-behavior
    */
   class LevelSetDiscretizer : public MMG5
   {
@@ -135,6 +144,10 @@ namespace Rodin::MMG
        * @brief Indicates that a material reference should not be split.
        * @param[in] ref Material reference that should not be split
        * @returns Reference to self (for method chaining)
+       *
+       * This configures MMG's material-reference split policy. It does not
+       * make each individual edge, triangle, or tetrahedron with that
+       * reference immutable when the level set cuts through it.
        */
       LevelSetDiscretizer& noSplit(const Geometry::Attribute& ref);
 
@@ -147,6 +160,11 @@ namespace Rodin::MMG
        *
        * The material reference of the generated level-set boundary defaults to
        * `10` unless changed via @ref setBoundaryReference.
+       *
+       * @note Required entities that are not crossed by the level set are
+       * tested to keep their metadata and original geometry in Rodin's 2D/3D
+       * cases. If the level set crosses a required entity, MMG may replace it
+       * while conforming the output mesh to the isovalue.
        */
       MMG::Mesh discretize(const MMG::RealGridFunction& ls);
 

--- a/src/Rodin/MMG/MMG5.cpp
+++ b/src/Rodin/MMG/MMG5.cpp
@@ -314,6 +314,7 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
 {
   bool isSurface = src.isSurface();
   assert(isSurface || (src.getSpaceDimension() == src.getDimension()));
+  const auto* ptr = dynamic_cast<const MMG::Mesh*>(&src);
 
   MMG5_pMesh res = createMesh(
       s_meshVersionFormatted, src.getDimension(), src.getSpaceDimension());
@@ -502,6 +503,14 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
   else if (src.getDimension() == 3) // Use MMG3D
   {
     constexpr size_t edgeDim = 1;
+    constexpr size_t faceDim = 2;
+    constexpr size_t cellDim = 3;
+    const bool hasFaceCellIncidence =
+      src.getConnectivity().getIncidence(faceDim, cellDim).size() > 0;
+    const auto isMMG3DBoundaryTriangle = [&](Index faceIdx)
+    {
+      return !hasFaceCellIncidence || src.isBoundary(faceIdx);
+    };
 
     // Always convert cells (tets)
     res->ne = src.getCellCount();
@@ -518,12 +527,19 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
       edgeRemap.assign(rodinEdgeCount, 0);
     }
 
-    // Only convert boundary triangles if they have an attribute
+    // Only convert boundary triangles if they have an attribute or MMG metadata
     {
       size_t nt = 0;
       for (auto it = src.getFace(); !it.end(); ++it)
-        if ((*it).getAttribute().has_value())
+      {
+        const auto& face = *it;
+        if (!isMMG3DBoundaryTriangle(face.getIndex()))
+          continue;
+        const bool isRequired =
+          ptr && ptr->getRequiredTriangles().count(face.getIndex()) > 0;
+        if (face.getAttribute().has_value() || isRequired)
           ++nt;
+      }
       res->nt = nt;
 
       triRemap.assign(src.getFaceCount(), 0);
@@ -575,7 +591,12 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
       const auto& face = *it;
       assert(face.getGeometry() == Geometry::Polytope::Type::Triangle);
 
-      if (!face.getAttribute().has_value())
+      if (!isMMG3DBoundaryTriangle(face.getIndex()))
+        continue;
+
+      const bool isRequired =
+        ptr && ptr->getRequiredTriangles().count(face.getIndex()) > 0;
+      if (!face.getAttribute().has_value() && !isRequired)
         continue;
 
       const Index old = face.getIndex();
@@ -588,7 +609,7 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
       pt->v[0] = vertices[0] + 1;
       pt->v[1] = vertices[1] + 1;
       pt->v[2] = vertices[2] + 1;
-      pt->ref = *face.getAttribute();
+      pt->ref = face.getAttribute().value_or(0);
     }
 
     // Copy tetrahedra with correct orientation (cells always)
@@ -626,7 +647,6 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
     return nullptr;
   }
 
-  const auto* ptr = dynamic_cast<const MMG::Mesh*>(&src);
   if (ptr)
   {
     // Tag corners (vertices always exist)
@@ -684,6 +704,38 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
         if (old + 1 <= res->na)
           res->edge[old + 1].tag |= MG_REQ;
       }
+    }
+
+    // Tag required triangles
+    for (const auto& r : ptr->getRequiredTriangles())
+    {
+      assert(r >= 0);
+      const Index old = r;
+
+      Index i = 0;
+      if (!triRemap.empty() && old >= 0 && (size_t)old < triRemap.size())
+      {
+        i = triRemap[old];
+      }
+      else if (old + 1 <= res->nt)
+      {
+        i = old + 1;
+      }
+
+      if (i > 0)
+      {
+        res->tria[i].tag[0] |= MG_REQ;
+        res->tria[i].tag[1] |= MG_REQ;
+        res->tria[i].tag[2] |= MG_REQ;
+      }
+    }
+
+    // Tag required tetrahedra (tetrahedra are always copied densely)
+    for (const auto& r : ptr->getRequiredTetrahedra())
+    {
+      assert(r >= 0);
+      if (r + 1 <= res->ne)
+        res->tetra[r + 1].tag |= MG_REQ;
     }
   }
 
@@ -773,6 +825,10 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
             static_cast<size_t>(src->tria[i].v[1] - 1),
             static_cast<size_t>(src->tria[i].v[2] - 1) });
       build.attribute({ 2, i - 1 }, src->tria[i].ref );
+      if ((src->tria[i].tag[0] & MG_REQ) &&
+          (src->tria[i].tag[1] & MG_REQ) &&
+          (src->tria[i].tag[2] & MG_REQ))
+        build.requiredTriangle(i - 1);
     }
     // Add tetrahedra
     build.reserve(3, src->ne);
@@ -788,6 +844,8 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
             static_cast<size_t>(src->tetra[i].v[2] - 1),
             static_cast<size_t>(src->tetra[i].v[3] - 1) });
       build.attribute({ 3, i - 1 }, src->tetra[i].ref );
+      if (src->tetra[i].tag & MG_REQ)
+        build.requiredTetrahedron(i - 1);
     }
     return build.finalize();
   }
@@ -987,4 +1045,3 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
     return *this;
   }
 }
-

--- a/src/Rodin/MMG/Mesh.cpp
+++ b/src/Rodin/MMG/Mesh.cpp
@@ -30,6 +30,18 @@ namespace Rodin::MMG
     return *this;
   }
 
+  Mesh& Mesh::setRequiredTriangle(Index triangleIdx)
+  {
+    m_requiredTriangleIndex.insert(triangleIdx);
+    return *this;
+  }
+
+  Mesh& Mesh::setRequiredTetrahedron(Index tetrahedronIdx)
+  {
+    m_requiredTetrahedronIndex.insert(tetrahedronIdx);
+    return *this;
+  }
+
   Mesh& Mesh::setRequiredVertex(Index vertexIdx)
   {
     m_requiredVertexIndex.insert(vertexIdx);
@@ -79,4 +91,3 @@ namespace Rodin::MMG
     return *this;
   }
 }
-

--- a/src/Rodin/MMG/Mesh.h
+++ b/src/Rodin/MMG/Mesh.h
@@ -19,14 +19,30 @@ namespace Rodin::MMG
    * @brief Local mesh enriched with MMG boundary tags and constraints.
    *
    * This class extends @ref Rodin::Geometry::Mesh<Context::Local> with index
-   * sets required by MMG workflows:
+   * sets used by MMG workflows:
    * - corners (`MG_CRN`),
    * - ridges (`MG_GEO`),
    * - required vertices (`MG_REQ`),
-   * - required edges (`MG_REQ` on edges).
+   * - required edges (`MG_REQ` on edges),
+   * - required triangles (`MG_REQ` on triangle entities),
+   * - required tetrahedra (`MG_REQ` on tetrahedra).
    *
    * These sets are preserved when converting to/from native MMG structures via
-   * @ref MMG5::rodinToMesh and @ref MMG5::meshToRodin.
+   * @ref MMG5::rodinToMesh and @ref MMG5::meshToRodin. The optimizer and
+   * level-set wrappers also restore the required index sets when the original
+   * indices are still valid in the remeshed output.
+   * In MMG3D, required triangles refer to boundary triangles exported to MMG's
+   * triangle table; interior faces of a tetrahedral mesh are not exported as
+   * MMG boundary triangles when face-cell incidence is available.
+   *
+   * @note Required entities are MMG constraints, not an unconditional
+   * element-integrity promise for every workflow. In level-set discretization,
+   * required entities that are not crossed by the level set are tested to keep
+   * their metadata and geometry in Rodin's 2D/3D test cases. If the level set
+   * crosses a required entity, MMG may alter that entity in order to conform
+   * the output mesh to the isovalue.
+   *
+   * @see @ref examples-mmg-behavior
    */
   class Mesh : public Geometry::Mesh<Context::Local>
   {
@@ -48,6 +64,12 @@ namespace Rodin::MMG
 
       /// Index set of required edges in the mesh.
       using RequiredEdgeIndex = IndexSet;
+
+      /// Index set of required triangles in the mesh.
+      using RequiredTriangleIndex = IndexSet;
+
+      /// Index set of required tetrahedra in the mesh.
+      using RequiredTetrahedronIndex = IndexSet;
 
       /**
        * @brief Class used to build MMG::Mesh instances.
@@ -73,7 +95,9 @@ namespace Rodin::MMG
               m_cornerIndex(std::move(other.m_cornerIndex)),
               m_ridgeIndex(std::move(other.m_ridgeIndex)),
               m_requiredVertexIndex(std::move(other.m_requiredVertexIndex)),
-              m_requiredEdgeIndex(std::move(other.m_requiredEdgeIndex))
+              m_requiredEdgeIndex(std::move(other.m_requiredEdgeIndex)),
+              m_requiredTriangleIndex(std::move(other.m_requiredTriangleIndex)),
+              m_requiredTetrahedronIndex(std::move(other.m_requiredTetrahedronIndex))
           {}
 
           /**
@@ -194,6 +218,20 @@ namespace Rodin::MMG
           Builder& requiredEdge(Index edgeIdx);
 
           /**
+           * @brief Marks a triangle as required.
+           * @param[in] triangleIdx Triangle index in the mesh.
+           * @returns Reference to this builder.
+           */
+          Builder& requiredTriangle(Index triangleIdx);
+
+          /**
+           * @brief Marks a tetrahedron as required.
+           * @param[in] tetrahedronIdx Tetrahedron index in the mesh.
+           * @returns Reference to this builder.
+           */
+          Builder& requiredTetrahedron(Index tetrahedronIdx);
+
+          /**
            * @brief Marks a vertex as required.
            * @param[in] vertexIdx Vertex index in the mesh.
            * @returns Reference to this builder.
@@ -212,6 +250,8 @@ namespace Rodin::MMG
           RidgeIndex  m_ridgeIndex; ///< Ridge edge set accumulated during build.
           RequiredVertexIndex m_requiredVertexIndex; ///< Required-vertex set accumulated during build.
           RequiredEdgeIndex m_requiredEdgeIndex; ///< Required-edge set accumulated during build.
+          RequiredTriangleIndex m_requiredTriangleIndex; ///< Required-triangle set accumulated during build.
+          RequiredTetrahedronIndex m_requiredTetrahedronIndex; ///< Required-tetrahedron set accumulated during build.
       };
 
       /**
@@ -242,6 +282,8 @@ namespace Rodin::MMG
         : Parent(other),
           m_cornerIndex(other.m_cornerIndex),
           m_requiredVertexIndex(other.m_requiredVertexIndex),
+          m_requiredTriangleIndex(other.m_requiredTriangleIndex),
+          m_requiredTetrahedronIndex(other.m_requiredTetrahedronIndex),
           m_ridgeIndex(other.m_ridgeIndex),
           m_requiredEdgeIndex(other.m_requiredEdgeIndex)
       {}
@@ -253,6 +295,8 @@ namespace Rodin::MMG
         : Parent(std::move(other)),
           m_cornerIndex(std::move(other.m_cornerIndex)),
           m_requiredVertexIndex(std::move(other.m_requiredVertexIndex)),
+          m_requiredTriangleIndex(std::move(other.m_requiredTriangleIndex)),
+          m_requiredTetrahedronIndex(std::move(other.m_requiredTetrahedronIndex)),
           m_ridgeIndex(std::move(other.m_ridgeIndex)),
           m_requiredEdgeIndex(std::move(other.m_requiredEdgeIndex))
       {}
@@ -265,6 +309,8 @@ namespace Rodin::MMG
         Parent::operator=(std::move(other));
         m_cornerIndex = std::move(other.m_cornerIndex);
         m_requiredVertexIndex = std::move(other.m_requiredVertexIndex);
+        m_requiredTriangleIndex = std::move(other.m_requiredTriangleIndex);
+        m_requiredTetrahedronIndex = std::move(other.m_requiredTetrahedronIndex);
         m_ridgeIndex = std::move(other.m_ridgeIndex);
         m_requiredEdgeIndex = std::move(other.m_requiredEdgeIndex);
         return *this;
@@ -284,11 +330,15 @@ namespace Rodin::MMG
       {
         m_cornerIndex.clear();
         m_requiredVertexIndex.clear();
+        m_requiredTriangleIndex.clear();
+        m_requiredTetrahedronIndex.clear();
         m_ridgeIndex.clear();
         m_requiredEdgeIndex.clear();
         Parent::operator=(std::move(other));
         m_cornerIndex.clear();
         m_requiredVertexIndex.clear();
+        m_requiredTriangleIndex.clear();
+        m_requiredTetrahedronIndex.clear();
         m_ridgeIndex.clear();
         m_requiredEdgeIndex.clear();
         return *this;
@@ -314,6 +364,20 @@ namespace Rodin::MMG
        * @returns Reference to this mesh.
        */
       Mesh& setRequiredEdge(Index edgeIdx);
+
+      /**
+       * @brief Marks a triangle as required.
+       * @param[in] triangleIdx Triangle index.
+       * @returns Reference to this mesh.
+       */
+      Mesh& setRequiredTriangle(Index triangleIdx);
+
+      /**
+       * @brief Marks a tetrahedron as required.
+       * @param[in] tetrahedronIdx Tetrahedron index.
+       * @returns Reference to this mesh.
+       */
+      Mesh& setRequiredTetrahedron(Index tetrahedronIdx);
 
       /**
        * @brief Marks a vertex as required.
@@ -377,6 +441,42 @@ namespace Rodin::MMG
       }
 
       /**
+       * @brief Gets the required-triangle index set.
+       * @returns Mutable set of required triangle indices.
+       */
+      RequiredTriangleIndex& getRequiredTriangles()
+      {
+        return m_requiredTriangleIndex;
+      }
+
+      /**
+       * @brief Gets the required-triangle index set (const).
+       * @returns Immutable set of required triangle indices.
+       */
+      const RequiredTriangleIndex& getRequiredTriangles() const
+      {
+        return m_requiredTriangleIndex;
+      }
+
+      /**
+       * @brief Gets the required-tetrahedron index set.
+       * @returns Mutable set of required tetrahedron indices.
+       */
+      RequiredTetrahedronIndex& getRequiredTetrahedra()
+      {
+        return m_requiredTetrahedronIndex;
+      }
+
+      /**
+       * @brief Gets the required-tetrahedron index set (const).
+       * @returns Immutable set of required tetrahedron indices.
+       */
+      const RequiredTetrahedronIndex& getRequiredTetrahedra() const
+      {
+        return m_requiredTetrahedronIndex;
+      }
+
+      /**
        * @brief Gets the required-vertex index set.
        * @returns Mutable set of required vertex indices.
        */
@@ -424,6 +524,8 @@ namespace Rodin::MMG
     private:
       CornerIndex m_cornerIndex; ///< Corner vertex indices (`MG_CRN`).
       RequiredVertexIndex m_requiredVertexIndex; ///< Required vertex indices (`MG_REQ` on vertices).
+      RequiredTriangleIndex m_requiredTriangleIndex; ///< Required triangle indices (`MG_REQ` on triangle entities).
+      RequiredTetrahedronIndex m_requiredTetrahedronIndex; ///< Required tetrahedron indices (`MG_REQ` on tetrahedra).
 
       RidgeIndex  m_ridgeIndex; ///< Ridge edge indices (`MG_GEO`).
       RequiredEdgeIndex m_requiredEdgeIndex; ///< Required edge indices (`MG_REQ` on edges).

--- a/src/Rodin/MMG/MeshBuilder.cpp
+++ b/src/Rodin/MMG/MeshBuilder.cpp
@@ -14,6 +14,8 @@ namespace Rodin::MMG
     m_cornerIndex = std::move(other.m_cornerIndex);
     m_ridgeIndex = std::move(other.m_ridgeIndex);
     m_requiredEdgeIndex = std::move(other.m_requiredEdgeIndex);
+    m_requiredTriangleIndex = std::move(other.m_requiredTriangleIndex);
+    m_requiredTetrahedronIndex = std::move(other.m_requiredTetrahedronIndex);
     m_requiredVertexIndex = std::move(other.m_requiredVertexIndex);
     return *this;
   }
@@ -36,6 +38,18 @@ namespace Rodin::MMG
     return *this;
   }
 
+  Mesh::Builder& Mesh::Builder::requiredTriangle(Index triangleIdx)
+  {
+    m_requiredTriangleIndex.insert(triangleIdx);
+    return *this;
+  }
+
+  Mesh::Builder& Mesh::Builder::requiredTetrahedron(Index tetrahedronIdx)
+  {
+    m_requiredTetrahedronIndex.insert(tetrahedronIdx);
+    return *this;
+  }
+
   Mesh::Builder& Mesh::Builder::requiredVertex(Index vertexIdx)
   {
     m_requiredVertexIndex.insert(vertexIdx);
@@ -49,8 +63,9 @@ namespace Rodin::MMG
     res.m_cornerIndex = std::move(m_cornerIndex);
     res.m_ridgeIndex = std::move(m_ridgeIndex);
     res.m_requiredEdgeIndex = std::move(m_requiredEdgeIndex);
+    res.m_requiredTriangleIndex = std::move(m_requiredTriangleIndex);
+    res.m_requiredTetrahedronIndex = std::move(m_requiredTetrahedronIndex);
     res.m_requiredVertexIndex = std::move(m_requiredVertexIndex);
     return res;
   }
 }
-

--- a/src/Rodin/MMG/MeshLoader.cpp
+++ b/src/Rodin/MMG/MeshLoader.cpp
@@ -71,6 +71,27 @@ namespace Rodin::MMG
         mesh.setRequiredVertex(std::stoul(line) - 1);
       }
     }
+
+    find = pos.find(IO::MEDIT::Keyword::RequiredTriangles);
+    if (find != pos.end())
+    {
+      is.seekg(find->second);
+      for (size_t i = 0; i < count.at(IO::MEDIT::Keyword::RequiredTriangles); i++)
+      {
+        std::getline(is, line);
+        mesh.setRequiredTriangle(std::stoul(line) - 1);
+      }
+    }
+
+    find = pos.find(IO::MEDIT::Keyword::RequiredTetrahedra);
+    if (find != pos.end())
+    {
+      is.seekg(find->second);
+      for (size_t i = 0; i < count.at(IO::MEDIT::Keyword::RequiredTetrahedra); i++)
+      {
+        std::getline(is, line);
+        mesh.setRequiredTetrahedron(std::stoul(line) - 1);
+      }
+    }
   }
 }
-

--- a/src/Rodin/MMG/MeshLoader.h
+++ b/src/Rodin/MMG/MeshLoader.h
@@ -21,8 +21,9 @@ namespace Rodin::MMG
    * @brief Loads an @ref Rodin::MMG::Mesh from the MEDIT format.
    *
    * Extends the base MEDIT loader by additionally parsing MMG-specific sections
-   * (corners, ridges, required vertices and required edges) and storing them in
-   * the associated @ref MMG::Mesh metadata sets.
+   * (corners, ridges, required vertices, required edges, required triangles,
+   * and required tetrahedra) and storing them in the associated @ref MMG::Mesh
+   * metadata sets.
    */
   class MeshLoader : public IO::MeshLoader<IO::FileFormat::MEDIT, Context::Local>
   {

--- a/src/Rodin/MMG/MeshOptimizer.h
+++ b/src/Rodin/MMG/MeshOptimizer.h
@@ -28,6 +28,10 @@ namespace Rodin::MMG
    *
    * Typical usage is post-processing after adaptation/imported meshes to remove
    * poorly shaped elements while preserving geometric features.
+   *
+   * Required vertex, edge, triangle, and tetrahedron metadata is passed to MMG
+   * and restored on output when the original indices are still valid after the
+   * optimization.
    */
   class Optimizer : public MMG5
   {
@@ -57,6 +61,10 @@ namespace Rodin::MMG
           return;
         }
 
+        const auto requiredVertices = mesh.getRequiredVertices();
+        const auto requiredEdges = mesh.getRequiredEdges();
+        const auto requiredTriangles = mesh.getRequiredTriangles();
+        const auto requiredTetrahedra = mesh.getRequiredTetrahedra();
         MMG5_pMesh mmgMesh = rodinToMesh(mesh);
 
         MMG5::setParameters(mmgMesh);
@@ -89,6 +97,35 @@ namespace Rodin::MMG
         }
 
         mesh = meshToRodin(mmgMesh);
+        mesh.getRequiredVertices().clear();
+        const size_t vertexCount = mesh.getVertexCount();
+        for (const auto& idx : requiredVertices)
+        {
+          if (idx < vertexCount)
+            mesh.setRequiredVertex(idx);
+        }
+        mesh.getRequiredEdges().clear();
+        const size_t edgeCount = mesh.getPolytopeCount(Geometry::Polytope::Type::Segment);
+        for (const auto& idx : requiredEdges)
+        {
+          if (idx < edgeCount)
+            mesh.setRequiredEdge(idx);
+        }
+        mesh.getRequiredTriangles().clear();
+        const size_t triangleCount = mesh.getPolytopeCount(Geometry::Polytope::Type::Triangle);
+        for (const auto& idx : requiredTriangles)
+        {
+          if (idx < triangleCount)
+            mesh.setRequiredTriangle(idx);
+        }
+        mesh.getRequiredTetrahedra().clear();
+        const size_t tetrahedronCount =
+          mesh.getPolytopeCount(Geometry::Polytope::Type::Tetrahedron);
+        for (const auto& idx : requiredTetrahedra)
+        {
+          if (idx < tetrahedronCount)
+            mesh.setRequiredTetrahedron(idx);
+        }
         destroyMesh(mmgMesh);
       }
 

--- a/src/Rodin/MMG/MeshPrinter.cpp
+++ b/src/Rodin/MMG/MeshPrinter.cpp
@@ -19,6 +19,8 @@ namespace Rodin::MMG
     printRidges(os);
     printRequiredVertices(os);
     printRequiredEdges(os);
+    printRequiredTriangles(os);
+    printRequiredTetrahedra(os);
     m_printer.printEnd(os);
   }
 
@@ -69,5 +71,28 @@ namespace Rodin::MMG
       os << r + 1 << '\n';
     os << '\n';
   }
-}
 
+  void MeshPrinter::printRequiredTriangles(std::ostream& os)
+  {
+    const auto& mesh = getObject();
+    os << IO::MEDIT::Keyword::RequiredTriangles
+       << '\n'
+       << mesh.getRequiredTriangles().size()
+       << '\n';
+    for (const auto& r : mesh.getRequiredTriangles())
+      os << r + 1 << '\n';
+    os << '\n';
+  }
+
+  void MeshPrinter::printRequiredTetrahedra(std::ostream& os)
+  {
+    const auto& mesh = getObject();
+    os << IO::MEDIT::Keyword::RequiredTetrahedra
+       << '\n'
+       << mesh.getRequiredTetrahedra().size()
+       << '\n';
+    for (const auto& r : mesh.getRequiredTetrahedra())
+      os << r + 1 << '\n';
+    os << '\n';
+  }
+}

--- a/src/Rodin/MMG/MeshPrinter.h
+++ b/src/Rodin/MMG/MeshPrinter.h
@@ -26,6 +26,8 @@ namespace Rodin::MMG
    * - `Ridges`
    * - `RequiredVertices`
    * - `RequiredEdges`
+   * - `RequiredTriangles`
+   * - `RequiredTetrahedra`
    */
   class MeshPrinter : public IO::Printer<MMG::Mesh>
   {
@@ -65,6 +67,16 @@ namespace Rodin::MMG
        * @param[out] os Output stream.
        */
       void printRequiredEdges(std::ostream& os);
+      /**
+       * @brief Prints the `RequiredTriangles` section.
+       * @param[out] os Output stream.
+       */
+      void printRequiredTriangles(std::ostream& os);
+      /**
+       * @brief Prints the `RequiredTetrahedra` section.
+       * @param[out] os Output stream.
+       */
+      void printRequiredTetrahedra(std::ostream& os);
 
       /**
        * @brief Gets the mesh bound to this printer.

--- a/tests/unit/Rodin/MMG/MMGTest.cpp
+++ b/tests/unit/Rodin/MMG/MMGTest.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <sstream>
 #include <cmath>
+#include <vector>
 
 #include <Rodin/Geometry.h>
 #include <Rodin/Variational.h>
@@ -18,6 +19,260 @@ using namespace Rodin::Variational;
 
 namespace Rodin::Tests::Unit
 {
+  static Index getFirstBoundaryTriangleIndex(MMG::Mesh& mesh)
+  {
+    mesh.getConnectivity().compute(2, 3);
+    auto it = mesh.getBoundary();
+    EXPECT_FALSE(it.end());
+    if (it.end())
+      return 0;
+    EXPECT_EQ(it->getGeometry(), Polytope::Type::Triangle);
+    return it->getIndex();
+  }
+
+  static void setAllFaceAttributes(MMG::Mesh& mesh, Attribute attr)
+  {
+    mesh.getConnectivity().compute(mesh.getDimension() - 1, mesh.getDimension());
+    for (auto it = mesh.getFace(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+  }
+
+  static void setAllBoundaryAttributes(MMG::Mesh& mesh, Attribute attr)
+  {
+    mesh.getConnectivity().compute(mesh.getDimension() - 1, mesh.getDimension());
+    for (auto it = mesh.getBoundary(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+  }
+
+  static void setAllSegmentAttributes(MMG::Mesh& mesh, Attribute attr)
+  {
+    mesh.getConnectivity().compute(1, mesh.getDimension());
+    for (auto it = mesh.getPolytope(1); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+  }
+
+  static bool samePoint(const Point& a, const Point& b, Real tol = 1e-10)
+  {
+    if (a.getDimension() != b.getDimension())
+      return false;
+    for (size_t i = 0; i < a.getDimension(); i++)
+    {
+      if (std::abs(a.getCoordinates()(i) - b.getCoordinates()(i)) > tol)
+        return false;
+    }
+    return true;
+  }
+
+  static size_t getDimension(Polytope::Type type)
+  {
+    switch (type)
+    {
+      case Polytope::Type::Point:
+        return 0;
+      case Polytope::Type::Segment:
+        return 1;
+      case Polytope::Type::Triangle:
+      case Polytope::Type::Quadrilateral:
+        return 2;
+      case Polytope::Type::Tetrahedron:
+      case Polytope::Type::Pyramid:
+      case Polytope::Type::Hexahedron:
+      case Polytope::Type::Wedge:
+        return 3;
+      default:
+        assert(false);
+        return 0;
+    }
+  }
+
+  static std::vector<Point> getVertexCoordinates(const Mesh<Context::Local>& mesh, const Polytope& p)
+  {
+    std::vector<Point> points;
+    for (const auto& v : p.getVertices())
+    {
+      const auto coords = mesh.getVertexCoordinates(v);
+      points.emplace_back(p, coords, coords);
+    }
+    return points;
+  }
+
+  static bool containsPointSet(const std::vector<Point>& haystack, const std::vector<Point>& needles)
+  {
+    for (const auto& needle : needles)
+    {
+      bool found = false;
+      for (const auto& point : haystack)
+      {
+        if (samePoint(point, needle))
+        {
+          found = true;
+          break;
+        }
+      }
+      if (!found)
+        return false;
+    }
+    return true;
+  }
+
+  static bool hasEntityWithCoordinates(
+      MMG::Mesh& mesh,
+      Polytope::Type type,
+      const std::vector<Point>& points)
+  {
+    const size_t dimension = getDimension(type);
+    if (dimension < mesh.getDimension())
+      mesh.getConnectivity().compute(dimension, mesh.getDimension());
+    for (auto it = mesh.getPolytope(getDimension(type)); it; ++it)
+    {
+      if (it->getGeometry() != type)
+        continue;
+      const auto candidate = getVertexCoordinates(mesh, *it);
+      if (containsPointSet(candidate, points) && containsPointSet(points, candidate))
+        return true;
+    }
+    return false;
+  }
+
+  static bool hasVertexWithCoordinates(MMG::Mesh& mesh, const Point& point)
+  {
+    for (Index i = 0; i < mesh.getVertexCount(); i++)
+    {
+      const auto coords = mesh.getVertexCoordinates(i);
+      const Point candidate(*mesh.getVertex(i), coords, coords);
+      if (samePoint(candidate, point))
+        return true;
+    }
+    return false;
+  }
+
+  static bool isCutByLevelSet(
+      const Mesh<Context::Local>& mesh,
+      const Polytope& p,
+      const std::function<Real(const Point&)>& ls)
+  {
+    bool hasNegative = false;
+    bool hasPositive = false;
+    for (const auto& v : p.getVertices())
+    {
+      const auto coords = mesh.getVertexCoordinates(v);
+      const Real value = ls(Point(p, coords, coords));
+      hasNegative = hasNegative || value < 0;
+      hasPositive = hasPositive || value > 0;
+    }
+    return hasNegative && hasPositive;
+  }
+
+  static Index getFirstCutEntity(
+      MMG::Mesh& mesh,
+      Polytope::Type type,
+      const std::function<Real(const Point&)>& ls)
+  {
+    for (auto it = mesh.getPolytope(getDimension(type)); it; ++it)
+    {
+      if (it->getGeometry() != type)
+        continue;
+      if (isCutByLevelSet(mesh, *it, ls))
+        return it->getIndex();
+    }
+    ADD_FAILURE() << "Could not find cut entity.";
+    return 0;
+  }
+
+  static Index getFirstUncutEntity(
+      MMG::Mesh& mesh,
+      Polytope::Type type,
+      const std::function<Real(const Point&)>& ls)
+  {
+    for (auto it = mesh.getPolytope(getDimension(type)); it; ++it)
+    {
+      if (it->getGeometry() != type)
+        continue;
+      if (!isCutByLevelSet(mesh, *it, ls))
+        return it->getIndex();
+    }
+    ADD_FAILURE() << "Could not find uncut entity.";
+    return 0;
+  }
+
+  static void setCellsContainingVertices(
+      MMG::Mesh& mesh,
+      const Polytope::Key& vertices,
+      Attribute attr)
+  {
+    for (auto it = mesh.getCell(); it; ++it)
+    {
+      bool containsAll = true;
+      for (const auto& vertex : vertices)
+      {
+        bool containsVertex = false;
+        for (const auto& cellVertex : it->getVertices())
+        {
+          if (cellVertex == vertex)
+          {
+            containsVertex = true;
+            break;
+          }
+        }
+        containsAll = containsAll && containsVertex;
+      }
+      if (containsAll)
+        mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+    }
+  }
+
+  static std::vector<Index> getCellsContainingVertices(
+      MMG::Mesh& mesh,
+      const Polytope::Key& vertices)
+  {
+    std::vector<Index> cells;
+    for (auto it = mesh.getCell(); it; ++it)
+    {
+      bool containsAll = true;
+      for (const auto& vertex : vertices)
+      {
+        bool containsVertex = false;
+        for (const auto& cellVertex : it->getVertices())
+        {
+          if (cellVertex == vertex)
+          {
+            containsVertex = true;
+            break;
+          }
+        }
+        containsAll = containsAll && containsVertex;
+      }
+      if (containsAll)
+        cells.emplace_back(it->getIndex());
+    }
+    return cells;
+  }
+
+  static std::vector<Index> getEdgesOnTriangle(MMG::Mesh& mesh, const Polytope::Key& vertices)
+  {
+    std::vector<Index> edges;
+    mesh.getConnectivity().compute(1, mesh.getDimension());
+    for (auto it = mesh.getPolytope(1); it; ++it)
+    {
+      const auto& edgeVertices = it->getVertices();
+      size_t matches = 0;
+      for (const auto& edgeVertex : edgeVertices)
+      {
+        for (const auto& triangleVertex : vertices)
+        {
+          if (edgeVertex == triangleVertex)
+          {
+            matches++;
+            break;
+          }
+        }
+      }
+      if (matches == edgeVertices.size())
+        edges.emplace_back(it->getIndex());
+    }
+    return edges;
+  }
+
   // ========================================================================
   // MMG::Mesh construction tests
   // ========================================================================
@@ -30,6 +285,8 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(mesh.getRidges().size(), 0);
     EXPECT_EQ(mesh.getRequiredVertices().size(), 0);
     EXPECT_EQ(mesh.getRequiredEdges().size(), 0);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 0);
+    EXPECT_EQ(mesh.getRequiredTetrahedra().size(), 0);
   }
 
   TEST(Rodin_MMG_Mesh, UniformGridConstruction)
@@ -107,6 +364,32 @@ namespace Rodin::Tests::Unit
     EXPECT_TRUE(mesh.getRequiredEdges().count(1));
   }
 
+  TEST(Rodin_MMG_Mesh, SetRequiredTriangle)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+
+    mesh.setRequiredTriangle(0);
+    mesh.setRequiredTriangle(3);
+
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 2);
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(0));
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(3));
+  }
+
+  TEST(Rodin_MMG_Mesh, SetRequiredTetrahedron)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+
+    mesh.setRequiredTetrahedron(0);
+    mesh.setRequiredTetrahedron(2);
+
+    EXPECT_EQ(mesh.getRequiredTetrahedra().size(), 2);
+    EXPECT_TRUE(mesh.getRequiredTetrahedra().count(0));
+    EXPECT_TRUE(mesh.getRequiredTetrahedra().count(2));
+  }
+
   // ========================================================================
   // MMG::Mesh copy and move tests
   // ========================================================================
@@ -120,6 +403,8 @@ namespace Rodin::Tests::Unit
     mesh.setRidge(0);
     mesh.setRequiredVertex(5);
     mesh.setRequiredEdge(2);
+    mesh.setRequiredTriangle(1);
+    mesh.setRequiredTetrahedron(0);
 
     MMG::Mesh copy(mesh);
     EXPECT_EQ(copy.getVertexCount(), mesh.getVertexCount());
@@ -128,8 +413,12 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(copy.getRidges().size(), 1);
     EXPECT_EQ(copy.getRequiredVertices().size(), 1);
     EXPECT_EQ(copy.getRequiredEdges().size(), 1);
+    EXPECT_EQ(copy.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(copy.getRequiredTetrahedra().size(), 1);
     EXPECT_TRUE(copy.getCorners().count(0));
     EXPECT_TRUE(copy.getCorners().count(3));
+    EXPECT_TRUE(copy.getRequiredTriangles().count(1));
+    EXPECT_TRUE(copy.getRequiredTetrahedra().count(0));
   }
 
   TEST(Rodin_MMG_Mesh, MoveConstruction)
@@ -140,6 +429,8 @@ namespace Rodin::Tests::Unit
     mesh.setRidge(0);
     mesh.setRequiredVertex(5);
     mesh.setRequiredEdge(2);
+    mesh.setRequiredTriangle(1);
+    mesh.setRequiredTetrahedron(0);
 
     size_t vertexCount = mesh.getVertexCount();
     size_t cellCount = mesh.getCellCount();
@@ -151,6 +442,8 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(moved.getRidges().size(), 1);
     EXPECT_EQ(moved.getRequiredVertices().size(), 1);
     EXPECT_EQ(moved.getRequiredEdges().size(), 1);
+    EXPECT_EQ(moved.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(moved.getRequiredTetrahedra().size(), 1);
   }
 
   TEST(Rodin_MMG_Mesh, MoveAssignment)
@@ -221,24 +514,29 @@ namespace Rodin::Tests::Unit
   {
     MMG::Mesh mesh =
       MMG::Mesh::Builder()
-      .initialize(2)
+      .initialize(3)
       .nodes(4)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .vertex({1, 1})
+      .vertex({0, 0, 0})
+      .vertex({1, 0, 0})
+      .vertex({0, 1, 0})
+      .vertex({0, 0, 1})
+      .polytope(Polytope::Type::Segment, {0, 1})
       .polytope(Polytope::Type::Triangle, {0, 1, 2})
-      .polytope(Polytope::Type::Triangle, {1, 3, 2})
+      .polytope(Polytope::Type::Tetrahedron, {0, 1, 2, 3})
       .corner(0)
       .ridge(0)
       .requiredVertex(1)
       .requiredEdge(0)
+      .requiredTriangle(0)
+      .requiredTetrahedron(0)
       .finalize();
 
     EXPECT_EQ(mesh.getCorners().size(), 1);
     EXPECT_EQ(mesh.getRidges().size(), 1);
     EXPECT_EQ(mesh.getRequiredVertices().size(), 1);
     EXPECT_EQ(mesh.getRequiredEdges().size(), 1);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(mesh.getRequiredTetrahedra().size(), 1);
   }
 
   // ========================================================================
@@ -263,6 +561,8 @@ namespace Rodin::Tests::Unit
 
     mesh.setRequiredVertex(0);
     mesh.setRequiredVertex(15);
+    mesh.setRequiredTriangle(0);
+    mesh.setRequiredTriangle(1);
 
     // Save to file
     const std::string filename = "/tmp/rodin_mmg_test_roundtrip.mesh";
@@ -280,6 +580,9 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(loaded.getCorners().size(), mesh.getCorners().size());
     EXPECT_EQ(loaded.getRidges().size(), mesh.getRidges().size());
     EXPECT_EQ(loaded.getRequiredVertices().size(), mesh.getRequiredVertices().size());
+    EXPECT_EQ(loaded.getRequiredEdges().size(), mesh.getRequiredEdges().size());
+    EXPECT_EQ(loaded.getRequiredTriangles().size(), mesh.getRequiredTriangles().size());
+    EXPECT_EQ(loaded.getRequiredTetrahedra().size(), mesh.getRequiredTetrahedra().size());
 
     // Verify specific corners
     EXPECT_TRUE(loaded.getCorners().count(0));
@@ -290,8 +593,91 @@ namespace Rodin::Tests::Unit
     // Verify required vertices
     EXPECT_TRUE(loaded.getRequiredVertices().count(0));
     EXPECT_TRUE(loaded.getRequiredVertices().count(15));
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(0));
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(1));
 
     // Clean up
+    std::remove(filename.c_str());
+  }
+
+  TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredTriangles2D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+
+    mesh.setRequiredTriangle(0);
+    mesh.setRequiredTriangle(4);
+
+    const std::string filename = "/tmp/rodin_mmg_required_triangles_2d.mesh";
+    mesh.save(filename, IO::FileFormat::MEDIT);
+
+    MMG::Mesh loaded;
+    loaded.load(filename, IO::FileFormat::MEDIT);
+
+    EXPECT_EQ(loaded.getVertexCount(), mesh.getVertexCount());
+    EXPECT_EQ(loaded.getCellCount(), mesh.getCellCount());
+    EXPECT_EQ(loaded.getRequiredTriangles().size(), 2);
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(0));
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(4));
+
+    std::remove(filename.c_str());
+  }
+
+  TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredTriangles3D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    setAllFaceAttributes(mesh, 7);
+    const Index required = 0;
+    mesh.setRequiredTriangle(required);
+
+    const std::string filename = "/tmp/rodin_mmg_required_triangles_3d.mesh";
+    mesh.save(filename, IO::FileFormat::MEDIT);
+
+    MMG::Mesh loaded;
+    loaded.load(filename, IO::FileFormat::MEDIT);
+
+    EXPECT_EQ(loaded.getVertexCount(), mesh.getVertexCount());
+    EXPECT_EQ(loaded.getCellCount(), mesh.getCellCount());
+    EXPECT_EQ(loaded.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(required));
+
+    std::remove(filename.c_str());
+  }
+
+  TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredEntities3D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    setAllSegmentAttributes(mesh, 8);
+    setAllFaceAttributes(mesh, 7);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = getFirstBoundaryTriangleIndex(mesh);
+    const Index requiredTetrahedron = 0;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+    mesh.setRequiredTetrahedron(requiredTetrahedron);
+
+    const std::string filename = "/tmp/rodin_mmg_required_entities_3d.mesh";
+    mesh.save(filename, IO::FileFormat::MEDIT);
+
+    MMG::Mesh loaded;
+    loaded.load(filename, IO::FileFormat::MEDIT);
+
+    EXPECT_EQ(loaded.getVertexCount(), mesh.getVertexCount());
+    EXPECT_EQ(loaded.getCellCount(), mesh.getCellCount());
+    EXPECT_EQ(loaded.getRequiredVertices().size(), 1);
+    EXPECT_EQ(loaded.getRequiredEdges().size(), 1);
+    EXPECT_EQ(loaded.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(loaded.getRequiredTetrahedra().size(), 1);
+    EXPECT_TRUE(loaded.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(loaded.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(loaded.getRequiredTriangles().count(requiredTriangle));
+    EXPECT_TRUE(loaded.getRequiredTetrahedra().count(requiredTetrahedron));
+
     std::remove(filename.c_str());
   }
 
@@ -314,6 +700,8 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(loaded.getRidges().size(), 0);
     EXPECT_EQ(loaded.getRequiredVertices().size(), 0);
     EXPECT_EQ(loaded.getRequiredEdges().size(), 0);
+    EXPECT_EQ(loaded.getRequiredTriangles().size(), 0);
+    EXPECT_EQ(loaded.getRequiredTetrahedra().size(), 0);
 
     std::remove(filename.c_str());
   }
@@ -367,6 +755,7 @@ namespace Rodin::Tests::Unit
     }
 
     mesh.setRequiredVertex(0);
+    mesh.setRequiredTriangle(1);
 
     // Convert to MMG and back
     MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
@@ -385,6 +774,10 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(result.getRequiredVertices().size(), mesh.getRequiredVertices().size());
     EXPECT_TRUE(result.getRequiredVertices().count(0));
 
+    // Required triangles should be preserved
+    EXPECT_EQ(result.getRequiredTriangles().size(), mesh.getRequiredTriangles().size());
+    EXPECT_TRUE(result.getRequiredTriangles().count(1));
+
     // Ridges live on edges; only attributed edges survive the roundtrip.
     // Verify that the result carries at least some ridges if any attributed
     // edges were marked.
@@ -392,6 +785,117 @@ namespace Rodin::Tests::Unit
     {
       EXPECT_GT(result.getRidges().size(), 0);
     }
+  }
+
+  TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip2D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh.setRequiredTriangle(0);
+    mesh.setRequiredTriangle(3);
+
+    MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
+    ASSERT_NE(mmgMesh, nullptr);
+
+    MMG::Mesh result = MMG::MMG5::meshToRodin(mmgMesh);
+    MMG::MMG5::destroyMesh(mmgMesh);
+
+    EXPECT_EQ(result.getRequiredTriangles().size(), 2);
+    EXPECT_TRUE(result.getRequiredTriangles().count(0));
+    EXPECT_TRUE(result.getRequiredTriangles().count(3));
+  }
+
+  TEST(Rodin_MMG_MMG5, RequiredEntitiesRoundtrip2D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    setAllSegmentAttributes(mesh, 8);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = 3;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+
+    MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
+    ASSERT_NE(mmgMesh, nullptr);
+
+    MMG::Mesh result = MMG::MMG5::meshToRodin(mmgMesh);
+    MMG::MMG5::destroyMesh(mmgMesh);
+
+    EXPECT_EQ(result.getRequiredVertices().size(), 1);
+    EXPECT_EQ(result.getRequiredEdges().size(), 1);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
+  }
+
+  TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip3DWithoutFaceAttributes)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    const Index required = getFirstBoundaryTriangleIndex(mesh);
+    mesh.setRequiredTriangle(required);
+
+    MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
+    ASSERT_NE(mmgMesh, nullptr);
+
+    MMG::Mesh result = MMG::MMG5::meshToRodin(mmgMesh);
+    MMG::MMG5::destroyMesh(mmgMesh);
+
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+  }
+
+  TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip3DPreservesBoundaryMetadataWithFaceAttributes)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    setAllBoundaryAttributes(mesh, 7);
+    const Index required = getFirstBoundaryTriangleIndex(mesh);
+    mesh.setRequiredTriangle(required);
+
+    MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
+    ASSERT_NE(mmgMesh, nullptr);
+
+    MMG::Mesh result = MMG::MMG5::meshToRodin(mmgMesh);
+    MMG::MMG5::destroyMesh(mmgMesh);
+
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(result.getRequiredTriangles().count(0));
+  }
+
+  TEST(Rodin_MMG_MMG5, RequiredEntitiesRoundtrip3D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    setAllSegmentAttributes(mesh, 8);
+    setAllBoundaryAttributes(mesh, 7);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = getFirstBoundaryTriangleIndex(mesh);
+    const Index requiredTetrahedron = 0;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+    mesh.setRequiredTetrahedron(requiredTetrahedron);
+
+    MMG5_pMesh mmgMesh = MMG::MMG5::rodinToMesh(mesh);
+    ASSERT_NE(mmgMesh, nullptr);
+
+    MMG::Mesh result = MMG::MMG5::meshToRodin(mmgMesh);
+    MMG::MMG5::destroyMesh(mmgMesh);
+
+    EXPECT_EQ(result.getRequiredVertices().size(), 1);
+    EXPECT_EQ(result.getRequiredEdges().size(), 1);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(result.getRequiredTetrahedra().size(), 1);
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(0));
+    EXPECT_TRUE(result.getRequiredTetrahedra().count(requiredTetrahedron));
   }
 
   // ========================================================================
@@ -455,6 +959,99 @@ namespace Rodin::Tests::Unit
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_GT(mesh.getVertexCount(), 0);
     EXPECT_GT(mesh.getCellCount(), 0);
+  }
+
+  TEST(Rodin_MMG_Optimizer, PreservesRequiredTriangles2D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 6, 6 });
+    const Index required = 0;
+    mesh.setRequiredTriangle(required);
+
+    MMG::Optimizer()
+      .setHMax(0.5)
+      .optimize(mesh);
+
+    EXPECT_FALSE(mesh.isEmpty());
+    EXPECT_GT(mesh.getCellCount(), 0);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(required));
+  }
+
+  TEST(Rodin_MMG_Optimizer, PreservesRequiredTriangles3D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    const Index required = getFirstBoundaryTriangleIndex(mesh);
+    mesh.setRequiredTriangle(required);
+
+    MMG::Optimizer()
+      .setHMax(0.75)
+      .optimize(mesh);
+
+    EXPECT_FALSE(mesh.isEmpty());
+    EXPECT_GT(mesh.getCellCount(), 0);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(required));
+  }
+
+  TEST(Rodin_MMG_Optimizer, PreservesRequiredEntities2D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 6, 6 });
+    setAllSegmentAttributes(mesh, 8);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = 0;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+
+    MMG::Optimizer()
+      .setHMax(0.5)
+      .optimize(mesh);
+
+    EXPECT_FALSE(mesh.isEmpty());
+    EXPECT_GT(mesh.getCellCount(), 0);
+    EXPECT_EQ(mesh.getRequiredVertices().size(), 1);
+    EXPECT_EQ(mesh.getRequiredEdges().size(), 1);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(mesh.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(mesh.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(requiredTriangle));
+  }
+
+  TEST(Rodin_MMG_Optimizer, PreservesRequiredEntities3D)
+  {
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    setAllSegmentAttributes(mesh, 8);
+    setAllFaceAttributes(mesh, 7);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = getFirstBoundaryTriangleIndex(mesh);
+    const Index requiredTetrahedron = 0;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+    mesh.setRequiredTetrahedron(requiredTetrahedron);
+
+    MMG::Optimizer()
+      .setHMax(0.75)
+      .optimize(mesh);
+
+    EXPECT_FALSE(mesh.isEmpty());
+    EXPECT_GT(mesh.getCellCount(), 0);
+    EXPECT_EQ(mesh.getRequiredVertices().size(), 1);
+    EXPECT_EQ(mesh.getRequiredEdges().size(), 1);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(mesh.getRequiredTetrahedra().size(), 1);
+    EXPECT_TRUE(mesh.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(mesh.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(mesh.getRequiredTriangles().count(requiredTriangle));
+    EXPECT_TRUE(mesh.getRequiredTetrahedra().count(requiredTetrahedron));
   }
 
   // ========================================================================
@@ -678,6 +1275,831 @@ namespace Rodin::Tests::Unit
 
     EXPECT_FALSE(result.isEmpty());
     EXPECT_GT(result.getVertexCount(), 0);
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesRequiredTriangles2D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+    const Index required = 0;
+    mesh.setRequiredTriangle(required);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = [](const Geometry::Point& p)
+    {
+      return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
+    };
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_GT(result.getCellCount(), 0);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(result.getRequiredTriangles().count(required));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesRequiredTriangles3D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    const Index required = getFirstBoundaryTriangleIndex(mesh);
+    mesh.setRequiredTriangle(required);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = [](const Geometry::Point& p)
+    {
+      const Real dx = p.x() - 0.5;
+      const Real dy = p.y() - 0.5;
+      const Real dz = p.z() - 0.5;
+      return dx * dx + dy * dy + dz * dz - 0.16;
+    };
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_GT(result.getCellCount(), 0);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(result.getRequiredTriangles().count(required));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesRequiredEntities2D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+    setAllSegmentAttributes(mesh, 8);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = 0;
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = [](const Geometry::Point& p)
+    {
+      return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
+    };
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_GT(result.getCellCount(), 0);
+    EXPECT_EQ(result.getRequiredVertices().size(), 1);
+    EXPECT_EQ(result.getRequiredEdges().size(), 1);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesUncutRequiredEntityGeometry2D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(1, 2);
+    setAllSegmentAttributes(mesh, 8);
+
+    const auto lsFn = [](const Point& p)
+    {
+      return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
+    };
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = getFirstUncutEntity(mesh, Polytope::Type::Segment, lsFn);
+    const Index requiredTriangle = getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto vertexCoords = mesh.getVertexCoordinates(requiredVertex);
+    const Point requiredVertexPoint(
+        *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
+    const auto requiredEdgePoints =
+      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
+    const auto requiredTrianglePoints =
+      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
+
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
+    EXPECT_TRUE(hasVertexWithCoordinates(result, requiredVertexPoint));
+    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
+    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesRequiredEntities3D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    setAllSegmentAttributes(mesh, 8);
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = 0;
+    const Index requiredTriangle = getFirstBoundaryTriangleIndex(mesh);
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = [](const Geometry::Point& p)
+    {
+      const Real dx = p.x() - 0.5;
+      const Real dy = p.y() - 0.5;
+      const Real dz = p.z() - 0.5;
+      return dx * dx + dy * dy + dz * dz - 0.16;
+    };
+
+    Index requiredTetrahedron = 0;
+    bool foundUncutTetrahedron = false;
+    for (auto it = mesh.getCell(); it; ++it)
+    {
+      bool hasNegative = false;
+      bool hasPositive = false;
+      for (const auto& vertex : it->getVertices())
+      {
+        hasNegative = hasNegative || ls[vertex] < 0;
+        hasPositive = hasPositive || ls[vertex] > 0;
+      }
+      if (!(hasNegative && hasPositive))
+      {
+        requiredTetrahedron = it->getIndex();
+        foundUncutTetrahedron = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(foundUncutTetrahedron);
+    mesh.setRequiredTetrahedron(requiredTetrahedron);
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_GT(result.getCellCount(), 0);
+    EXPECT_EQ(result.getRequiredVertices().size(), 1);
+    EXPECT_EQ(result.getRequiredEdges().size(), 1);
+    EXPECT_EQ(result.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(result.getRequiredTetrahedra().size(), 1);
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
+    EXPECT_TRUE(result.getRequiredTetrahedra().count(requiredTetrahedron));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, PreservesUncutRequiredEntityGeometry3D)
+  {
+    static constexpr Attribute interior = 1;
+    static constexpr Attribute exterior = 2;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(1, 3);
+    mesh.getConnectivity().compute(2, 3);
+    setAllSegmentAttributes(mesh, 8);
+
+    const auto lsFn = [](const Point& p)
+    {
+      const Real dx = p.x() - 0.5;
+      const Real dy = p.y() - 0.5;
+      const Real dz = p.z() - 0.5;
+      return dx * dx + dy * dy + dz * dz - 0.16;
+    };
+
+    const Index requiredVertex = 0;
+    const Index requiredEdge = getFirstUncutEntity(mesh, Polytope::Type::Segment, lsFn);
+    const Index requiredTriangle = getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const Index requiredTetrahedron = getFirstUncutEntity(mesh, Polytope::Type::Tetrahedron, lsFn);
+    const auto vertexCoords = mesh.getVertexCoordinates(requiredVertex);
+    const Point requiredVertexPoint(
+        *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
+    const auto requiredEdgePoints =
+      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
+    const auto requiredTrianglePoints =
+      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
+    const auto requiredTetrahedronPoints =
+      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), requiredTetrahedron));
+
+    mesh.setRequiredVertex(requiredVertex);
+    mesh.setRequiredEdge(requiredEdge);
+    mesh.setRequiredTriangle(requiredTriangle);
+    mesh.setRequiredTetrahedron(requiredTetrahedron);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(interior, { interior, exterior })
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
+    EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
+    EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
+    EXPECT_TRUE(result.getRequiredTetrahedra().count(requiredTetrahedron));
+    EXPECT_TRUE(hasVertexWithCoordinates(result, requiredVertexPoint));
+    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
+    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
+    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Tetrahedron, requiredTetrahedronPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveCutRequiredEdge2D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(1, 2);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() - 0.75; };
+    const Index required = getFirstCutEntity(mesh, Polytope::Type::Segment, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Segment), required);
+    const auto requiredPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setRequiredEdge(required);
+    setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveCutRequiredTriangle2D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() - 0.75; };
+    const Index required = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
+    const auto requiredPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setRequiredTriangle(required);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle2D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 16;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh.scale(1.0 / (n - 1));
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() - 0.75; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.1)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveCutRequiredEdge3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(1, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index required = getFirstCutEntity(mesh, Polytope::Type::Segment, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Segment), required);
+    const auto requiredPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setRequiredEdge(required);
+    setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveCutRequiredTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index required = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
+    const auto requiredPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setRequiredTriangle(required);
+    setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitAdjacentTetrahedraDoesNotPreserveLabeledRequiredCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    mesh.setRequiredTriangle(protectedTriangle);
+    setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    ASSERT_FALSE(adjacentTetrahedra.empty());
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    for (const auto& tetrahedron : adjacentTetrahedra)
+    {
+      mesh.setRequiredTetrahedron(tetrahedron);
+      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+    }
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredTriangleClosureDoesNotPreserveCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    const auto edges = getEdgesOnTriangle(mesh, entity->getVertices());
+    ASSERT_FALSE(adjacentTetrahedra.empty());
+    ASSERT_EQ(edges.size(), 3);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    for (const auto& vertex : entity->getVertices())
+      mesh.setRequiredVertex(vertex);
+    for (const auto& edge : edges)
+      mesh.setRequiredEdge(edge);
+    for (const auto& tetrahedron : adjacentTetrahedra)
+    {
+      mesh.setRequiredTetrahedron(tetrahedron);
+      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+    }
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredFullTriangleClosureDoesNotPreserveCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    const auto edges = getEdgesOnTriangle(mesh, entity->getVertices());
+    ASSERT_FALSE(adjacentTetrahedra.empty());
+    ASSERT_EQ(edges.size(), 3);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    for (const auto& vertex : entity->getVertices())
+      mesh.setRequiredVertex(vertex);
+    for (const auto& edge : edges)
+      mesh.setRequiredEdge(edge);
+    mesh.setRequiredTriangle(protectedTriangle);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    for (const auto& tetrahedron : adjacentTetrahedra)
+    {
+      mesh.setRequiredTetrahedron(tetrahedron);
+      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+    }
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledRequiredCutTriangle3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+    mesh.getConnectivity().compute(2, 3);
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const auto protectedPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    mesh.setRequiredTriangle(protectedTriangle);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_FALSE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+  }
+
+  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveCutRequiredTetrahedron3D)
+  {
+    static constexpr Attribute splitRef = 1;
+    static constexpr Attribute exterior = 2;
+    static constexpr Attribute protectedRef = 7;
+
+    const size_t n = 4;
+    MMG::Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh.scale(1.0 / (n - 1));
+
+    const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
+    const Index required = getFirstCutEntity(mesh, Polytope::Type::Tetrahedron, lsFn);
+    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), required);
+    const auto requiredPoints = getVertexCoordinates(mesh, *entity);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+    mesh.setRequiredTetrahedron(required);
+    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+
+    P1 fes(mesh);
+    MMG::RealGridFunction ls(fes);
+    ls = lsFn;
+
+    MMG::Mesh result =
+      MMG::LevelSetDiscretizer()
+        .split(splitRef, { splitRef, exterior })
+        .noSplit(protectedRef)
+        .setBoundaryReference(10)
+        .setHMax(0.35)
+        .discretize(ls);
+
+    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
+    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Tetrahedron, requiredPoints));
   }
 
   // ========================================================================
@@ -912,6 +2334,8 @@ namespace Rodin::Tests::Unit
     mesh.setRidge(1);
     mesh.setRequiredVertex(5);
     mesh.setRequiredEdge(2);
+    mesh.setRequiredTriangle(1);
+    mesh.setRequiredTetrahedron(0);
 
     MMG::Mesh target;
     target = std::move(mesh);
@@ -921,6 +2345,8 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(target.getRidges().size(), 1);
     EXPECT_EQ(target.getRequiredVertices().size(), 1);
     EXPECT_EQ(target.getRequiredEdges().size(), 1);
+    EXPECT_EQ(target.getRequiredTriangles().size(), 1);
+    EXPECT_EQ(target.getRequiredTetrahedra().size(), 1);
     EXPECT_FALSE(target.isEmpty());
   }
 
@@ -948,6 +2374,8 @@ namespace Rodin::Tests::Unit
     mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
     mesh.setCorner(0);
     mesh.setRidge(1);
+    mesh.setRequiredTriangle(0);
+    mesh.setRequiredTetrahedron(0);
 
     // Assign from parent type (which has no MMG metadata)
     Mesh<Context::Local> parentMesh;
@@ -960,6 +2388,8 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(mesh.getRidges().size(), 0);
     EXPECT_EQ(mesh.getRequiredVertices().size(), 0);
     EXPECT_EQ(mesh.getRequiredEdges().size(), 0);
+    EXPECT_EQ(mesh.getRequiredTriangles().size(), 0);
+    EXPECT_EQ(mesh.getRequiredTetrahedra().size(), 0);
   }
 
   TEST(Rodin_MMG_Mesh, IsSurface)


### PR DESCRIPTION
## Summary

- Add MMG required entity metadata for vertices, edges, triangles, and tetrahedra.
- Extend MEDIT IO with `RequiredTriangles` and `RequiredTetrahedra` sections.
- Map required vertices, edges, triangles, and tetrahedra through native MMG `MG_REQ` tags.
- Preserve required entity index sets after MMG optimization and level-set discretization when the original indices are still valid in the result.
- Add explicit non-cut geometry preservation tests for required vertices, edges, triangles, and tetrahedra in 2D/3D.
- Add 2D/3D coverage for API lifecycle, MEDIT IO, native MMG conversion, optimizer preservation, level-set discretization preservation cases, and required-entity plus `NoSplit` characterization.
- Improve Doxygen documentation for MMG workflows, required-entity behavior, `NoSplit`, level-set limitations, and the math behind the main-page Poisson example / level-set cantilever example.

## Important MMG behavior

This PR exposes MMG required-entity support in Rodin; it does not add a Rodin-side guard that prevents MMG from running.

For required entities that the level set does **not** cut, this branch now has positive 2D/3D preservation tests. Those tests mark required vertices, edges, triangles, and tetrahedra, run level-set discretization, and verify both that required metadata survives and that the original entity coordinates remain present in the output.

For 3D level-set discretization, MMG does **not** guarantee that a required entity remains untouched if the level set intersects it. In `MMG3D_cuttet_ls`, MMG hashes edges of required tetrahedra / required boundary entities to avoid splitting them when possible, but when an isosurface actually intersects a required entity it emits:

```text
Warning: MMG3D_cuttet_ls: the level-set intersect at least one required entity. Required entity ignored.
```

and proceeds by replacing the protected hash marker with the new intersection point. In plain terms: if your 3D level set cuts through a required triangle, MMG may cut it. `MG_REQ` is not a hard no-cut constraint for that level-set case.

I also probed `MG_REQ`, individual element/face attributes, adjacent tetrahedron attributes, and MMG's material `NoSplit` behavior. These probes compare actual original entity coordinates in the output, not only restored Rodin required-index metadata.

Tested cut-through combinations:

| Probe | Required? | `NoSplit` reference applied to | Exact original entity survived? |
| --- | --- | --- | --- |
| edge in 2D triangle mesh | yes | containing triangles | no |
| triangle/cell in 2D mesh | no | the individual triangle/cell | no |
| triangle/cell in 2D mesh | yes | the individual triangle/cell | no |
| edge in 3D tetrahedral mesh | yes | adjacent/containing tetrahedra | no |
| triangle face in 3D tetrahedral mesh | yes | adjacent tetrahedra | no |
| triangle face in 3D tetrahedral mesh | no | the individual triangle face only | no |
| triangle face in 3D tetrahedral mesh | yes | the individual triangle face only | no |
| triangle face in 3D tetrahedral mesh | no | adjacent tetrahedra | no |
| triangle face in 3D tetrahedral mesh | yes | triangle face + adjacent tetrahedra | no |
| triangle face in 3D tetrahedral mesh | vertices + edges + adjacent tetrahedra required | adjacent tetrahedra | no |
| triangle face in 3D tetrahedral mesh | vertices + edges + triangle + adjacent tetrahedra required | triangle face + adjacent tetrahedra | no |
| tetrahedron in 3D tetrahedral mesh | yes | the individual tetrahedron | no |

Observed behavior:

- In 2D, an individual triangle label is a cell/material label, and `noSplit(label)` keeps that material reference present in the output, but the exact original triangle can still be replaced.
- In 3D volume level-set mode, `noSplit(ref)` is a tetrahedron material-reference policy. Labeling only an individual triangle face does not make that face an unsplit volume material.
- Marking adjacent tetrahedra as `NoSplit` still does not preserve the original cut-through triangle geometry. The protected tetrahedron material reference survives, but the triangle itself is not kept intact.
- Marking the whole local closure as required, i.e. the triangle vertices, triangle edges, adjacent tetrahedra, and optionally the triangle face itself, still does not preserve the original cut-through triangle.

So `NoSplit` and `MG_REQ` are not an element-integrity guarantee for cut-through required triangles in 3D level-set discretization.

## Documentation

The Doxygen docs now include a dedicated MMG behavior page covering:

- optimizer vs adaptation vs level-set discretization semantics;
- required vertices, edges, triangles, and tetrahedra;
- MEDIT required-entity IO;
- tested uncut required-entity preservation in 2D and 3D;
- tested cut-through limitations with `MG_REQ`, labels, adjacent tetrahedra, local closure requirements, and `NoSplit`;
- practical workarounds when a protected element must remain untouched.

The main page now explains the strong and weak Poisson problem behind the introductory code snippet, and the level-set cantilever page now documents the elasticity state problem, compliance objective, level-set representation, shape-gradient regularization, and advection equation.

## How to use

Mark required entities directly on an `MMG::Mesh` before calling MMG workflows:

```cpp
MMG::Mesh mesh;
mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 16, 16 });

mesh.setRequiredVertex(vertexIndex);
mesh.setRequiredEdge(edgeIndex);
mesh.setRequiredTriangle(triangleIndex);
```

For tetrahedral meshes, tetrahedra can be marked too:

```cpp
MMG::Mesh mesh;
mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 4, 4, 4 });

mesh.setRequiredTriangle(boundaryTriangleIndex);
mesh.setRequiredTetrahedron(tetrahedronIndex);
```

The metadata is inspectable through:

```cpp
mesh.getRequiredVertices();
mesh.getRequiredEdges();
mesh.getRequiredTriangles();
mesh.getRequiredTetrahedra();
```

Optimization preserves required metadata and original indices when those indices are still valid after optimization:

```cpp
mesh.setRequiredTriangle(triangleIndex);

MMG::Optimizer()
  .setHMax(0.1)
  .optimize(mesh);

assert(mesh.getRequiredTriangles().count(triangleIndex));
```

Level-set discretization can preserve required metadata when the marked entities survive with valid indices:

```cpp
mesh.setRequiredTriangle(triangleIndex);
P1 fes(mesh);
MMG::RealGridFunction ls(fes);

MMG::Mesh result = MMG::LevelSetDiscretizer()
  .split(interior, { interior, exterior })
  .setHMax(0.1)
  .discretize(ls);

assert(result.getRequiredTriangles().count(triangleIndex));
```

Use `noSplit(ref)` only to control material splitting for a material reference:

```cpp
MMG::Mesh result = MMG::LevelSetDiscretizer()
  .split(cutRef, { insideRef, outsideRef })
  .noSplit(protectedRef)
  .discretize(ls);
```

Do not use `setRequiredTriangle()`, individual triangle labels, adjacent tetrahedron labels, required adjacent tetrahedra, required triangle vertices/edges, or `noSplit()` as a guarantee that a level-set cut will leave a specific triangle geometrically untouched. If the level set crosses it, the tested MMG behavior is that the original entity may be replaced.

## Validation

```sh
cmake --build build --target RodinMMGTest -j2 && ./build/tests/unit/Rodin/MMG/RodinMMGTest
cmake --build build --target RodinDoxygen
```

Passed: 105/105 MMG tests. Doxygen target builds successfully; it still emits existing project-wide documentation warnings unrelated to this MMG docs update.

Note: the existing `src/Rodin/MMG/MMG5.h:240` unused variable warning still appears during the test build and is unrelated to this change.
