### PR TITLE
ActiveContraction

### DIFF
--- a/.github/workflows/Style.yml
+++ b/.github/workflows/Style.yml
@@ -66,20 +66,22 @@ jobs:
         run: >-
           sudo apt-get update && sudo apt-get install -y
           clang-tidy-18 libomp-18-dev cmake libboost-all-dev libeigen3-dev
-          libhdf5-dev
+          libhdf5-dev libsuitesparse-dev libscotch-dev libmetis-dev petsc-dev mpich
       - name: Configure (generates Configure.h)
         run: >-
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-          -DRODIN_BUILD_EXAMPLES=OFF -DRODIN_USE_PETSC=OFF
+          -DRODIN_BUILD_EXAMPLES=OFF -DRODIN_BUILD_TIDY=ON
+          -DRODIN_USE_OPENMP=ON -DRODIN_USE_MPI=ON -DRODIN_USE_PETSC=ON
+          -DRODIN_USE_SCOTCH=ON -DRODIN_USE_UMFPACK=ON
+          -DRODIN_USE_SPQR=ON -DRODIN_USE_CHOLMOD=ON
       - name: clang-tidy naming ratchet
         # Full-tree analysis of the aggregate TU against the committed
         # findings baseline (dev/clang_tidy.baseline): only NEW naming
         # violations fail; fixing names shrinks the baseline.
-        run: >-
-          python3 dev/check_clang_tidy.py --clang-tidy clang-tidy-18
-          --flags "-std=c++20 -fopenmp -I$PWD/src -I$PWD/build/src
-          -I$PWD/third-party/termcolor/include -isystem /usr/include/eigen3
-          -isystem /usr/include/hdf5/serial"
+        run: |
+          cmake --build build --target copy_mmg_headers
+          python3 dev/check_clang_tidy.py --clang-tidy clang-tidy-18 \
+            --build-dir build
 
   DoxygenRatchet:
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(RODIN_BUILD_UNIT_TESTS         "Build Rodin unit tests"                  
 option(RODIN_BUILD_MANUFACTURED_TESTS "Build Rodin manufactured solution tests"   OFF)
 option(RODIN_BUILD_BENCHMARKS         "Build Rodin benchmarks"                    OFF)
 option(RODIN_BUILD_DOC                "Build the Rodin documentation"             OFF)
+option(RODIN_BUILD_TIDY               "Configure the clang-tidy aggregate target" OFF)
 option(RODIN_WITH_PY                  "Build Python bindings"                     OFF)
 option(RODIN_USE_MCSS                 "Build documentation with m.css"            OFF)
 option(RODIN_USE_MPI                  "Use Rodin with MPI support"                OFF)
@@ -263,18 +264,26 @@ if (RODIN_BUILD_SRC)
     find_package(Scotch REQUIRED)
   endif()
 
-  # ---- UMFPACK, SPQR, CHOLMOD ----
+  # ---- SuiteSparse ---------------------------------------------------------
+  set(_RODIN_SUITESPARSE_COMPONENTS)
+
   if (RODIN_USE_UMFPACK)
-    find_package(SuiteSparse REQUIRED COMPONENTS UMFPACK)
+    list(APPEND _RODIN_SUITESPARSE_COMPONENTS UMFPACK)
   endif()
 
   if (RODIN_USE_SPQR)
-    find_package(SuiteSparse REQUIRED COMPONENTS SPQR)
+    list(APPEND _RODIN_SUITESPARSE_COMPONENTS SPQR)
   endif()
 
   if (RODIN_USE_CHOLMOD)
-    find_package(SuiteSparse REQUIRED COMPONENTS CHOLMOD)
+    list(APPEND _RODIN_SUITESPARSE_COMPONENTS CHOLMOD)
   endif()
+
+  if (_RODIN_SUITESPARSE_COMPONENTS)
+    find_package(SuiteSparse REQUIRED
+      COMPONENTS ${_RODIN_SUITESPARSE_COMPONENTS})
+  endif()
+  unset(_RODIN_SUITESPARSE_COMPONENTS)
 
   # ---- OpenMP ----
   if (RODIN_USE_OPENMP)
@@ -282,6 +291,23 @@ if (RODIN_BUILD_SRC)
   endif()
 
   add_subdirectory(src)
+
+  if (RODIN_BUILD_TIDY)
+    add_library(RodinTidyTU OBJECT EXCLUDE_FROM_ALL dev/TidyTU.cpp)
+    target_link_libraries(RodinTidyTU PRIVATE Rodin::MMG Rodin::Solver)
+
+    if (RODIN_USE_MPI)
+      target_link_libraries(RodinTidyTU PRIVATE Rodin::MPI)
+    endif()
+
+    if (RODIN_USE_PETSC)
+      target_link_libraries(RodinTidyTU PRIVATE Rodin::PETSc)
+    endif()
+
+    if (RODIN_USE_SCOTCH)
+      target_link_libraries(RodinTidyTU PRIVATE Rodin::Scotch)
+    endif()
+  endif()
 
   if (RODIN_BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -1,0 +1,50 @@
+#[[
+         Copyright Carlos BRITO PACHECO 2021 - 2026.
+Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENSE or copy at
+         https://www.boost.org/LICENSE_1_0.txt)
+]]
+
+#[=======================================================================[.rst:
+FindMETIS
+=========
+
+Finds the METIS graph partitioning library.
+
+Imported targets
+----------------
+
+``METIS::METIS``
+  METIS library target.
+
+Result variables
+----------------
+
+``METIS_FOUND``
+  True if METIS was found.
+
+``METIS_INCLUDE_DIR``
+  Directory containing ``metis.h``.
+
+``METIS_LIBRARY``
+  METIS library path.
+#]=======================================================================]
+
+find_path(METIS_INCLUDE_DIR
+  NAMES metis.h)
+
+find_library(METIS_LIBRARY
+  NAMES metis)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(METIS
+  REQUIRED_VARS METIS_INCLUDE_DIR METIS_LIBRARY)
+
+if (METIS_FOUND AND NOT TARGET METIS::METIS)
+  add_library(METIS::METIS UNKNOWN IMPORTED)
+  set_target_properties(METIS::METIS PROPERTIES
+    IMPORTED_LOCATION "${METIS_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(METIS_INCLUDE_DIR METIS_LIBRARY)

--- a/cmake/FindScotch.cmake
+++ b/cmake/FindScotch.cmake
@@ -1,0 +1,81 @@
+# @file FindScotch.cmake
+# @brief CMake module to locate the Scotch partitioning library.
+#
+# This module finds the Scotch libraries and headers and defines an imported
+# interface target `Scotch::Scotch` for linking against Scotch.
+#
+# Variables defined by this module:
+#
+#   SCOTCH_FOUND           - True if Scotch was found
+#   SCOTCH_INCLUDE_DIRS    - Include directories for Scotch
+#   SCOTCH_LIBRARIES       - Libraries required to link Scotch
+#
+# Imported target:
+#
+#   Scotch::Scotch         - Interface target to link with Scotch
+#
+# Usage:
+#
+#   find_package(Scotch REQUIRED)
+#   target_link_libraries(MyTarget PRIVATE Scotch::Scotch)
+#
+# The user may set SCOTCH_DIR or the SCOTCH_DIR environment variable
+# to help locate the installation.
+#
+
+include(FindPackageHandleStandardArgs)
+
+# Allow user-supplied hints
+if (DEFINED SCOTCH_DIR)
+  set(_SCOTCH_HINTS "${SCOTCH_DIR}")
+elseif (DEFINED ENV{SCOTCH_DIR})
+  set(_SCOTCH_HINTS "$ENV{SCOTCH_DIR}")
+endif()
+
+# Locate header and libraries
+find_path(SCOTCH_INCLUDE_DIR
+  NAMES scotch.h
+  HINTS ${_SCOTCH_HINTS}
+  PATH_SUFFIXES include include/scotch
+  DOC "Path to Scotch header files"
+)
+
+find_library(SCOTCH_LIBRARY
+  NAMES scotch
+  HINTS ${_SCOTCH_HINTS}
+  PATH_SUFFIXES lib
+  DOC "Path to Scotch core library"
+)
+
+find_library(SCOTCHERR_LIBRARY
+  NAMES scotcherr
+  HINTS ${_SCOTCH_HINTS}
+  PATH_SUFFIXES lib
+  DOC "Path to Scotch error-handling library"
+)
+
+# Final values
+if (SCOTCH_INCLUDE_DIR)
+  set(SCOTCH_INCLUDE_DIRS "${SCOTCH_INCLUDE_DIR}")
+endif()
+
+if (SCOTCH_LIBRARY AND SCOTCHERR_LIBRARY)
+  set(SCOTCH_LIBRARIES "${SCOTCH_LIBRARY}" "${SCOTCHERR_LIBRARY}")
+endif()
+
+# Detection logic
+find_package_handle_standard_args(Scotch
+  REQUIRED_VARS SCOTCH_INCLUDE_DIRS SCOTCH_LIBRARIES
+)
+
+# Define the target
+if (SCOTCH_FOUND AND NOT TARGET Scotch::Scotch)
+  add_library(Scotch::Scotch IMPORTED INTERFACE)
+  set_target_properties(Scotch::Scotch PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${SCOTCH_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${SCOTCH_LIBRARIES};m"
+  )
+endif()
+
+# Hide internals from GUIs
+mark_as_advanced(SCOTCH_INCLUDE_DIR SCOTCH_LIBRARY SCOTCHERR_LIBRARY)

--- a/cmake/FindSuiteSparse.cmake
+++ b/cmake/FindSuiteSparse.cmake
@@ -461,7 +461,7 @@ if (TARGET SuiteSparse::SPQR)
       INTERFACE_LINK_LIBRARIES SuiteSparse::CHOLMOD)
   else (TARGET SuiteSparse::CHOLMOD)
     # Consider SPQR not found if CHOLMOD cannot be found
-    set (SuiteSparse_SQPR_FOUND FALSE)
+    set (SuiteSparse_SPQR_FOUND FALSE)
   endif (TARGET SuiteSparse::CHOLMOD)
 endif (TARGET SuiteSparse::SPQR)
 
@@ -516,6 +516,12 @@ if (TARGET SuiteSparse::Partition)
 else (TARGET SuiteSparse::Partition)
   set (SuiteSparse_Partition_FOUND FALSE)
 endif (TARGET SuiteSparse::Partition)
+
+foreach (component IN LISTS SuiteSparse_FIND_COMPONENTS)
+  if (TARGET SuiteSparse::${component})
+    set (SuiteSparse_${component}_FOUND TRUE)
+  endif()
+endforeach()
 
 suitesparse_reset_find_library_prefix()
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -45,12 +45,16 @@ diagnostics between releases.
 `TidyTU.cpp` and compares findings against `clang_tidy.baseline`.
 
 ```sh
+cmake -S . -B build -DRODIN_BUILD_TIDY=ON
+python3 dev/check_clang_tidy.py --build-dir build
 python3 dev/check_clang_tidy.py --flags "<compiler flags>"
 python3 dev/check_clang_tidy.py --flags "<compiler flags>" --update-baseline
 ```
 
 `TidyTU.cpp` is an aggregate translation unit that includes Rodin headers so
-clang-tidy can inspect the library consistently.
+clang-tidy can inspect the library consistently. The CMake-backed invocation
+also checks optional modules enabled in that build with their actual dependency
+include paths and feature definitions.
 
 ### House Style
 

--- a/dev/TidyTU.cpp
+++ b/dev/TidyTU.cpp
@@ -14,9 +14,12 @@
  * checks the whole header surface. Used by dev/style_lint and the Style CI
  * workflow; not part of the library build.
  *
- * Optional-dependency headers (PETSc, MMG, MPI) are excluded so the TU
- * analyzes without those packages installed.
+ * Optional modules are included under the same feature definitions as the
+ * library. The RodinTidyTU CMake target supplies their dependency include
+ * paths whenever they are enabled.
  */
+#include <Rodin/Configure.h>
+
 #include <Rodin/Types.h>
 #include <Rodin/Alert.h>
 #include <Rodin/Math.h>
@@ -29,8 +32,28 @@
 #include <Rodin/Solid.h>
 #include <Rodin/Heart.h>
 #include <Rodin/IO.h>
+#include <Rodin/Utility.h>
 #include <Rodin/Serialization/Export.h>
+#include <Rodin/Advection/Lagrangian.h>
+#include <Rodin/Eikonal/FMM.h>
 #include <Rodin/Adaptation/WNGIR.h>
+#include <Rodin/MMG.h>
+
+#ifdef RODIN_USE_MPI
+#include <Rodin/MPI.h>
+#endif
+
+#ifdef RODIN_USE_PETSC
+#include <Rodin/PETSc.h>
+#endif
+
+#ifdef RODIN_USE_SCOTCH
+#include <Rodin/Scotch/MeshPartitioner.h>
+#endif
+
+#ifdef RODIN_USE_APPLE_ACCELERATE
+#include <Rodin/Solver/AppleAccelerate.h>
+#endif
 
 int main()
 {

--- a/dev/check_clang_tidy.py
+++ b/dev/check_clang_tidy.py
@@ -17,6 +17,8 @@ agnostic, so unrelated edits do not shift old findings into "new" status.
 Under GitHub Actions each new finding is emitted as an inline annotation.
 
 Usage:
+  python3 dev/check_clang_tidy.py --build-dir build \
+      [--clang-tidy BIN] [--update-baseline]
   python3 dev/check_clang_tidy.py --flags "<compiler flags>" \
       [--clang-tidy BIN] [--update-baseline]
 """
@@ -42,10 +44,13 @@ def color(code, s, enabled=True):
     return f"\033[{code}m{s}\033[0m" if enabled else s
 
 
-def run(binary, flags):
+def run(binary, flags, build_dir):
     cmd = [binary, os.path.join(REPO, "dev", "TidyTU.cpp"),
-           "--header-filter=(^|/)src/Rodin/.*", "--quiet",
-           "--"] + shlex.split(flags)
+           "--header-filter=(^|/)src/Rodin/.*", "--quiet"]
+    if build_dir:
+        cmd.extend(["-p", os.path.abspath(build_dir)])
+    else:
+        cmd.extend(["--"] + shlex.split(flags))
     r = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True)
     findings = {}
     fatal = []
@@ -73,13 +78,15 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--clang-tidy", default=os.environ.get("CLANG_TIDY", "clang-tidy"))
-    ap.add_argument("--flags", required=True,
-                    help="compiler flags for the aggregate TU")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--build-dir",
+                      help="CMake build directory containing compile_commands.json")
+    mode.add_argument("--flags", help="compiler flags for the aggregate TU")
     ap.add_argument("--update-baseline", action="store_true")
     args = ap.parse_args()
 
     tty = sys.stdout.isatty() or GITHUB
-    findings, fatal = run(args.clang_tidy, args.flags)
+    findings, fatal = run(args.clang_tidy, args.flags, args.build_dir)
 
     if fatal:
         print(color("1;31", "error:", tty),

--- a/examples/IO/XDMF.cpp
+++ b/examples/IO/XDMF.cpp
@@ -57,7 +57,7 @@ int main(int, char**)
     };
 
     // export snapshot
-    xdmf.write(t);
+    xdmf.write(t).flush();
   }
 
   return 0;

--- a/examples/MPI/Geometry/UniformGrid.cpp
+++ b/examples/MPI/Geometry/UniformGrid.cpp
@@ -44,12 +44,8 @@ int main(int argc, char** argv)
 
   IO::XDMF xdmf(world, "UniformGrid");
   xdmf.grid().setMesh(mesh);
-  xdmf.write();
+  xdmf.write().flush();
   xdmf.close();
 
   return 0;
 }
-
-
-
-

--- a/examples/PDEs/Poisson.cpp
+++ b/examples/PDEs/Poisson.cpp
@@ -38,7 +38,7 @@ int main(int, char**)
   Problem poisson(u, v);
   poisson = Integral(Grad(u), Grad(v))
           // - Integral(f, v)
-          + DirichletBC(u, f).on(17);
+    + DirichletBC(u, f).on(17);
   CG(poisson).solve();
 
   mesh.save("Poisson.mesh", IO::FileFormat::MEDIT);
@@ -47,7 +47,7 @@ int main(int, char**)
   // Save solution
   IO::XDMF xdmf("Poisson");
   xdmf.grid().setMesh(mesh).add("u", u.getSolution());
-  xdmf.write();
+  xdmf.write().flush();
   xdmf.close();
 
   return 0;

--- a/examples/PETSc/PDEs/MPI_Poisson.cpp
+++ b/examples/PETSc/PDEs/MPI_Poisson.cpp
@@ -159,8 +159,7 @@ int main(int argc, char** argv)
 
     std::snprintf(filename, sizeof(filename), "sol.%06d", world.rank());
 
-
-    xdmf.write();
+    xdmf.write().flush();
     u.getSolution().save(filename, IO::FileFormat::MFEM);
   }
 
@@ -169,4 +168,3 @@ int main(int argc, char** argv)
   (void) ierr;
   PetscFinalize();
 }
-

--- a/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI.cpp
+++ b/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI.cpp
@@ -633,7 +633,7 @@ int main(int argc, char** argv)
     solidOutputVelocity.setData(solidVelocity.getData());
     solidOutputFluidTraction.setData(solidFluidTraction.getData());
 
-    xdmf.write(0.0);
+    xdmf.write(0.0).flush();
 
     /*
      * Parameters.
@@ -857,7 +857,7 @@ int main(int argc, char** argv)
       TrialFunction du(solidVh);
       TestFunction  w(solidVh);
 
-      auto ivw    = Solid::InternalVirtualWork(law, solidDisplacement);
+      auto ivw = Solid::InternalVirtualWork(law, solidDisplacement);
       auto ivwOld = Solid::InternalVirtualWork(law, solidDisplacementOld);
 
       /*
@@ -938,21 +938,18 @@ int main(int argc, char** argv)
        */
       Problem solid(du, w);
 
-      solid =
-          ivw.Tangent(du, w)
-        + solidMassCoeff * Integral(du, w)
-        + (solidRayleighBeta / dt) * ivw.Tangent(du, w)
+      solid = ivw.Tangent(du, w) + solidMassCoeff * Integral(du, w) +
+        (solidRayleighBeta / dt) * ivw.Tangent(du, w)
 
-        + ivw.Residual(w)
-        + solidMassCoeff * Integral(solidDisplacement, w)
-        - solidMassCoeff * Integral(solidDisplacementOld, w)
-        - (rhoS / dt) * Integral(solidVelocityOld, w)
-        + (solidRayleighBeta / dt) * ivw.Residual(w)
-        - (solidRayleighBeta / dt) * ivwOld.Residual(w)
-        - BoundaryIntegral(solidFluidTraction, w).over(SolidBoundary::FSI)
+        + ivw.Residual(w) + solidMassCoeff * Integral(solidDisplacement, w) -
+        solidMassCoeff * Integral(solidDisplacementOld, w) -
+        (rhoS / dt) * Integral(solidVelocityOld, w) +
+        (solidRayleighBeta / dt) * ivw.Residual(w) -
+        (solidRayleighBeta / dt) * ivwOld.Residual(w) -
+        BoundaryIntegral(solidFluidTraction, w).over(SolidBoundary::FSI)
 
-        + DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampLeft)
-        + DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampRight);
+        + DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampLeft) +
+        DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampRight);
 
       Alert::Info()
         << "Solid BDF1 hyperelastic step " << step << " / " << Nt

--- a/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI_Monolithic.cpp
+++ b/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI_Monolithic.cpp
@@ -475,7 +475,7 @@ int main(int argc, char** argv)
   grid.add("pressure", pState);
   grid.add("displacement", dState);
   grid.add("mesh_velocity", meshVelocity);
-  xdmf.write(0.0);
+  xdmf.write(0.0).flush();
 
   const Real rhoF = 1.0;
   const Real muF = 0.02;
@@ -535,65 +535,61 @@ int main(int argc, char** argv)
 
   fsi =
       /* Fully nonlinear ALE Navier--Stokes tangent over fluid cells. */
-        (rhoF / dt) * Integral(du, v).over(Volume::Fluid)
-      + rhoF * Integral(Dot(convTangentVelocity, v)).over(Volume::Fluid)
-      + rhoF * Integral(Dot(convTangentTransportU, v)).over(Volume::Fluid)
-      - (rhoF / dt) * Integral(Dot(convTangentTransportEta, v)).over(Volume::Fluid)
-      + 0.5 * rhoF * Integral(divTransport * Dot(du, v)).over(Volume::Fluid)
-      + 0.5 * rhoF * Integral(Dot(Div(du) * uState, v)).over(Volume::Fluid)
-      - (0.5 * rhoF / dt) * Integral(Dot(Div(deta) * uState, v)).over(Volume::Fluid)
-      + muF * Integral(Jacobian(du), Jacobian(v)).over(Volume::Fluid)
-      - Integral(dp, Div(v)).over(Volume::Fluid)
-      + Integral(Div(du), q).over(Volume::Fluid)
-      + Integral(dlambda, q).over(Volume::Fluid)
-      + Integral(dp, m).over(Volume::Fluid)
-      + BoundaryIntegral(0.5 * rhoF * beta * Dot(du, v)).over(Boundary::Outlet)
-      + 1e-10 * Integral(dp, q).over(Volume::Fluid)
-      + 1e-10 * Integral(dlambda, m)
+    (rhoF / dt) * Integral(du, v).over(Volume::Fluid) +
+    rhoF * Integral(Dot(convTangentVelocity, v)).over(Volume::Fluid) +
+    rhoF * Integral(Dot(convTangentTransportU, v)).over(Volume::Fluid) -
+    (rhoF / dt) * Integral(Dot(convTangentTransportEta, v)).over(Volume::Fluid) +
+    0.5 * rhoF * Integral(divTransport * Dot(du, v)).over(Volume::Fluid) +
+    0.5 * rhoF * Integral(Dot(Div(du) * uState, v)).over(Volume::Fluid) -
+    (0.5 * rhoF / dt) * Integral(Dot(Div(deta) * uState, v)).over(Volume::Fluid) +
+    muF * Integral(Jacobian(du), Jacobian(v)).over(Volume::Fluid) -
+    Integral(dp, Div(v)).over(Volume::Fluid) + Integral(Div(du), q).over(Volume::Fluid) +
+    Integral(dlambda, q).over(Volume::Fluid) + Integral(dp, m).over(Volume::Fluid) +
+    BoundaryIntegral(0.5 * rhoF * beta * Dot(du, v)).over(Boundary::Outlet) +
+    1e-10 * Integral(dp, q).over(Volume::Fluid) +
+    1e-10 * Integral(dlambda, m)
 
       /* Fully nonlinear ALE Navier--Stokes residual over fluid cells. */
-      + (rhoF / dt) * Integral(uState - uOld, v).over(Volume::Fluid)
-      + rhoF * Integral(Dot(convState, v)).over(Volume::Fluid)
-      + 0.5 * rhoF * Integral(Dot(divTransport * uState, v)).over(Volume::Fluid)
-      + muF * Integral(Jacobian(uState), Jacobian(v)).over(Volume::Fluid)
-      - Integral(pState, Div(v)).over(Volume::Fluid)
-      + Integral(Div(uState), q).over(Volume::Fluid)
-      + Integral(lambdaState, q).over(Volume::Fluid)
-      + Integral(pState, m).over(Volume::Fluid)
-      + BoundaryIntegral(0.5 * rhoF * Dot(beta * uState, v)).over(Boundary::Outlet)
-      + 1e-10 * Integral(pState, q).over(Volume::Fluid)
-      + 1e-10 * Integral(lambdaState, m)
+    + (rhoF / dt) * Integral(uState - uOld, v).over(Volume::Fluid) +
+    rhoF * Integral(Dot(convState, v)).over(Volume::Fluid) +
+    0.5 * rhoF * Integral(Dot(divTransport * uState, v)).over(Volume::Fluid) +
+    muF * Integral(Jacobian(uState), Jacobian(v)).over(Volume::Fluid) -
+    Integral(pState, Div(v)).over(Volume::Fluid) +
+    Integral(Div(uState), q).over(Volume::Fluid) +
+    Integral(lambdaState, q).over(Volume::Fluid) +
+    Integral(pState, m).over(Volume::Fluid) +
+    BoundaryIntegral(0.5 * rhoF * Dot(beta * uState, v)).over(Boundary::Outlet) +
+    1e-10 * Integral(pState, q).over(Volume::Fluid) +
+    1e-10 * Integral(lambdaState, m)
 
       /* Harmonic ALE displacement in the fluid. */
-      + Integral(Jacobian(deta), Jacobian(z)).over(Volume::Fluid)
-      + Integral(Jacobian(etaState), Jacobian(z)).over(Volume::Fluid)
+    + Integral(Jacobian(deta), Jacobian(z)).over(Volume::Fluid) +
+    Integral(Jacobian(etaState), Jacobian(z)).over(Volume::Fluid)
 
       /* Solid BDF1/Newmark-like displacement increment equation. */
-      + (rhoS / (dt * dt)) * Integral(deta, z).over(Volume::Solid)
-      + (solidRayleighAlpha * rhoS / dt) * Integral(deta, z).over(Volume::Solid)
-      + ivw.Tangent(deta, z).over(Volume::Solid)
+    + (rhoS / (dt * dt)) * Integral(deta, z).over(Volume::Solid) +
+    (solidRayleighAlpha * rhoS / dt) * Integral(deta, z).over(Volume::Solid) +
+    ivw.Tangent(deta, z).over(Volume::Solid)
 
-      + (rhoS / (dt * dt)) * Integral(etaState - etaOld, z).over(Volume::Solid)
-      + (solidRayleighAlpha * rhoS / dt) * Integral(etaState, z).over(Volume::Solid)
-      + ivw.Residual(z).over(Volume::Solid)
+    + (rhoS / (dt * dt)) * Integral(etaState - etaOld, z).over(Volume::Solid) +
+    (solidRayleighAlpha * rhoS / dt) * Integral(etaState, z).over(Volume::Solid) +
+    ivw.Residual(z).over(Volume::Solid)
 
       /* Temporary inactive-region regularization for globally-defined fluid
        * variables.  Replace by subdomain-restricted spaces when available.
        */
-      + inactive * Integral(du, v).over(Volume::Solid)
-      + inactive * Integral(uState, v).over(Volume::Solid)
-      + inactive * Integral(dp, q).over(Volume::Solid)
-      + inactive * Integral(pState, q).over(Volume::Solid)
+    + inactive * Integral(du, v).over(Volume::Solid) +
+    inactive * Integral(uState, v).over(Volume::Solid) +
+    inactive * Integral(dp, q).over(Volume::Solid) +
+    inactive * Integral(pState, q).over(Volume::Solid)
 
       /* Boundary and interface constraints. */
-      + DirichletBC(du, inletVelocity - uState).on(Boundary::Inlet)
-      + DirichletBC(du, -uState).on(Boundary::FluidWall)
-      + DirichletBC(deta, -etaState).on(Boundary::Inlet, Boundary::Outlet, Boundary::FluidWall)
-      + DirichletBC(deta, -etaState).on(Boundary::SolidClampLeft, Boundary::SolidClampRight)
-      + DirichletBC(
-          du,
-          (1.0 / dt) * deta,
-          (1.0 / dt) * etaState - uState).on(Boundary::FSI);
+    + DirichletBC(du, inletVelocity - uState).on(Boundary::Inlet) +
+    DirichletBC(du, -uState).on(Boundary::FluidWall) +
+    DirichletBC(deta, -etaState)
+      .on(Boundary::Inlet, Boundary::Outlet, Boundary::FluidWall) +
+    DirichletBC(deta, -etaState).on(Boundary::SolidClampLeft, Boundary::SolidClampRight) +
+    DirichletBC(du, (1.0 / dt) * deta, (1.0 / dt) * etaState - uState).on(Boundary::FSI);
 
   fsi.assemble().setFieldSplits();
 
@@ -675,7 +671,7 @@ int main(int argc, char** argv)
     dOld.setData(dState.getData());
 
     moveMeshToCurrentDisplacement();
-    xdmf.write(t);
+    xdmf.write(t).flush();
     xdmf.flush();
   }
   }

--- a/examples/Solid/ActiveContractionPlaneWave.cpp
+++ b/examples/Solid/ActiveContractionPlaneWave.cpp
@@ -36,6 +36,8 @@
  *
  * Optional command-line arguments:
  *   ActiveContractionPlaneWave [nc=64] [nSteps=full]
+ *                                [targetMaxDisplacement=0]
+ *                                [activeScale=1]
  */
 #include <algorithm>
 #include <cmath>
@@ -90,25 +92,55 @@ namespace
     }
     return static_cast<size_t>(parsed);
   }
+
+  Real parseReal(const char* value, const char* name)
+  {
+    char* end = nullptr;
+    const Real parsed = std::strtod(value, &end);
+    if (end == value || *end != '\0')
+    {
+      std::cerr << "Invalid " << name << ": " << value << std::endl;
+      std::exit(2);
+    }
+    return parsed;
+  }
 }
 
 int main(int argc, char** argv)
 {
   size_t nc = 64;
   size_t requestedSteps = 0;
+  Real targetMaxDisplacement = 0.0;
+  Real activeScale = 1.0;
 
   if (argc > 1)
     nc = parseSize(argv[1], "mesh resolution");
   if (argc > 2)
     requestedSteps = parseSize(argv[2], "step count");
   if (argc > 3)
+    targetMaxDisplacement = parseReal(argv[3], "target max displacement");
+  if (argc > 4)
+    activeScale = parseReal(argv[4], "active scale");
+  if (argc > 5)
   {
-    std::cerr << "Usage: " << argv[0] << " [nc=64] [nSteps=full]" << std::endl;
+    std::cerr << "Usage: " << argv[0]
+              << " [nc=64] [nSteps=full]"
+              << " [targetMaxDisplacement=0] [activeScale=1]" << std::endl;
     return 2;
   }
   if (nc < 2)
   {
     std::cerr << "Mesh resolution must be at least 2." << std::endl;
+    return 2;
+  }
+  if (targetMaxDisplacement < 0.0)
+  {
+    std::cerr << "Target max displacement must be nonnegative." << std::endl;
+    return 2;
+  }
+  if (activeScale <= 0.0)
+  {
+    std::cerr << "Active scale must be positive." << std::endl;
     return 2;
   }
 
@@ -152,11 +184,11 @@ int main(int argc, char** argv)
   Solid::NeoHookean passive(lambda, mu);
 
   Solid::ActiveFiberLaw::Parameters activeParams;
-  activeParams.stiffness            = 20.0;
+  activeParams.stiffness            = activeScale * 20.0;
   activeParams.damping              = 300;
   activeParams.destructionRate      = 0.4;
-  activeParams.crossBridgeStiffness = 100.0;
-  activeParams.contractility        = 20.0;
+  activeParams.crossBridgeStiffness = activeScale * 100.0;
+  activeParams.contractility        = activeScale * 20.0;
   activeParams.initial.extension    = 0.0;
   activeParams.initial.stiffness    = 0.0;
   activeParams.initial.stress       = 0.0;
@@ -182,7 +214,7 @@ int main(int argc, char** argv)
   const size_t nWaves = 2;
 
   PlaneWaveParams wave;
-  wave.amplitude      = 20;
+  wave.amplitude      = activeScale * 20.0;
   wave.speed          = 0.5;
   wave.width          = 0.05;
   wave.start          = 0;
@@ -268,6 +300,24 @@ int main(int argc, char** argv)
   GridFunction fiberField(Vh);
   fiberField.setName("FiberDirection");
   fiberField = VectorFunction{ RealFunction(1.0), Zero() };
+
+  auto computeMaxNodalDisplacement = [&]() -> Real
+  {
+    Real maxDisplacement = 0.0;
+    const auto& uData = u.getData();
+    for (auto it = mesh.getVertex(); it; ++it)
+    {
+      const auto& dofs = Vh.getDOFs(0, it->getIndex());
+      Real squaredNorm = 0.0;
+      for (size_t c = 0; c < dim && c < static_cast<size_t>(dofs.size()); ++c)
+      {
+        const Real component = uData(dofs(static_cast<Index>(c)));
+        squaredNorm += component * component;
+      }
+      maxDisplacement = std::max(maxDisplacement, std::sqrt(squaredNorm));
+    }
+    return maxDisplacement;
+  };
 
   // ---- XDMF output --------------------------------------------------------
   IO::XDMF xdmf("ActiveContractionPlaneWave");
@@ -362,6 +412,12 @@ int main(int argc, char** argv)
   if (nSteps != fullSteps)
     std::cout << " (truncated from " << fullSteps << ")";
   std::cout << std::endl;
+  std::cout << "Active scale: " << activeScale;
+  if (targetMaxDisplacement > 0.0)
+    std::cout << ", target max displacement: " << targetMaxDisplacement;
+  std::cout << std::endl;
+
+  Real peakMaxNodalDisplacement = 0.0;
 
   for (size_t step = 1; step <= nSteps; ++step)
   {
@@ -439,6 +495,9 @@ int main(int argc, char** argv)
 
     const auto diagnostics = commitState();
     const auto& report = solver.getReport();
+    const Real maxNodalDisplacement = computeMaxNodalDisplacement();
+    peakMaxNodalDisplacement =
+      std::max(peakMaxNodalDisplacement, maxNodalDisplacement);
 
     const auto bdfData =
       bdfA0 * u.getData()
@@ -449,12 +508,22 @@ int main(int argc, char** argv)
               << " converged = " << (report.converged ? "yes" : "no")
               << " iterations = " << report.iterations
               << " finalResidual = " << report.finalResidual
-              << " |u| = " << u.getData().norm() << " |BDF(u)| = " << bdfData.norm()
+              << " |u| = " << u.getData().norm()
+              << " max_node|u| = " << maxNodalDisplacement
+              << " peak_max_node|u| = " << peakMaxNodalDisplacement
+              << " |BDF(u)| = " << bdfData.norm()
               << " ec = [" << diagnostics.minActiveExtension << ", "
               << diagnostics.maxActiveExtension << "]"
               << " max|gamma| = " << diagnostics.maxGamma
               << " max|beta| = " << diagnostics.maxBeta
-              << " max_local_newton = " << diagnostics.maxLocalIterations << std::endl;
+              << " max_local_newton = " << diagnostics.maxLocalIterations;
+    if (targetMaxDisplacement > 0.0 && peakMaxNodalDisplacement > 0.0)
+    {
+      const Real suggestedScale =
+        activeScale * targetMaxDisplacement / peakMaxNodalDisplacement;
+      std::cout << " suggested_active_scale = " << suggestedScale;
+    }
+    std::cout << std::endl;
 
     uPreviousPrevious = uPrevious;
     uPrevious = u;
@@ -466,6 +535,18 @@ int main(int argc, char** argv)
     };
 
     xdmf.write(currentTime).flush();
+  }
+
+  if (targetMaxDisplacement > 0.0 && peakMaxNodalDisplacement > 0.0)
+  {
+    const Real suggestedScale =
+      activeScale * targetMaxDisplacement / peakMaxNodalDisplacement;
+    std::cout << "\nCalibration:"
+              << " target_max_node|u| = " << targetMaxDisplacement
+              << " observed_peak_max_node|u| = " << peakMaxNodalDisplacement
+              << " active_scale = " << activeScale
+              << " suggested_active_scale = " << suggestedScale
+              << std::endl;
   }
 
   xdmf.close();

--- a/examples/Solid/ActiveContractionPlaneWave.cpp
+++ b/examples/Solid/ActiveContractionPlaneWave.cpp
@@ -53,7 +53,7 @@
 #include <Rodin/Solid.h>
 #include <Rodin/IO/XDMF.h>
 #include <Rodin/Solver/NewtonSolver.h>
-#include <Rodin/Solver/SparseLU.h>
+#include <Rodin/Solver/CG.h>
 #include <Rodin/QF/PolytopeQuadratureFormula.h>
 
 using namespace Rodin;
@@ -462,7 +462,8 @@ int main(int argc, char** argv)
                         + bdfA2 * uPreviousPrevious, v)
            + DirichletBC(du, zero).on(topBC);
 
-    SparseLU linearSolver(newton);
+    CG linearSolver(newton);
+    linearSolver.setTolerance(1e-8).setMaxIterations(2000);
     NewtonSolver solver(linearSolver);
     solver.setMaxIterations(50)
           .setAbsoluteTolerance(1e-9)

--- a/examples/Solid/ActiveContractionPlaneWave.cpp
+++ b/examples/Solid/ActiveContractionPlaneWave.cpp
@@ -123,8 +123,7 @@ int main(int argc, char** argv)
     activeScale = parseReal(argv[4], "active scale");
   if (argc > 5)
   {
-    std::cerr << "Usage: " << argv[0]
-              << " [nc=64] [nSteps=full]"
+    std::cerr << "Usage: " << argv[0] << " [nc=64] [nSteps=full]"
               << " [targetMaxDisplacement=0] [activeScale=1]" << std::endl;
     return 2;
   }
@@ -184,11 +183,11 @@ int main(int argc, char** argv)
   Solid::NeoHookean passive(lambda, mu);
 
   Solid::ActiveFiberLaw::Parameters activeParams;
-  activeParams.stiffness            = activeScale * 20.0;
+  activeParams.stiffness = activeScale * 20.0;
   activeParams.damping              = 300;
   activeParams.destructionRate      = 0.4;
   activeParams.crossBridgeStiffness = activeScale * 100.0;
-  activeParams.contractility        = activeScale * 20.0;
+  activeParams.contractility = activeScale * 20.0;
   activeParams.initial.extension    = 0.0;
   activeParams.initial.stiffness    = 0.0;
   activeParams.initial.stress       = 0.0;
@@ -214,7 +213,7 @@ int main(int argc, char** argv)
   const size_t nWaves = 2;
 
   PlaneWaveParams wave;
-  wave.amplitude      = activeScale * 20.0;
+  wave.amplitude = activeScale * 20.0;
   wave.speed          = 0.5;
   wave.width          = 0.05;
   wave.start          = 0;
@@ -301,8 +300,7 @@ int main(int argc, char** argv)
   fiberField.setName("FiberDirection");
   fiberField = VectorFunction{ RealFunction(1.0), Zero() };
 
-  auto computeMaxNodalDisplacement = [&]() -> Real
-  {
+  auto computeMaxNodalDisplacement = [&]() -> Real {
     Real maxDisplacement = 0.0;
     const auto& uData = u.getData();
     for (auto it = mesh.getVertex(); it; ++it)
@@ -497,8 +495,7 @@ int main(int argc, char** argv)
     const auto diagnostics = commitState();
     const auto& report = solver.getReport();
     const Real maxNodalDisplacement = computeMaxNodalDisplacement();
-    peakMaxNodalDisplacement =
-      std::max(peakMaxNodalDisplacement, maxNodalDisplacement);
+    peakMaxNodalDisplacement = std::max(peakMaxNodalDisplacement, maxNodalDisplacement);
 
     const auto bdfData =
       bdfA0 * u.getData()
@@ -512,9 +509,9 @@ int main(int argc, char** argv)
               << " |u| = " << u.getData().norm()
               << " max_node|u| = " << maxNodalDisplacement
               << " peak_max_node|u| = " << peakMaxNodalDisplacement
-              << " |BDF(u)| = " << bdfData.norm()
-              << " ec = [" << diagnostics.minActiveExtension << ", "
-              << diagnostics.maxActiveExtension << "]"
+              << " |BDF(u)| = " << bdfData.norm() << " ec = ["
+              << diagnostics.minActiveExtension << ", " << diagnostics.maxActiveExtension
+              << "]"
               << " max|gamma| = " << diagnostics.maxGamma
               << " max|beta| = " << diagnostics.maxBeta
               << " max_local_newton = " << diagnostics.maxLocalIterations;
@@ -546,8 +543,7 @@ int main(int argc, char** argv)
               << " target_max_node|u| = " << targetMaxDisplacement
               << " observed_peak_max_node|u| = " << peakMaxNodalDisplacement
               << " active_scale = " << activeScale
-              << " suggested_active_scale = " << suggestedScale
-              << std::endl;
+              << " suggested_active_scale = " << suggestedScale << std::endl;
   }
 
   xdmf.close();

--- a/examples/Solid/ActiveContractionPlaneWave.cpp
+++ b/examples/Solid/ActiveContractionPlaneWave.cpp
@@ -33,10 +33,14 @@
  *   - Displacement (transient vector) - warp by vector in ParaView
  *   - Activation   (transient scalar) - Gaussian travelling plane wave
  *   - FiberDirection (static vector)  - constant (1,0) fiber field
+ *
+ * Optional command-line arguments:
+ *   ActiveContractionPlaneWave [nc=64] [nSteps=full]
  */
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdlib>
 #include <iomanip>
 #include <limits>
 #include <vector>
@@ -74,12 +78,41 @@ namespace
     Real maxBeta = 0.0;
     size_t maxLocalIterations = 0;
   };
+
+  size_t parseSize(const char* value, const char* name)
+  {
+    char* end = nullptr;
+    const auto parsed = std::strtoull(value, &end, 10);
+    if (end == value || *end != '\0')
+    {
+      std::cerr << "Invalid " << name << ": " << value << std::endl;
+      std::exit(2);
+    }
+    return static_cast<size_t>(parsed);
+  }
 }
 
-int main(int, char**)
+int main(int argc, char** argv)
 {
+  size_t nc = 64;
+  size_t requestedSteps = 0;
+
+  if (argc > 1)
+    nc = parseSize(argv[1], "mesh resolution");
+  if (argc > 2)
+    requestedSteps = parseSize(argv[2], "step count");
+  if (argc > 3)
+  {
+    std::cerr << "Usage: " << argv[0] << " [nc=64] [nSteps=full]" << std::endl;
+    return 2;
+  }
+  if (nc < 2)
+  {
+    std::cerr << "Mesh resolution must be at least 2." << std::endl;
+    return 2;
+  }
+
   // ---- geometry -----------------------------------------------------------
-  constexpr size_t nc = 16;
   Mesh mesh;
   mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { nc, nc, nc });
   mesh.scale(1.0 / static_cast<Real>(nc - 1));
@@ -119,7 +152,7 @@ int main(int, char**)
   Solid::NeoHookean passive(lambda, mu);
 
   Solid::ActiveFiberLaw::Parameters activeParams;
-  activeParams.stiffness            = 200.0;
+  activeParams.stiffness            = 20.0;
   activeParams.damping              = 300;
   activeParams.destructionRate      = 0.4;
   activeParams.crossBridgeStiffness = 100.0;
@@ -178,7 +211,9 @@ int main(int, char**)
     static_cast<Real>(nWaves - 1) * wave.gap
     + traversalTime
     + 0.4 / wave.speed;
-  const size_t nSteps = static_cast<size_t>(tEnd / dtStep) + 1;
+  const size_t fullSteps = static_cast<size_t>(tEnd / dtStep) + 1;
+  const size_t nSteps =
+    requestedSteps == 0 ? fullSteps : std::min(requestedSteps, fullSteps);
 
   Real currentTime = 0.0;
 
@@ -323,6 +358,10 @@ int main(int, char**)
   auto zero = VectorFunction{ Zero(), Zero() };
 
   std::cout << std::scientific << std::setprecision(6);
+  std::cout << "Time steps: " << nSteps;
+  if (nSteps != fullSteps)
+    std::cout << " (truncated from " << fullSteps << ")";
+  std::cout << std::endl;
 
   for (size_t step = 1; step <= nSteps; ++step)
   {

--- a/examples/Solid/BlockGravity.cpp
+++ b/examples/Solid/BlockGravity.cpp
@@ -108,9 +108,7 @@ int main(int, char**)
 
     // Newton linearization:  K δu = -F_int(u) + F_body
     Problem newton(du, v);
-    newton = ivw(du, v)
-           - Integral(bodyForce, v)
-           + DirichletBC(du, zero).on(bottomBC);
+    newton = ivw(du, v) - Integral(bodyForce, v) + DirichletBC(du, zero).on(bottomBC);
 
     SparseLU linearSolver(newton);
     NewtonSolver solver(linearSolver);
@@ -120,7 +118,7 @@ int main(int, char**)
 
     solver.solve(u);
 
-    xdmf.write(static_cast<Real>(step));
+    xdmf.write(static_cast<Real>(step)).flush();
   }
 
   return 0;

--- a/examples/Solid/CantileverBeam.cpp
+++ b/examples/Solid/CantileverBeam.cpp
@@ -312,7 +312,7 @@ int main(int, char**)
   grid.add(vel);
   grid.add(acc);
 
-  xdmf.write(0.0);
+  xdmf.write(0.0).flush();
 
   // ---- time loop ----------------------------------------------------------
   constexpr Real maxTraction = -1.0; // downward
@@ -359,16 +359,10 @@ int main(int, char**)
     //   J(u^k)[du] + R(u^k) = 0
     //
     Problem newton(du, w);
-    newton =
-          ivw(du, w)
-           + aMass * Integral(du, w)
-           + aDamp * Integral(du, w)
-           + aMass * Integral(u, w)
-           + aDamp * Integral(u, w)
-           - BoundaryIntegral(traction, w).over(rightBC)
-           - aMass * Integral(uPred, w)
-           + c * Integral(rhsDamp, w)
-           + DirichletBC(du, zero).on(leftBC);
+    newton = ivw(du, w) + aMass * Integral(du, w) + aDamp * Integral(du, w) +
+      aMass * Integral(u, w) + aDamp * Integral(u, w) -
+      BoundaryIntegral(traction, w).over(rightBC) - aMass * Integral(uPred, w) +
+      c * Integral(rhsDamp, w) + DirichletBC(du, zero).on(leftBC);
 
     // Discrete derivative check once, at the first time step and first Newton base point
     if (step == 1)

--- a/src/Rodin/Advection/Lagrangian.h
+++ b/src/Rodin/Advection/Lagrangian.h
@@ -86,8 +86,8 @@ namespace Rodin::Advection
    *   relying on a pre-defined orientation convention of face normals.
    *
    * @par Parameters
-   * - @p eps_in_phys: desired inward physical offset when the boundary is hit. The effective
-   *   offset is @c max(eps_in_phys, 50*sqrt(machine_epsilon)).
+   * - @p epsInPhys: desired inward physical offset when the boundary is hit. The effective
+   *   offset is @c max(epsInPhys, 50*sqrt(machine_epsilon)).
    *
    * @par Complexity
    * Constant time per boundary hit: one projection to cell + face, a few transforms, and a clamp.
@@ -100,15 +100,13 @@ namespace Rodin::Advection
        *
        * @param[in] dt          Signed time step used by the tracer (kept for API symmetry).
        * @param[in] mesh        Mesh on which tracing occurs.
-       * @param[in] eps_in_phys Inward physical offset used to place the footpoint strictly inside.
+       * @param[in] epsInPhys Inward physical offset used to place the footpoint strictly inside.
        */
       StopInsideBoundaryPolicy(
-          Real dt,
-          const Geometry::Mesh<Context::Local>& mesh,
-          Real eps_in_phys = Real(1e-12))
+        Real dt, const Geometry::Mesh<Context::Local>& mesh, Real epsInPhys = Real(1e-12))
         : m_dt(dt),
           m_mesh(mesh),
-          m_eps_in_phys(eps_in_phys)
+          m_epsInPhys(epsInPhys)
       {}
 
       /**
@@ -166,7 +164,6 @@ namespace Rodin::Advection
         Geometry::Point qface(cell, r, x);
         const auto JinvT = qface.getJacobianInverse().transpose();
 
-        Math::SpatialMatrix<Real> JinvT_nref = (JinvT * nref);
         Math::SpatialVector<Real> nu = (JinvT * nref).col(0); // unnormalized physical normal
         Real nn = nu.dot(nu);
         if (!(nn > Real(0)) || !std::isfinite(nn))
@@ -185,17 +182,17 @@ namespace Rodin::Advection
         mesh.getPolytopeTransformation(cd, c).transform(xc, rcent);
 
         const Real cplane = nhat.dot(x);
-        const Real sd_in  = cplane - nhat.dot(xc);
-        if (sd_in < Real(0))
+        const Real sdIn = cplane - nhat.dot(xc);
+        if (sdIn < Real(0))
           nhat = -nhat;
 
         // -------- (4) nudge inside in physical space (inside = -nhat) --------
-        const Real eps_machine = std::numeric_limits<Real>::epsilon();
-        const Real eps_floor   = Real(10) * eps_machine;
-        const Real eps_dt      = Real(0.1) * std::abs(m_dt);
-        const Real eps_in      = std::max(eps_floor, std::min(m_eps_in_phys, eps_dt));
+        const Real epsMachine = std::numeric_limits<Real>::epsilon();
+        const Real epsFloor = Real(10) * epsMachine;
+        const Real epsDt = Real(0.1) * std::abs(m_dt);
+        const Real epsIn = std::max(epsFloor, std::min(m_epsInPhys, epsDt));
 
-        x -= eps_in * nhat;
+        x -= epsIn * nhat;
 
         // -------- (5) map back + clamp --------
         mesh.getPolytopeTransformation(cd, c).inverse(rtmp, x);
@@ -209,7 +206,7 @@ namespace Rodin::Advection
     private:
       Real m_dt;
       std::reference_wrapper<const Geometry::Mesh<Context::Local>> m_mesh;
-      const Real m_eps_in_phys;
+      const Real m_epsInPhys;
   };
 
   /**
@@ -269,8 +266,8 @@ namespace Rodin::Advection
    * - `dt`: Signed step size of the tracer (kept for API symmetry; not used directly here).
    * - `mesh`: Mesh on which tracing occurs.
    * - `phi`: Scalar field/function to correct (typically the advected field itself in level-set use).
-   * - `eps_in_phys`: Desired inward physical offset. The effective shift is
-   *   `max(eps_in_phys, 50*sqrt(machine_epsilon))`.
+   * - `epsInPhys`: Desired inward physical offset. The effective shift is
+   *   `max(epsInPhys, 50*sqrt(machine_epsilon))`.
    */
   template <class Field>
   class TaylorBoundaryShiftPolicy
@@ -281,17 +278,14 @@ namespace Rodin::Advection
        * @param dt Signed time step used by the tracer.
        * @param mesh Mesh on which tracing occurs.
        * @param phi Scalar field used for the Taylor correction.
-       * @param eps_in_phys Inward physical offset used after a boundary hit.
+       * @param epsInPhys Inward physical offset used after a boundary hit.
        */
-      TaylorBoundaryShiftPolicy(
-          Real dt,
-          const Geometry::Mesh<Context::Local>& mesh,
-          const Field& phi,
-          Real eps_in_phys = Real(1e-12))
+      TaylorBoundaryShiftPolicy(Real dt, const Geometry::Mesh<Context::Local>& mesh,
+        const Field& phi, Real epsInPhys = Real(1e-12))
         : m_dt(dt),
           m_mesh(mesh),
           m_phi(phi),
-          m_eps_in_phys(eps_in_phys)
+          m_epsInPhys(epsInPhys)
       {}
 
       /**
@@ -325,9 +319,9 @@ namespace Rodin::Advection
         Geometry::Polytope::Project(g).cell(rtmp, r);
         Geometry::Polytope::Project(g).face(j, r, rtmp);
 
-        // ---- (2) physical boundary point x_hit
-        Math::SpatialPoint x_hit;
-        mesh.getPolytopeTransformation(cd, c).transform(x_hit, r);
+        // ---- (2) physical boundary point xHit
+        Math::SpatialPoint xHit;
+        mesh.getPolytopeTransformation(cd, c).transform(xHit, r);
 
         // ---- (3) outward unit normal on \partialD in physical space
         const auto nref = hs.matrix.row(j).transpose();
@@ -335,8 +329,8 @@ namespace Rodin::Advection
         const auto itc   = mesh.getPolytope(cd, c);
         const auto& cell = *itc;
 
-        Geometry::Point q_hit(cell, r, x_hit);
-        const auto JinvT = q_hit.getJacobianInverse().transpose();
+        Geometry::Point qHit(cell, r, xHit);
+        const auto JinvT = qHit.getJacobianInverse().transpose();
 
         Math::SpatialVector<Real> nu = (JinvT * nref).col(0); // unnormalized physical normal
         const Real nn = nu.dot(nu);
@@ -354,39 +348,39 @@ namespace Rodin::Advection
         Math::SpatialPoint xc;
         mesh.getPolytopeTransformation(cd, c).transform(xc, rcent);
 
-        const Real cplane = nD.dot(x_hit);
-        const Real sd_in  = cplane - nD.dot(xc);
-        if (sd_in < Real(0))
+        const Real cplane = nD.dot(xHit);
+        const Real sdIn = cplane - nD.dot(xc);
+        if (sdIn < Real(0))
           nD = -nD;
 
-        // ---- (4) inward nudge: x_new = x_hit - eps_in * nD
-        const Real eps_machine = std::numeric_limits<Real>::epsilon();
-        const Real eps_floor   = Real(10) * eps_machine;
-        const Real eps_dt      = Real(0.1) * std::abs(m_dt);
-        const Real eps_in      = std::max(eps_floor, std::min(m_eps_in_phys, eps_dt));
+        // ---- (4) inward nudge: xNew = xHit - epsIn * nD
+        const Real epsMachine = std::numeric_limits<Real>::epsilon();
+        const Real epsFloor = Real(10) * epsMachine;
+        const Real epsDt = Real(0.1) * std::abs(m_dt);
+        const Real epsIn = std::max(epsFloor, std::min(m_epsInPhys, epsDt));
 
-        Math::SpatialPoint x_new = x_hit;
-        x_new -= eps_in * nD;
+        Math::SpatialPoint xNew = xHit;
+        xNew -= epsIn * nD;
 
-        // ---- (5) value correction via first-order Taylor to recover phi(x_hit) from phi(x_new)
+        // ---- (5) value correction via first-order Taylor to recover phi(xHit) from phi(xNew)
         //
-        // We will evaluate phi at the nudged point x_new (since we set hit.rref to it).
+        // We will evaluate phi at the nudged point xNew (since we set hit.rref to it).
         // To approximate the *unshifted* hit value, use:
-        //   phi(x_hit) ≈ phi(x_new) + gradphi \cdot (x_hit - x_new)
-        const auto gphi = Variational::Grad(m_phi.get()).getValue(q_hit);
+        //   phi(xHit) ≈ phi(xNew) + gradphi \cdot (xHit - xNew)
+        const auto gphi = Variational::Grad(m_phi.get()).getValue(qHit);
 
-        // dx = x_hit - x_new  (NOTE THE SIGN)
+        // dx = xHit - xNew  (NOTE THE SIGN)
         Math::SpatialVector<Real> dx;
         dx.resize(gphi.size());
         for (int k = 0; k < dx.size(); ++k)
-          dx[k] = x_hit[k] - x_new[k];
+          dx[k] = xHit[k] - xNew[k];
 
         const Real dphi = dx.dot(gphi);
         if (std::isfinite(dphi))
           hit.correction += dphi;
 
         // ---- (6) map back + clamp
-        mesh.getPolytopeTransformation(cd, c).inverse(rtmp, x_new);
+        mesh.getPolytopeTransformation(cd, c).inverse(rtmp, xNew);
         Geometry::Polytope::Project(g).cell(r, rtmp);
 
         hit.rref = r;
@@ -398,7 +392,7 @@ namespace Rodin::Advection
       const Real m_dt;
       std::reference_wrapper<const Geometry::Mesh<Context::Local>> m_mesh;
       std::reference_wrapper<const Field> m_phi;
-      const Real m_eps_in_phys;
+      const Real m_epsInPhys;
   };
 
   /**

--- a/src/Rodin/Assembly/OpenMP.cpp
+++ b/src/Rodin/Assembly/OpenMP.cpp
@@ -18,24 +18,13 @@ namespace Rodin::Assembly
   Geometry::PolytopeIterator
   OpenMPIteration<Geometry::Mesh<Context::Local>>::getIterator(Index i) const
   {
-    Geometry::PolytopeIterator it;
-    switch (m_region)
-    {
-      case Geometry::Region::Cells:
-      {
-        it = m_mesh.get().getCell(i);
-        return it;
-      }
-      case Geometry::Region::Faces:
-      case Geometry::Region::Boundary:
-      case Geometry::Region::Interface:
-      {
-        it = m_mesh.get().getFace(i);
-        return it;
-      }
-    }
-    assert(false);
-    return it;
+    return m_mesh.get().getPolytope(getDimension(), i);
+  }
+
+  Geometry::Polytope OpenMPIteration<Geometry::Mesh<Context::Local>>::getPolytope(
+    Index i) const
+  {
+    return Geometry::Polytope(getDimension(), i, m_mesh.get());
   }
 
   size_t OpenMPIteration<Geometry::Mesh<Context::Local>>::getDimension() const
@@ -98,5 +87,3 @@ namespace Rodin::Assembly
     return false;
   }
 }
-
-

--- a/src/Rodin/Assembly/OpenMP.h
+++ b/src/Rodin/Assembly/OpenMP.h
@@ -62,12 +62,18 @@ namespace Rodin::Assembly
       OpenMPIteration(const MeshType& mesh, const Geometry::Region& region);
 
       /**
-       * @brief Gets an iterator for a specific thread.
-       *
-       * @param i Thread index
-       * @return PolytopeIterator for the specified thread's element subset
+       * @brief Gets an iterator positioned at a specific polytope.
+       * @param i Polytope index
+       * @return Iterator positioned at @p i
        */
       Geometry::PolytopeIterator getIterator(Index i) const;
+
+      /**
+       * @brief Gets a polytope value for an indexed assembly iteration.
+       * @param i Polytope index
+       * @return Non-owning polytope descriptor
+       */
+      Geometry::Polytope getPolytope(Index i) const;
 
       /**
        * @brief Gets the topological dimension of elements.
@@ -235,8 +241,8 @@ namespace Rodin::Assembly
                   continue;
               }
 
-              auto it = seq.getIterator(i);
-              integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(i);
+              integrator->setPolytope(polytope);
 
               const auto& rows = input.getTestFES().getDOFs(d, i);
               const auto& cols = input.getTrialFES().getDOFs(d, i);
@@ -536,8 +542,8 @@ namespace Rodin::Assembly
                 if (!a || !attrs.contains(*a)) continue; // or attrs.count(*a)==0
               }
 
-              auto it = seq.getIterator(i);
-              lbfi->setPolytope(*it);
+              const auto polytope = seq.getPolytope(i);
+              lbfi->setPolytope(polytope);
 
               const auto& rows = input.getTestFES().getDOFs(d, i);
               const auto& cols = input.getTrialFES().getDOFs(d, i);
@@ -585,21 +591,26 @@ namespace Rodin::Assembly
                 if (!a || !testAttrs.contains(*a)) continue;
               }
 
-              auto teIt = testseq.getIterator(i);
-              SequentialIteration trialseq{ mesh, gbfi->getTrialRegion() };
+              const auto testPolytope = testseq.getPolytope(i);
+              OpenMPIteration trialseq{mesh, gbfi->getTrialRegion()};
+              const Index rd = trialseq.getDimension();
+              const Index rcount = trialseq.getCount();
 
-              for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+              for (Index tr = 0; tr < rcount; ++tr)
               {
+                if (!trialseq.filter(tr))
+                  continue;
                 if (!trialAttrs.empty())
                 {
-                  const auto a = trIt->getAttribute(); // Optional<Attribute>
+                  const auto a = mesh.getAttribute(rd, tr);
                   if (!a || !trialAttrs.contains(*a)) continue; // or trialAttrs.count(*a)==0
                 }
 
-                gbfi->setPolytope(*trIt, *teIt);
+                const auto trialPolytope = trialseq.getPolytope(tr);
+                gbfi->setPolytope(trialPolytope, testPolytope);
 
-                const auto& rows = input.getTestFES().getDOFs(d, teIt->getIndex());
-                const auto& cols = input.getTrialFES().getDOFs(d, trIt->getIndex());
+                const auto& rows = input.getTestFES().getDOFs(d, i);
+                const auto& cols = input.getTrialFES().getDOFs(rd, tr);
                 for (size_t r = 0; r < rows.size(); ++r)
                   for (size_t c = 0; c < cols.size(); ++c)
                     local(rows(r), cols(c)) += Math::conj(gbfi->integrate(c, r));
@@ -729,8 +740,8 @@ namespace Rodin::Assembly
                 if (!a || !attrs.contains(*a)) continue; // or attrs.count(*a)==0
               }
 
-              auto it = seq.getIterator(i);
-              integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(i);
+              integrator->setPolytope(polytope);
 
               const auto& dofs = input.getFES().getDOFs(d, i);
               assert(dofs.size() >= 0);
@@ -1083,7 +1094,8 @@ namespace Rodin::Assembly
         {
           // ---- Sparse path: eliminate during assembly (thread-local triplets + RHS) ----
           std::vector<std::vector<Eigen::Triplet<ScalarType>>> tchunks(static_cast<size_t>(tc));
-          std::vector<std::vector<std::pair<Index, ScalarType>>> rhsChunks(static_cast<size_t>(tc));
+          std::vector<std::vector<std::pair<Index, ScalarType>>> rhsChunks(
+            static_cast<size_t>(tc));
 
           auto sparseEntry = [&](std::vector<Eigen::Triplet<ScalarType>>& localT,
                                std::vector<std::pair<Index, ScalarType>>& localRhs,
@@ -1099,9 +1111,7 @@ namespace Rodin::Assembly
             for (const auto& r : constraints.expand(row))
             {
               if (colValue != ScalarType(0))
-                localRhs.emplace_back(
-                    r.index,
-                    -r.coefficient * val * colValue);
+                localRhs.emplace_back(r.index, -r.coefficient * val * colValue);
               for (const auto& c : constraints.expand(col))
                 localT.emplace_back(
                     r.index, c.index, r.coefficient * val * c.coefficient);
@@ -1143,8 +1153,8 @@ namespace Rodin::Assembly
                   if (!a || !attrs.contains(*a)) continue; // or attrs.count(*a)==0
                 }
 
-                auto it = seq.getIterator(p);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                integrator->setPolytope(polytope);
 
                 const auto& rowsDOF = testFES.getDOFs(d, p);
                 const auto& colsDOF = trialFES.getDOFs(d, p);
@@ -1194,6 +1204,7 @@ namespace Rodin::Assembly
                 }
 
                 const auto& rowsDOF = testFES.getDOFs(td, te);
+                const auto testPolytope = testseq.getPolytope(te);
 
                 const Index rd = trialseq.getDimension();
                 const Index rcount = trialseq.getCount();
@@ -1209,10 +1220,8 @@ namespace Rodin::Assembly
 
                   const auto& colsDOF = trialFES.getDOFs(rd, tr);
 
-                  auto teIt = testseq.getIterator(te);
-                  auto trIt = trialseq.getIterator(tr);
-
-                  integrator->setPolytope(*trIt, *teIt);
+                  const auto trialPolytope = trialseq.getPolytope(tr);
+                  integrator->setPolytope(trialPolytope, testPolytope);
 
                   for (size_t i = 0; i < static_cast<size_t>(rowsDOF.size()); ++i)
                   {
@@ -1263,8 +1272,8 @@ namespace Rodin::Assembly
                   if (!a || !attrs.contains(*a)) continue; // or attrs.count(*a)==0
                 }
 
-                auto it = seq.getIterator(p);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                integrator->setPolytope(polytope);
 
                 const auto& dofs = testFES.getDOFs(d, p);
                 for (size_t l = 0; l < static_cast<size_t>(dofs.size()); ++l)
@@ -1306,7 +1315,7 @@ namespace Rodin::Assembly
             all.insert(all.end(),
                        std::make_move_iterator(v0.begin()),
                        std::make_move_iterator(v0.end()));
-            v0.clear();
+            std::vector<Eigen::Triplet<ScalarType>>().swap(v0);
           }
 
           for (const Index gs : constraints.getIdentifiedRows())
@@ -1319,10 +1328,10 @@ namespace Rodin::Assembly
             b.coeffRef(static_cast<size_t>(gs)) = constraints.getIdentificationValue(gs);
           }
 
-          std::vector<Eigen::Triplet<ScalarType>> filtered;
-          filtered.reserve(all.size() + rows);
-          for (const auto& t : all)
+          size_t write = 0;
+          for (size_t read = 0; read < all.size(); ++read)
           {
+            const auto& t = all[read];
             const Index row = static_cast<Index>(t.row());
             const Index col = static_cast<Index>(t.col());
             const ScalarType val = t.value();
@@ -1334,21 +1343,24 @@ namespace Rodin::Assembly
                 val * constraints.getFixedValue(col);
               continue;
             }
-            filtered.push_back(t);
+            if (write != read)
+              all[write] = t;
+            ++write;
           }
+          all.resize(write);
 
           for (Index i = 0; i < static_cast<Index>(rows); ++i)
           {
             if (constraints.isFixed(i))
             {
-              filtered.emplace_back(i, i, ScalarType(1));
+              all.emplace_back(i, i, ScalarType(1));
               b.coeffRef(static_cast<size_t>(i)) =
                 constraints.getFixedValue(i);
             }
           }
 
           A.resize(rows, cols);
-          A.setFromTriplets(filtered.begin(), filtered.end());
+          A.setFromTriplets(all.begin(), all.end());
         }
         else
         {
@@ -1394,8 +1406,8 @@ namespace Rodin::Assembly
                   if (!a || !attrs.contains(*a)) continue; // or attrs.count(*a)==0
                 }
 
-                auto it = seq.getIterator(p);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                integrator->setPolytope(polytope);
 
                 const auto& rowsDOF = testFES.getDOFs(d, p);
                 const auto& colsDOF = trialFES.getDOFs(d, p);
@@ -1460,6 +1472,7 @@ namespace Rodin::Assembly
                 }
 
                 const auto& rowsDOF = testFES.getDOFs(td, te);
+                const auto testPolytope = testseq.getPolytope(te);
 
                 const Index rd = trialseq.getDimension();
                 const Index rcount = trialseq.getCount();
@@ -1475,10 +1488,8 @@ namespace Rodin::Assembly
 
                   const auto& colsDOF = trialFES.getDOFs(rd, tr);
 
-                  auto teIt = testseq.getIterator(te);
-                  auto trIt = trialseq.getIterator(tr);
-
-                  integrator->setPolytope(*trIt, *teIt);
+                  const auto trialPolytope = trialseq.getPolytope(tr);
+                  integrator->setPolytope(trialPolytope, testPolytope);
 
                   for (size_t i = 0; i < static_cast<size_t>(rowsDOF.size()); ++i)
                   {
@@ -1567,8 +1578,8 @@ namespace Rodin::Assembly
                   if (!a || !attrs.contains(*a)) continue;
                 }
 
-                auto it = seq.getIterator(p);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                integrator->setPolytope(polytope);
 
                 const auto& dofs = testFES.getDOFs(d, p);
                 for (size_t l = 0; l < static_cast<size_t>(dofs.size()); ++l)
@@ -1653,10 +1664,8 @@ namespace Rodin::Assembly
        * @param input Problem assembly input.
        * @param target Side of the system to assemble.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         LinearSystemType scratch;
         execute(scratch, input);
@@ -1868,7 +1877,8 @@ namespace Rodin::Assembly
         // Thread-local accumulators
         // ------------------------------------------------------------------
         std::vector<std::vector<Eigen::Triplet<ScalarType>>> tchunks(static_cast<size_t>(tc));
-        std::vector<std::vector<std::pair<Index, ScalarType>>> rhsChunks(static_cast<size_t>(tc));
+        std::vector<std::vector<std::pair<Index, ScalarType>>> rhsChunks(
+          static_cast<size_t>(tc));
 
         std::vector<OperatorType> Achunks;
         if constexpr (!IsSparse)
@@ -1899,8 +1909,7 @@ namespace Rodin::Assembly
           {
             if (colValue != ScalarType(0))
               rhsChunks[static_cast<size_t>(tid)].emplace_back(
-                  r.index,
-                  -r.coefficient * val * colValue);
+                r.index, -r.coefficient * val * colValue);
             for (const auto& c : constraints.expand(col))
               tchunks[static_cast<size_t>(tid)].emplace_back(
                   r.index, c.index, r.coefficient * val * c.coefficient);
@@ -1955,8 +1964,8 @@ namespace Rodin::Assembly
                     if (!a || !attrs.contains(*a)) continue;
                   }
 
-                  auto it = seq.getIterator(p);
-                  integrator->setPolytope(*it);
+                  const auto polytope = seq.getPolytope(p);
+                  integrator->setPolytope(polytope);
 
                   const auto& rows = vFES.getDOFs(d, p);
                   const auto& cols = uFES.getDOFs(d, p);
@@ -1983,8 +1992,7 @@ namespace Rodin::Assembly
                         {
                           if (colValue != ScalarType(0))
                             rhsChunks[static_cast<size_t>(tid)].emplace_back(
-                                r.index,
-                                -r.coefficient * val * colValue);
+                              r.index, -r.coefficient * val * colValue);
                           for (const auto& c : constraints.expand(J))
                             (*Alocal)(r.index, c.index) +=
                               r.coefficient * val * c.coefficient;
@@ -2051,6 +2059,7 @@ namespace Rodin::Assembly
                   }
 
                   const auto& rows = vFES.getDOFs(td, te);
+                  const auto testPolytope = testseq.getPolytope(te);
 
                   const Index rd = trialseq.getDimension();
                   const Index rcount = trialseq.getCount();
@@ -2066,10 +2075,8 @@ namespace Rodin::Assembly
 
                     const auto& cols = uFES.getDOFs(rd, tr);
 
-                    auto teIt = testseq.getIterator(te);
-                    auto trIt = trialseq.getIterator(tr);
-
-                    integrator->setPolytope(*trIt, *teIt);
+                    const auto trialPolytope = trialseq.getPolytope(tr);
+                    integrator->setPolytope(trialPolytope, testPolytope);
 
                     for (size_t i = 0; i < static_cast<size_t>(rows.size()); ++i)
                     {
@@ -2093,8 +2100,7 @@ namespace Rodin::Assembly
                           {
                             if (colValue != ScalarType(0))
                               rhsChunks[static_cast<size_t>(tid)].emplace_back(
-                                  r.index,
-                                  -r.coefficient * val * colValue);
+                                r.index, -r.coefficient * val * colValue);
                             for (const auto& c : constraints.expand(J))
                               (*Alocal)(r.index, c.index) +=
                                 r.coefficient * val * c.coefficient;
@@ -2145,8 +2151,8 @@ namespace Rodin::Assembly
                   if (!a || !attrs.contains(*a)) continue;
                 }
 
-                auto it = seq.getIterator(p);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                integrator->setPolytope(polytope);
 
                 const auto& dofs = vFES.getDOFs(d, p);
                 for (size_t l = 0; l < static_cast<size_t>(dofs.size()); ++l)
@@ -2237,7 +2243,7 @@ namespace Rodin::Assembly
             all.insert(all.end(),
                        std::make_move_iterator(v0.begin()),
                        std::make_move_iterator(v0.end()));
-            v0.clear();
+            std::vector<Eigen::Triplet<ScalarType>>().swap(v0);
           }
 
           for (const Index gs : constraints.getIdentifiedRows())
@@ -2250,10 +2256,10 @@ namespace Rodin::Assembly
             b.coeffRef(static_cast<size_t>(gs)) = constraints.getIdentificationValue(gs);
           }
 
-          std::vector<Eigen::Triplet<ScalarType>> filtered;
-          filtered.reserve(all.size() + nrows);
-          for (const auto& t : all)
+          size_t write = 0;
+          for (size_t read = 0; read < all.size(); ++read)
           {
+            const auto& t = all[read];
             const Index row = static_cast<Index>(t.row());
             const Index col = static_cast<Index>(t.col());
             const ScalarType val = t.value();
@@ -2265,21 +2271,24 @@ namespace Rodin::Assembly
                 val * constraints.getFixedValue(col);
               continue;
             }
-            filtered.push_back(t);
+            if (write != read)
+              all[write] = t;
+            ++write;
           }
+          all.resize(write);
 
           for (Index I = 0; I < static_cast<Index>(nrows); ++I)
           {
             if (constraints.isFixed(I))
             {
-              filtered.emplace_back(I, I, ScalarType(1));
+              all.emplace_back(I, I, ScalarType(1));
               b.coeffRef(static_cast<size_t>(I)) =
                 constraints.getFixedValue(I);
             }
           }
 
           A.resize(nrows, ncols);
-          A.setFromTriplets(filtered.begin(), filtered.end());
+          A.setFromTriplets(all.begin(), all.end());
         }
         else
         {
@@ -2376,10 +2385,8 @@ namespace Rodin::Assembly
        * @param input Mixed problem input.
        * @param target Side of the system to assemble.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         LinearSystemType scratch;
         execute(scratch, input);

--- a/src/Rodin/Assembly/Sequential.cpp
+++ b/src/Rodin/Assembly/Sequential.cpp
@@ -15,34 +15,68 @@ namespace Rodin::Assembly
     : m_mesh(mesh), m_region(region)
   {}
 
-  Geometry::PolytopeIterator SequentialIteration<Geometry::Mesh<Context::Local>>::getIterator() const
+  Geometry::PolytopeIterator
+  SequentialIteration<Geometry::Mesh<Context::Local>>::getIterator() const
   {
     Geometry::PolytopeIterator it;
     switch (m_region)
     {
       case Geometry::Region::Cells:
-      {
         it = m_mesh.get().getCell();
         break;
-      }
       case Geometry::Region::Faces:
-      {
         it = m_mesh.get().getFace();
         break;
-      }
       case Geometry::Region::Boundary:
-      {
         it = m_mesh.get().getBoundary();
         break;
-      }
       case Geometry::Region::Interface:
-      {
         it = m_mesh.get().getInterface();
         break;
-      }
     }
     return it;
   }
+
+  Geometry::Polytope SequentialIteration<Geometry::Mesh<Context::Local>>::getPolytope(
+    Index i) const
+  {
+    return Geometry::Polytope(getDimension(), i, m_mesh.get());
+  }
+
+  size_t SequentialIteration<Geometry::Mesh<Context::Local>>::getDimension() const
+  {
+    switch (m_region)
+    {
+      case Geometry::Region::Cells:
+        return m_mesh.get().getDimension();
+      case Geometry::Region::Boundary:
+      case Geometry::Region::Interface:
+      case Geometry::Region::Faces:
+        return m_mesh.get().getDimension() - 1;
+    }
+    assert(false);
+    return 0;
+  }
+
+  size_t SequentialIteration<Geometry::Mesh<Context::Local>>::getCount() const
+  {
+    return m_region == Geometry::Region::Cells ? m_mesh.get().getCellCount()
+                                               : m_mesh.get().getFaceCount();
+  }
+
+  bool SequentialIteration<Geometry::Mesh<Context::Local>>::filter(Index i) const
+  {
+    switch (m_region)
+    {
+      case Geometry::Region::Cells:
+      case Geometry::Region::Faces:
+        return true;
+      case Geometry::Region::Boundary:
+        return m_mesh.get().isBoundary(i);
+      case Geometry::Region::Interface:
+        return m_mesh.get().isInterface(i);
+    }
+    assert(false);
+    return false;
+  }
 }
-
-

--- a/src/Rodin/Assembly/Sequential.h
+++ b/src/Rodin/Assembly/Sequential.h
@@ -61,10 +61,26 @@ namespace Rodin::Assembly
       SequentialIteration(const MeshType& mesh, const Geometry::Region&);
 
       /**
-       * @brief Gets an iterator for traversing mesh elements.
-       * @return PolytopeIterator for sequential mesh traversal
+       * @brief Gets an iterator over the selected region.
+       * @return Polytope iterator
        */
       Geometry::PolytopeIterator getIterator() const;
+
+      /**
+       * @brief Gets a polytope value for an indexed assembly iteration.
+       * @param i Polytope index
+       * @return Non-owning polytope descriptor
+       */
+      Geometry::Polytope getPolytope(Index i) const;
+
+      /// @brief Gets the topological dimension of the iteration.
+      size_t getDimension() const;
+
+      /// @brief Gets the number of candidate polytopes.
+      size_t getCount() const;
+
+      /// @brief Tests whether a candidate belongs to the iteration region.
+      bool filter(Index i) const;
 
     private:
       std::reference_wrapper<const MeshType> m_mesh;  ///< Reference to the mesh
@@ -151,17 +167,20 @@ namespace Rodin::Assembly
         {
           const auto& attrs = lfi.getAttributes();
           SequentialIteration seq(mesh, lfi.getRegion());
-          for (auto it = seq.getIterator(); it; ++it)
+          const size_t d = seq.getDimension();
+          const Index count = seq.getCount();
+          for (Index i = 0; i < count; ++i)
           {
+            if (!seq.filter(i))
+              continue;
             if (!attrs.empty())
             {
-              const auto a = it->getAttribute();
+              const auto a = mesh.getAttribute(d, i);
               if (!a || !attrs.count(*a))
                 continue;
             }
-            lfi.setPolytope(*it);
-            const size_t d = it.getDimension();
-            const size_t i = it->getIndex();
+            const auto polytope = seq.getPolytope(i);
+            lfi.setPolytope(polytope);
             const auto& dofs = input.getFES().getDOFs(d, i);
             for (size_t l = 0; l < static_cast<size_t>(dofs.size()); l++)
               res(dofs(l)) += lfi.integrate(l);
@@ -258,17 +277,22 @@ namespace Rodin::Assembly
         {
           const auto& attrs = bfi.getAttributes();
           SequentialIteration seq(mesh, bfi.getRegion());
-          for (auto it = seq.getIterator(); it; ++it)
+          const size_t d = seq.getDimension();
+          const Index count = seq.getCount();
+          for (Index p = 0; p < count; ++p)
           {
+            if (!seq.filter(p))
+              continue;
             if (!attrs.empty())
             {
-              const auto a = it->getAttribute();
+              const auto a = mesh.getAttribute(d, p);
               if (!a || !attrs.count(*a))
                 continue;
             }
-            bfi.setPolytope(*it);
-            const auto& rows = input.getTestFES().getDOFs(it.getDimension(), it->getIndex());
-            const auto& cols = input.getTrialFES().getDOFs(it.getDimension(), it->getIndex());
+            const auto polytope = seq.getPolytope(p);
+            bfi.setPolytope(polytope);
+            const auto& rows = input.getTestFES().getDOFs(d, p);
+            const auto& cols = input.getTrialFES().getDOFs(d, p);
             for (size_t l = 0; l < static_cast<size_t>(rows.size()); l++)
               for (size_t m = 0; m < static_cast<size_t>(cols.size()); m++)
                 res(rows(l), cols(m)) += Math::conj(bfi.integrate(m, l));
@@ -280,25 +304,35 @@ namespace Rodin::Assembly
           const auto& testAttrs = bfi.getTestAttributes();
           SequentialIteration trialseq(mesh, bfi.getTrialRegion());
           SequentialIteration testseq(mesh, bfi.getTestRegion());
-          for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+          const size_t td = testseq.getDimension();
+          const size_t rd = trialseq.getDimension();
+          const Index tcount = testseq.getCount();
+          const Index rcount = trialseq.getCount();
+          for (Index te = 0; te < tcount; ++te)
           {
+            if (!testseq.filter(te))
+              continue;
             if (!testAttrs.empty())
             {
-              const auto a = teIt->getAttribute();
+              const auto a = mesh.getAttribute(td, te);
               if (!a || !testAttrs.count(*a))
                 continue;
             }
-            for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+            const auto testPolytope = testseq.getPolytope(te);
+            const auto& rows = input.getTestFES().getDOFs(td, te);
+            for (Index tr = 0; tr < rcount; ++tr)
             {
+              if (!trialseq.filter(tr))
+                continue;
               if (!trialAttrs.empty())
               {
-                const auto a = trIt->getAttribute();
+                const auto a = mesh.getAttribute(rd, tr);
                 if (!a || !trialAttrs.count(*a))
                   continue;
               }
-              bfi.setPolytope(*trIt, *teIt);
-              const auto& rows = input.getTestFES().getDOFs(teIt.getDimension(), teIt->getIndex());
-              const auto& cols = input.getTrialFES().getDOFs(trIt.getDimension(), trIt->getIndex());
+              const auto trialPolytope = trialseq.getPolytope(tr);
+              bfi.setPolytope(trialPolytope, testPolytope);
+              const auto& cols = input.getTrialFES().getDOFs(rd, tr);
               for (size_t l = 0; l < static_cast<size_t>(rows.size()); l++)
                 for (size_t m = 0; m < static_cast<size_t>(cols.size()); m++)
                   res(rows(l), cols(m)) += Math::conj(bfi.integrate(m, l));
@@ -485,17 +519,22 @@ namespace Rodin::Assembly
         {
           const auto& attrs = bfi.getAttributes();
           SequentialIteration seq(mesh, bfi.getRegion());
-          for (auto it = seq.getIterator(); it; ++it)
+          const size_t d = seq.getDimension();
+          const Index count = seq.getCount();
+          for (Index p = 0; p < count; ++p)
           {
+            if (!seq.filter(p))
+              continue;
             if (!attrs.empty())
             {
-              const auto a = it->getAttribute();
+              const auto a = mesh.getAttribute(d, p);
               if (!a || !attrs.count(*a))
                 continue;
             }
-            bfi.setPolytope(*it);
-            const auto& rows = input.getTestFES().getDOFs(it.getDimension(), it->getIndex());
-            const auto& cols = input.getTrialFES().getDOFs(it.getDimension(), it->getIndex());
+            const auto polytope = seq.getPolytope(p);
+            bfi.setPolytope(polytope);
+            const auto& rows = input.getTestFES().getDOFs(d, p);
+            const auto& cols = input.getTrialFES().getDOFs(d, p);
             for (size_t l = 0; l < static_cast<size_t>(rows.size()); l++)
             {
               for (size_t m = 0; m < static_cast<size_t>(cols.size()); m++)
@@ -513,26 +552,36 @@ namespace Rodin::Assembly
           const auto& trialAttrs = bfi.getTrialAttributes();
           const auto& testAttrs = bfi.getTestAttributes();
           SequentialIteration testseq(mesh, bfi.getTestRegion());
-          for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+          SequentialIteration trialseq(mesh, bfi.getTrialRegion());
+          const size_t td = testseq.getDimension();
+          const size_t rd = trialseq.getDimension();
+          const Index tcount = testseq.getCount();
+          const Index rcount = trialseq.getCount();
+          for (Index te = 0; te < tcount; ++te)
           {
+            if (!testseq.filter(te))
+              continue;
             if (!testAttrs.empty())
             {
-              const auto a = teIt->getAttribute();
+              const auto a = mesh.getAttribute(td, te);
               if (!a || !testAttrs.count(*a))
                 continue;
             }
-            SequentialIteration trialseq(mesh, bfi.getTrialRegion());
-            for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+            const auto testPolytope = testseq.getPolytope(te);
+            const auto& rows = input.getTestFES().getDOFs(td, te);
+            for (Index tr = 0; tr < rcount; ++tr)
             {
+              if (!trialseq.filter(tr))
+                continue;
               if (!trialAttrs.empty())
               {
-                const auto a = trIt->getAttribute();
+                const auto a = mesh.getAttribute(rd, tr);
                 if (!a || !trialAttrs.count(*a))
                   continue;
               }
-              bfi.setPolytope(*trIt, *teIt);
-              const auto& rows = input.getTestFES().getDOFs(teIt.getDimension(), teIt->getIndex());
-              const auto& cols = input.getTrialFES().getDOFs(trIt.getDimension(), trIt->getIndex());
+              const auto trialPolytope = trialseq.getPolytope(tr);
+              bfi.setPolytope(trialPolytope, testPolytope);
+              const auto& cols = input.getTrialFES().getDOFs(rd, tr);
               for (size_t l = 0; l < static_cast<size_t>(rows.size()); l++)
               {
                 for (size_t m = 0; m < static_cast<size_t>(cols.size()); m++)
@@ -1020,19 +1069,21 @@ namespace Rodin::Assembly
                   return;
                 const auto& vFES = vref.get().getFiniteElementSpace();
 
-                for (auto it = seq.getIterator(); it; ++it)
+                const size_t d = seq.getDimension();
+                const Index count = seq.getCount();
+                for (Index p = 0; p < count; ++p)
                 {
+                  if (!seq.filter(p))
+                    continue;
                   if (!attrs.empty())
                   {
-                    const auto a = it->getAttribute();
+                    const auto a = mesh.getAttribute(d, p);
                     if (!a || !attrs.count(*a))
                       continue;
                   }
 
-                  const size_t d = it->getDimension();
-                  const Index p = it->getIndex();
-
-                  bfi.setPolytope(*it);
+                  const auto polytope = seq.getPolytope(p);
+                  bfi.setPolytope(polytope);
 
                   const auto& rows = vFES.getDOFs(d, p);
                   const auto& cols = uFES.getDOFs(d, p);
@@ -1084,30 +1135,39 @@ namespace Rodin::Assembly
                   return;
                 const auto& vFES = vref.get().getFiniteElementSpace();
 
-                for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+                const size_t td = testseq.getDimension();
+                const size_t rd = trialseq.getDimension();
+                const Index tcount = testseq.getCount();
+                const Index rcount = trialseq.getCount();
+                for (Index te = 0; te < tcount; ++te)
                 {
+                  if (!testseq.filter(te))
+                    continue;
                   if (!testAttrs.empty())
                   {
-                    const auto a = teIt->getAttribute();
+                    const auto a = mesh.getAttribute(td, te);
                     if (!a || !testAttrs.count(*a))
                       continue;
                   }
 
-                  const auto& rows = vFES.getDOFs(teIt->getDimension(), teIt->getIndex());
+                  const auto testPolytope = testseq.getPolytope(te);
+                  const auto& rows = vFES.getDOFs(td, te);
 
-                  for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+                  for (Index tr = 0; tr < rcount; ++tr)
                   {
+                    if (!trialseq.filter(tr))
+                      continue;
                     if (!trialAttrs.empty())
                     {
-                      const auto a = trIt->getAttribute();
+                      const auto a = mesh.getAttribute(rd, tr);
                       if (!a || !trialAttrs.count(*a))
                         continue;
                     }
 
-                    const auto& cols =
-                      uFES.getDOFs(trIt->getDimension(), trIt->getIndex());
+                    const auto& cols = uFES.getDOFs(rd, tr);
 
-                    bfi.setPolytope(*trIt, *teIt);
+                    const auto trialPolytope = trialseq.getPolytope(tr);
+                    bfi.setPolytope(trialPolytope, testPolytope);
 
                     for (size_t i = 0; i < static_cast<size_t>(rows.size()); ++i)
                     {
@@ -1144,18 +1204,23 @@ namespace Rodin::Assembly
                 return;
               const auto& vFES = vref.get().getFiniteElementSpace();
 
-              for (auto it = seq.getIterator(); it; ++it)
+              const size_t d = seq.getDimension();
+              const Index count = seq.getCount();
+              for (Index p = 0; p < count; ++p)
               {
+                if (!seq.filter(p))
+                  continue;
                 if (!attrs.empty())
                 {
-                  const auto a = it->getAttribute();
+                  const auto a = mesh.getAttribute(d, p);
                   if (!a || !attrs.count(*a))
                     continue;
                 }
 
-                lfi.setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                lfi.setPolytope(polytope);
 
-                const auto& dofs = vFES.getDOFs(it->getDimension(), it->getIndex());
+                const auto& dofs = vFES.getDOFs(d, p);
                 for (size_t l = 0; l < static_cast<size_t>(dofs.size()); ++l)
                 {
                   const Index I = static_cast<Index>(vOff + static_cast<size_t>(dofs[l]));
@@ -1232,10 +1297,10 @@ namespace Rodin::Assembly
               b.coeffRef(gs) = constraints.getIdentificationValue(gs);
             }
 
-            std::vector<Eigen::Triplet<ScalarType>> filteredTriplets;
-            filteredTriplets.reserve(triplets.size() + nrows);
-            for (const auto& t : triplets)
+            size_t write = 0;
+            for (size_t read = 0; read < triplets.size(); ++read)
             {
+              const auto& t = triplets[read];
               const Index row = static_cast<Index>(t.row());
               const Index col = static_cast<Index>(t.col());
               const ScalarType val = t.value();
@@ -1246,20 +1311,23 @@ namespace Rodin::Assembly
                 b.coeffRef(row) -= val * constraints.getFixedValue(col);
                 continue;
               }
-              filteredTriplets.push_back(t);
+              if (write != read)
+                triplets[write] = t;
+              ++write;
             }
+            triplets.resize(write);
 
             for (Index i = 0; i < static_cast<Index>(nrows); ++i)
             {
               if (constraints.isFixed(i))
               {
-                filteredTriplets.emplace_back(i, i, ScalarType(1));
+                triplets.emplace_back(i, i, ScalarType(1));
                 b.coeffRef(i) = constraints.getFixedValue(i);
               }
             }
 
             A.resize(nrows, ncols);
-            A.setFromTriplets(filteredTriplets.begin(), filteredTriplets.end());
+            A.setFromTriplets(triplets.begin(), triplets.end());
           }
           else
           {
@@ -1568,19 +1636,21 @@ namespace Rodin::Assembly
             {
               const auto& attrs = bfi.getAttributes();
               SequentialIteration seq(mesh, bfi.getRegion());
-              for (auto it = seq.getIterator(); it; ++it)
+              const size_t d = seq.getDimension();
+              const Index count = seq.getCount();
+              for (Index p = 0; p < count; ++p)
               {
+                if (!seq.filter(p))
+                  continue;
                 if (!attrs.empty())
                 {
-                  const auto a = it->getAttribute();
+                  const auto a = mesh.getAttribute(d, p);
                   if (!a || !attrs.count(*a))
                     continue;
                 }
 
-                const size_t d = it->getDimension();
-                const Index p = it->getIndex();
-
-                bfi.setPolytope(*it);
+                const auto polytope = seq.getPolytope(p);
+                bfi.setPolytope(polytope);
 
                 const auto& rowsDOF = testFES.getDOFs(d, p);
                 const auto& colsDOF = trialFES.getDOFs(d, p);
@@ -1606,31 +1676,39 @@ namespace Rodin::Assembly
               SequentialIteration trialseq(mesh, bfi.getTrialRegion());
               SequentialIteration testseq(mesh, bfi.getTestRegion());
 
-              for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+              const size_t td = testseq.getDimension();
+              const size_t rd = trialseq.getDimension();
+              const Index tcount = testseq.getCount();
+              const Index rcount = trialseq.getCount();
+              for (Index te = 0; te < tcount; ++te)
               {
+                if (!testseq.filter(te))
+                  continue;
                 if (!testAttrs.empty())
                 {
-                  const auto a = teIt->getAttribute();
+                  const auto a = mesh.getAttribute(td, te);
                   if (!a || !testAttrs.count(*a))
                     continue;
                 }
 
-                const auto& rowsDOF =
-                  testFES.getDOFs(teIt->getDimension(), teIt->getIndex());
+                const auto testPolytope = testseq.getPolytope(te);
+                const auto& rowsDOF = testFES.getDOFs(td, te);
 
-                for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+                for (Index tr = 0; tr < rcount; ++tr)
                 {
+                  if (!trialseq.filter(tr))
+                    continue;
                   if (!trialAttrs.empty())
                   {
-                    const auto a = trIt->getAttribute();
+                    const auto a = mesh.getAttribute(rd, tr);
                     if (!a || !trialAttrs.count(*a))
                       continue;
                   }
 
-                  const auto& colsDOF =
-                    trialFES.getDOFs(trIt->getDimension(), trIt->getIndex());
+                  const auto& colsDOF = trialFES.getDOFs(rd, tr);
 
-                  bfi.setPolytope(*trIt, *teIt);
+                  const auto trialPolytope = trialseq.getPolytope(tr);
+                  bfi.setPolytope(trialPolytope, testPolytope);
 
                   for (size_t i = 0; i < static_cast<size_t>(rowsDOF.size()); ++i)
                   {
@@ -1680,17 +1758,22 @@ namespace Rodin::Assembly
             {
               const auto& attrs = lfi.getAttributes();
               SequentialIteration seq(mesh, lfi.getRegion());
-              for (auto it = seq.getIterator(); it; ++it)
+              const size_t d = seq.getDimension();
+              const Index count = seq.getCount();
+              for (Index p = 0; p < count; ++p)
               {
+                if (!seq.filter(p))
+                  continue;
                 if (!attrs.empty())
                 {
-                  const auto a = it->getAttribute();
+                  const auto a = mesh.getAttribute(d, p);
                   if (!a || !attrs.count(*a))
                     continue;
                 }
 
-                lfi.setPolytope(*it);
-                const auto& dofs = testFES.getDOFs(it->getDimension(), it->getIndex());
+                const auto polytope = seq.getPolytope(p);
+                lfi.setPolytope(polytope);
+                const auto& dofs = testFES.getDOFs(d, p);
                 for (size_t l = 0; l < static_cast<size_t>(dofs.size()); ++l)
                   vectorEntry(dofs[l], -static_cast<ScalarType>(lfi.integrate(l)));
               }
@@ -1721,10 +1804,10 @@ namespace Rodin::Assembly
                 b.coeffRef(gs) = constraints.getIdentificationValue(gs);
               }
 
-              std::vector<Eigen::Triplet<ScalarType>> filteredTriplets;
-              filteredTriplets.reserve(triplets.size() + rows);
-              for (const auto& t : triplets)
+              size_t write = 0;
+              for (size_t read = 0; read < triplets.size(); ++read)
               {
+                const auto& t = triplets[read];
                 const Index row = static_cast<Index>(t.row());
                 const Index col = static_cast<Index>(t.col());
                 const ScalarType val = t.value();
@@ -1735,20 +1818,23 @@ namespace Rodin::Assembly
                   b.coeffRef(row) -= val * constraints.getFixedValue(col);
                   continue;
                 }
-                filteredTriplets.push_back(t);
+                if (write != read)
+                  triplets[write] = t;
+                ++write;
               }
+              triplets.resize(write);
 
               for (Index i = 0; i < static_cast<Index>(rows); ++i)
               {
                 if (constraints.isFixed(i))
                 {
-                  filteredTriplets.emplace_back(i, i, ScalarType(1));
+                  triplets.emplace_back(i, i, ScalarType(1));
                   b.coeffRef(i) = constraints.getFixedValue(i);
                 }
               }
 
               A.resize(rows, cols);
-              A.setFromTriplets(filteredTriplets.begin(), filteredTriplets.end());
+              A.setFromTriplets(triplets.begin(), triplets.end());
             }
             else
             {
@@ -1797,19 +1883,22 @@ namespace Rodin::Assembly
             // columns kept), mirroring the PETSc MatZeroRows targeted path.
             if constexpr (IsSparse)
             {
-              std::vector<Eigen::Triplet<ScalarType>> filteredTriplets;
-              filteredTriplets.reserve(triplets.size() + rows);
-              for (const auto& t : triplets)
+              size_t write = 0;
+              for (size_t read = 0; read < triplets.size(); ++read)
               {
+                const auto& t = triplets[read];
                 if (constraints.isFixed(static_cast<Index>(t.row())))
                   continue;
-                filteredTriplets.push_back(t);
+                if (write != read)
+                  triplets[write] = t;
+                ++write;
               }
+              triplets.resize(write);
               for (Index i = 0; i < static_cast<Index>(rows); ++i)
                 if (constraints.isFixed(i))
-                  filteredTriplets.emplace_back(i, i, ScalarType(1));
+                  triplets.emplace_back(i, i, ScalarType(1));
               A.resize(rows, cols);
-              A.setFromTriplets(filteredTriplets.begin(), filteredTriplets.end());
+              A.setFromTriplets(triplets.begin(), triplets.end());
             }
             else
             {

--- a/src/Rodin/Eikonal/FMM.h
+++ b/src/Rodin/Eikonal/FMM.h
@@ -357,7 +357,7 @@ namespace Rodin::Eikonal
       }
 
       static Real computeEdgeGeodesicDistance(
-          Index a, Index b, Index edge_idx, const Mesh& mesh)
+        Index a, Index b, Index edgeIdx, const Mesh& mesh)
       {
         // For now, use geometric distance as approximation
         // In the future, this could integrate along curved edges using PolytopeTransformation

--- a/src/Rodin/Geometry/AttributeIndex.h
+++ b/src/Rodin/Geometry/AttributeIndex.h
@@ -12,12 +12,15 @@
  * @brief Attribute indexing for mesh polytopes.
  */
 
+#include <atomic>
+#include <deque>
 #include <mutex>
 #include <optional>
 #include <vector>
-#include <shared_mutex>
 
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/deque.hpp>
+#include <boost/serialization/split_member.hpp>
 
 #include "Rodin/Geometry/Types.h" // Attribute, Index, FlatSet
 
@@ -34,16 +37,15 @@ namespace Rodin::Geometry
    * -----------
    * The storage is organized by dimension:
    * - For each @c d in @c [0, meshDim], a @c Dimension stores:
-   *   - @c slots: a vector of @c Optional<Attribute>, indexed by polytope index.
-   *   - @c mutex: a @c std::shared_mutex protecting accesses to @c slots.
+   *   - @c slots: stable attribute slots indexed by polytope index.
+   *   - @c mutex: a mutex protecting storage growth.
    *
    * Thread-Safety Model
    * -------------------
    * This class provides fine-grained thread-safety at the level of individual
-   * dimensions:
-   * - Each dimension owns an independent @c std::shared_mutex.
-   * - Operations that read/write attributes in a given dimension synchronize
-   *   using that dimension's mutex.
+   * dimensions. Slot values and the published storage extent are atomic, so
+   * repeated reads require no lock. Storage growth and writes are serialized per
+   * dimension.
    *
    * After initialization, concurrent calls to the following methods are safe
    * w.r.t. each other (subject to each method's preconditions):
@@ -68,11 +70,11 @@ namespace Rodin::Geometry
    * Copy and Move Semantics
    * -----------------------
    * Copy construction:
-   * - Copies per-dimension storage using the source per-dimension locks.
+   * - Copies per-dimension storage while serializing source storage growth.
    *
    * Copy assignment:
    * - Requires both objects to be initialized with the same number of dimensions.
-   * - Copies per dimension using the per-dimension locks.
+   * - Copies per dimension while serializing storage growth.
    * - Is NOT an atomic snapshot across all dimensions: a concurrent reader may
    *   observe a mix of old and new dimension contents while assignment is in
    *   progress.
@@ -99,112 +101,179 @@ namespace Rodin::Geometry
      * @brief Storage for attributes of polytopes in a single dimension.
      *
      * Contains:
-     * - @c slots: attribute values indexed by polytope index.
-     * - @c mutex: a shared mutex protecting @c slots.
+     * - @c slots: stable attribute values indexed by polytope index.
+     * - @c mutex: a mutex protecting storage growth.
      *
      * Thread-safety:
-     * - Multiple concurrent readers are allowed via shared locking.
-     * - Writers use exclusive locking.
+     * - Readers use atomic slot snapshots and do not acquire a lock.
+     * - Storage growth and slot writes are serialized per dimension.
      */
-    struct Dimension
+    struct Slot
     {
       friend class boost::serialization::access;
 
-      std::vector<Optional<Attribute>> slots; ///< Attribute values indexed by polytope index
+      std::atomic<size_t> sequence{0};
+      std::atomic<Attribute> value{0};
+      std::atomic<bool> engaged{false};
 
-      mutable std::shared_mutex mutex; ///< Mutex for thread-safe access
+      Slot() = default;
+
+      Slot(const Slot& other)
+      {
+        assign(other.get());
+      }
+
+      Slot& operator=(const Slot& other)
+      {
+        if (this != &other)
+          set(other.get());
+        return *this;
+      }
+
+      Slot(Slot&& other) noexcept
+      {
+        assign(other.get());
+      }
+
+      Slot& operator=(Slot&& other) noexcept
+      {
+        if (this != &other)
+          set(other.get());
+        return *this;
+      }
+
+      Optional<Attribute> get() const
+      {
+        for (;;)
+        {
+          const size_t before = sequence.load(std::memory_order_acquire);
+          if (before & 1)
+            continue;
+
+          const bool hasValue = engaged.load(std::memory_order_relaxed);
+          const Attribute attribute = value.load(std::memory_order_relaxed);
+          const size_t after = sequence.load(std::memory_order_acquire);
+          if (before == after)
+            return hasValue ? Optional<Attribute>(attribute) : std::nullopt;
+        }
+      }
+
+      void set(const Optional<Attribute>& attribute)
+      {
+        sequence.fetch_add(1, std::memory_order_acq_rel);
+        assign(attribute);
+        sequence.fetch_add(1, std::memory_order_release);
+      }
+
+      template <class Archive>
+      void save(Archive& ar, const unsigned int) const
+      {
+        const Optional<Attribute> attribute = get();
+        ar & attribute;
+      }
+
+      template <class Archive>
+      void load(Archive& ar, const unsigned int)
+      {
+        Optional<Attribute> attribute;
+        ar & attribute;
+        assign(attribute);
+      }
+
+      BOOST_SERIALIZATION_SPLIT_MEMBER()
+
+    private:
+      void assign(const Optional<Attribute>& attribute)
+      {
+        if (attribute)
+          value.store(*attribute, std::memory_order_relaxed);
+        engaged.store(attribute.has_value(), std::memory_order_relaxed);
+      }
+    };
+
+    struct Dimension
+    {
+        friend class boost::serialization::access;
+
+        std::deque<Slot> slots; ///< Stable attribute slots indexed by polytope index
+        std::atomic<size_t> publishedSize{0}; ///< Lock-free readable slot count
+        mutable std::mutex mutex; ///< Serializes storage growth and slot writes
 
       /**
        * @brief Default constructor.
        */
-      Dimension() = default;
+        Dimension() = default;
 
       /**
        * @brief Copy constructor.
        *
-       * Copies the slot vector from @p other under @p other's shared lock.
+       * Copies the stable slots from @p other while blocking storage growth.
        *
        * Thread-safety:
        * - Safe w.r.t. concurrent readers/writers of @p other.
        */
-      Dimension(const Dimension& other)
-      {
-        std::shared_lock<std::shared_mutex> rd(other.mutex);
-        slots = other.slots;
-      }
+        Dimension(const Dimension& other)
+        {
+          std::lock_guard<std::mutex> lock(other.mutex);
+          slots = other.slots;
+          publishedSize.store(slots.size(), std::memory_order_relaxed);
+        }
 
       /**
        * @brief Copy assignment operator.
        *
-       * Assigns slots from @p other to @c *this using per-object locking.
-       * A deadlock-avoiding lock ordering is used based on object addresses.
+       * Assigns slots from @p other to @c *this while blocking storage growth.
        *
        * Thread-safety:
        * - Safe w.r.t. concurrent readers/writers of either dimension.
        * - Not an atomic snapshot w.r.t. external observers of the whole container.
        */
-      Dimension& operator=(const Dimension& other)
-      {
-        if (this == &other)
+        Dimension& operator=(const Dimension& other)
+        {
+          if (this == &other)
+            return *this;
+
+          std::scoped_lock lock(mutex, other.mutex);
+          slots = other.slots;
+          publishedSize.store(slots.size(), std::memory_order_release);
+
           return *this;
-
-        // Lock ordering by address to avoid deadlock.
-        const Dimension* first  = this;
-        const Dimension* second = &other;
-        if (std::less<const Dimension*>{}(second, first))
-          std::swap(first, second);
-
-        if (first == this)
-        {
-          std::unique_lock<std::shared_mutex> lockThis(mutex);
-          std::shared_lock<std::shared_mutex> lockOther(other.mutex);
-          slots = other.slots;
         }
-        else
-        {
-          std::shared_lock<std::shared_mutex> lockOther(other.mutex);
-          std::unique_lock<std::shared_mutex> lockThis(mutex);
-          slots = other.slots;
-        }
-
-        return *this;
-      }
 
       /**
        * @brief Move constructor.
        *
-       * Moves the slot vector from @p other under @p other's exclusive lock.
+       * Moves the stable slots from @p other while blocking storage growth.
        *
        * Thread-safety:
        * - Requires that no other thread accesses @p other concurrently.
        */
-      Dimension(Dimension&& other) noexcept
-      {
-        std::unique_lock<std::shared_mutex> wr(other.mutex);
-        slots = std::move(other.slots);
-      }
+        Dimension(Dimension&& other) noexcept
+        {
+          std::lock_guard<std::mutex> lock(other.mutex);
+          slots = std::move(other.slots);
+          publishedSize.store(slots.size(), std::memory_order_relaxed);
+        }
 
       /**
        * @brief Move assignment operator.
        *
-       * Moves slots from @p other into @c *this using exclusive locks on both.
+       * Moves slots from @p other into @c *this while blocking storage growth.
        *
        * Thread-safety:
        * - Requires external synchronization: no concurrent access to either
        *   dimension while moving.
        */
-      Dimension& operator=(Dimension&& other) noexcept
-      {
-        if (this == &other)
+        Dimension& operator=(Dimension&& other) noexcept
+        {
+          if (this == &other)
+            return *this;
+
+          std::scoped_lock lock(mutex, other.mutex);
+          slots = std::move(other.slots);
+          publishedSize.store(slots.size(), std::memory_order_release);
           return *this;
-
-        std::unique_lock<std::shared_mutex> thisLock(mutex, std::defer_lock);
-        std::unique_lock<std::shared_mutex> otherLock(other.mutex, std::defer_lock);
-        std::lock(thisLock, otherLock);
-
-        slots = std::move(other.slots);
-        return *this;
-      }
+        }
 
       /**
        * @brief Serialization method for Boost.Serialization.
@@ -212,11 +281,21 @@ namespace Rodin::Geometry
        *
        * The serialization version argument is ignored.
        */
-      template <class Archive>
-      void serialize(Archive& ar, const unsigned int)
-      {
-        ar & slots;
-      }
+        template <class Archive>
+        void save(Archive& ar, const unsigned int) const
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          ar & slots;
+        }
+
+        template <class Archive>
+        void load(Archive& ar, const unsigned int)
+        {
+          ar & slots;
+          publishedSize.store(slots.size(), std::memory_order_relaxed);
+        }
+
+        BOOST_SERIALIZATION_SPLIT_MEMBER()
     };
 
     public:
@@ -255,7 +334,7 @@ namespace Rodin::Geometry
        *   (i.e. same @c m_dimensions.size()).
        *
        * Thread-safety:
-       * - Uses per-dimension locks.
+       * - Serializes storage growth per dimension; slot snapshots are atomic.
        * - Not an atomic snapshot across dimensions.
        */
       AttributeIndex& operator=(const AttributeIndex& other)
@@ -345,9 +424,10 @@ namespace Rodin::Geometry
       void resize(size_t d, size_t count)
       {
         auto& dim = m_dimensions.at(d);
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
+        std::lock_guard<std::mutex> lock(dim.mutex);
         if (dim.slots.size() < count)
-          dim.slots.resize(count, std::nullopt);
+          dim.slots.resize(count);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
       }
 
       /**
@@ -357,7 +437,7 @@ namespace Rodin::Geometry
        * assigns @p attr.
        *
        * Thread-safety:
-       * - Thread-safe (dimension-level exclusive lock).
+       * - Thread-safe (dimension growth and slot writes are serialized).
        *
        * @param[in] p Pair (dimension, index) identifying the polytope.
        * @param[in] attr Attribute value to assign.
@@ -369,11 +449,12 @@ namespace Rodin::Geometry
         assert(d < m_dimensions.size());
 
         auto& dim = m_dimensions.at(d);
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
+        std::lock_guard<std::mutex> lock(dim.mutex);
         if (dim.slots.size() <= idx)
-          dim.slots.resize(idx + 1, std::nullopt);
+          dim.slots.resize(idx + 1);
         assert(idx < dim.slots.size());
-        dim.slots[idx] = attr;
+        dim.slots[idx].set(attr);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
       }
 
       /**
@@ -386,7 +467,7 @@ namespace Rodin::Geometry
        * - @p idx < @p count.
        *
        * Thread-safety:
-       * - Thread-safe (dimension-level exclusive lock).
+       * - Thread-safe (dimension growth and slot writes are serialized).
        *
        * @param[in] p Pair (dimension, index) identifying the polytope.
        * @param[in] count Expected number of polytopes in this dimension.
@@ -400,10 +481,11 @@ namespace Rodin::Geometry
         assert(idx < count);
 
         auto& dim = m_dimensions.at(d);
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
+        std::lock_guard<std::mutex> lock(dim.mutex);
         if (dim.slots.size() < count)
-          dim.slots.resize(count, std::nullopt);
-        dim.slots[idx] = attr;
+          dim.slots.resize(count);
+        dim.slots[idx].set(attr);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
       }
 
       /**
@@ -413,7 +495,7 @@ namespace Rodin::Geometry
        * then resets the entry at @p idx to @c std::nullopt.
        *
        * Thread-safety:
-       * - Thread-safe (dimension-level exclusive lock).
+       * - Thread-safe (dimension growth and slot writes are serialized).
        *
        * @param[in] p Pair (dimension, index) identifying the polytope.
        * @param[in] count Expected number of polytopes in this dimension.
@@ -423,16 +505,17 @@ namespace Rodin::Geometry
         const auto& [d, idx] = p;
         auto& dim = m_dimensions.at(d);
         assert(d < m_dimensions.size());
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
+        std::lock_guard<std::mutex> lock(dim.mutex);
         if (dim.slots.size() < count)
-          dim.slots.resize(count, std::nullopt);
-        dim.slots[idx].reset();
+          dim.slots.resize(count);
+        dim.slots[idx].set(std::nullopt);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
       }
 
       /**
        * @brief Gets the attribute for a polytope.
        *
-       * Reads the slot at @p idx under a shared lock.
+       * Reads an atomic snapshot of the slot at @p idx.
        *
        * Notes:
        * - This method does not resize. If @p idx is out of range, returns
@@ -442,7 +525,8 @@ namespace Rodin::Geometry
        * - @p idx < @p count (debug-checked).
        *
        * Thread-safety:
-       * - Thread-safe (dimension-level shared lock).
+       * - Thread-safe and does not acquire a mutex when the slot has been
+       *   published.
        *
        * @param[in] p Pair (dimension, index) identifying the polytope.
        * @param[in] count Expected number of polytopes in this dimension.
@@ -456,13 +540,9 @@ namespace Rodin::Geometry
         assert(idx < count);
 
         const auto& dim = m_dimensions.at(d);
-        std::shared_lock<std::shared_mutex> rd(dim.mutex);
-
-        // No resizing here: assume resize(d, count) happened earlier.
-        if (idx >= dim.slots.size())
+        if (idx >= dim.publishedSize.load(std::memory_order_acquire))
           return std::nullopt;
-
-        return dim.slots[idx];
+        return dim.slots[idx].get();
       }
 
       /**
@@ -472,7 +552,7 @@ namespace Rodin::Geometry
        * attributes.
        *
        * Thread-safety:
-       * - Thread-safe (dimension-level shared lock).
+       * - Thread-safe; each published slot is read atomically.
        *
        * @param[in] d Dimension of polytopes.
        * @return A flat set of unique attribute values.
@@ -481,9 +561,10 @@ namespace Rodin::Geometry
       {
         FlatSet<Attribute> out;
         const auto& dim = m_dimensions.at(d);
-        std::shared_lock<std::shared_mutex> rd(dim.mutex);
-        for (const auto& oa : dim.slots)
+        const size_t size = dim.publishedSize.load(std::memory_order_acquire);
+        for (size_t i = 0; i < size; ++i)
         {
+          const Optional<Attribute> oa = dim.slots[i].get();
           if (oa)
             out.insert(*oa);
         }

--- a/src/Rodin/Geometry/Connectivity.cpp
+++ b/src/Rodin/Geometry/Connectivity.cpp
@@ -79,8 +79,8 @@ namespace Rodin::Geometry
     return polytope(t, in, index);
   }
 
-  Connectivity<Context::Local>&
-  Connectivity<Context::Local>::polytope(Polytope::Type t, const Polytope::Key& in, Index& index)
+  Connectivity<Context::Local>& Connectivity<Context::Local>::polytope(
+    Polytope::Type t, const Polytope::Key& in, Index& index)
   {
     assert(in.size() > 0);
     const size_t d = Polytope::Traits(t).getDimension();
@@ -110,8 +110,8 @@ namespace Rodin::Geometry
     return polytope(t, std::move(in), index);
   }
 
-  Connectivity<Context::Local>&
-  Connectivity<Context::Local>::polytope(Polytope::Type t, Polytope::Key&& in, Index& index)
+  Connectivity<Context::Local>& Connectivity<Context::Local>::polytope(
+    Polytope::Type t, Polytope::Key&& in, Index& index)
   {
     assert(in.size() > 0);
     const size_t d = Polytope::Traits(t).getDimension();

--- a/src/Rodin/Geometry/Connectivity.h
+++ b/src/Rodin/Geometry/Connectivity.h
@@ -452,7 +452,7 @@ namespace Rodin::Geometry
        * @returns Reference to this object for method chaining
        */
       Connectivity& polytope(
-          Geometry::Polytope::Type t, std::initializer_list<Index> p, Index& index)
+        Geometry::Polytope::Type t, std::initializer_list<Index> p, Index& index)
       {
         return this->polytope(t, Polytope::Key(p), index);
       }
@@ -480,7 +480,7 @@ namespace Rodin::Geometry
        * @returns Reference to this object for method chaining
        */
       Connectivity& polytope(
-          Geometry::Polytope::Type t, const IndexArray& polytope, Index& index)
+        Geometry::Polytope::Type t, const IndexArray& polytope, Index& index)
       {
         assert(polytope.size() <= RODIN_MAXIMUM_POLYTOPE_VERTICES);
         Polytope::Key key(polytope.size());
@@ -514,7 +514,7 @@ namespace Rodin::Geometry
        * @returns Reference to this object for method chaining
        */
       Connectivity& polytope(
-          Geometry::Polytope::Type t, const Polytope::Key& polytope, Index& index);
+        Geometry::Polytope::Type t, const Polytope::Key& polytope, Index& index);
 
       /**
        * @brief Adds a moved polytope key and returns its connectivity index.
@@ -524,7 +524,7 @@ namespace Rodin::Geometry
        * @returns Reference to this object for method chaining
        */
       Connectivity& polytope(
-          Geometry::Polytope::Type t, Polytope::Key&& polytope, Index& index);
+        Geometry::Polytope::Type t, Polytope::Key&& polytope, Index& index);
 
       /**
        * @brief Computes the entities of dimension @f$ d @f$ of each cell and

--- a/src/Rodin/Geometry/Mesh.cpp
+++ b/src/Rodin/Geometry/Mesh.cpp
@@ -6,7 +6,6 @@
  */
 #include "Rodin/Alert/MemberFunctionException.h"
 
-#include "Rodin/Alert/NamespacedException.h"
 #include "Rodin/Math/SpatialVector.h"
 #include "Rodin/Variational/P1.h"
 #include "Rodin/Variational/GridFunction.h"
@@ -796,10 +795,20 @@ namespace Rodin::Geometry
 
     if (dimensions.size() != dim)
     {
-      Alert::NamespacedException("Rodin::Geometry::Mesh<Context::Local>::UniformGrid")
-        << "Expected " << dim << " dimensions for geometry type " << g
-        << ", but got " << dimensions.size() << "."
-        << Alert::Raise;
+      Alert::MemberFunctionException(Mesh(), __func__)
+        << "Expected " << dim << " dimensions for geometry type " << g << ", but got "
+        << dimensions.size() << "." << Alert::Raise;
+    }
+
+    for (size_t axis = 0; axis < dimensions.size(); ++axis)
+    {
+      if (dimensions.coeff(axis) < 2)
+      {
+        Alert::MemberFunctionException(Mesh(), __func__)
+          << "Expected at least 2 grid points along axis " << axis
+          << " for geometry type " << g << ", but got " << dimensions.coeff(axis) << "."
+          << Alert::Raise;
+      }
     }
 
     switch (g)
@@ -810,9 +819,7 @@ namespace Rodin::Geometry
       }
       case Polytope::Type::Segment:
       {
-        assert(dimensions.size() == 1);
         const size_t n = dimensions.coeff(0);
-        assert(n >= 2);
 
         build.initialize(dim).nodes(n);
 
@@ -829,11 +836,9 @@ namespace Rodin::Geometry
       }
       case Polytope::Type::Triangle:
       {
-        assert(dimensions.size() == 2);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         build.initialize(dim).nodes(w * h);
-        assert(w * h >= 4);
         for (size_t j = 0; j < h; j++)
         {
           for (size_t i = 0; i < w; i++)
@@ -853,11 +858,9 @@ namespace Rodin::Geometry
       }
       case Polytope::Type::Quadrilateral:
       {
-        assert(dimensions.size() == 2);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         build.initialize(dim).nodes(w * h);
-        assert(w * h >= 4);
         for (size_t j = 0; j < h; j++)
         {
           for (size_t i = 0; i < w; i++)
@@ -880,11 +883,9 @@ namespace Rodin::Geometry
       }
       case Polytope::Type::Tetrahedron:
       {
-        assert(dimensions.size() == 3);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         const size_t d = dimensions.coeff(2);
-        assert(w >= 2 && h >= 2 && d >= 2);
 
         build.initialize(dim)
              .nodes(w * h * d)
@@ -936,11 +937,9 @@ namespace Rodin::Geometry
       }
       case Polytope::Type::Wedge:
       {
-        assert(dimensions.size() == 3);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         const size_t d = dimensions.coeff(2);
-        assert(w >= 2 && h >= 2 && d >= 2);
         build.initialize(dim).nodes(w * h * d);
         for (size_t k = 0; k < d; k++)
         {
@@ -979,11 +978,9 @@ namespace Rodin::Geometry
 
       case Polytope::Type::Pyramid:
       {
-        assert(dimensions.size() == 3);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         const size_t d = dimensions.coeff(2);
-        assert(w >= 2 && h >= 2 && d >= 2);
 
         const size_t gridVertices = w * h * d;
         const size_t cellCount = (w - 1) * (h - 1) * (d - 1);
@@ -1063,11 +1060,9 @@ namespace Rodin::Geometry
       {
         // Structured brick mesh with MFEM-compatible vertex ordering
         // dimensions = {w, h, d}
-        assert(dimensions.size() == 3);
         const size_t w = dimensions.coeff(0);
         const size_t h = dimensions.coeff(1);
         const size_t d = dimensions.coeff(2);
-        assert(w >= 2 && h >= 2 && d >= 2);
 
         // Total vertices
         build.initialize(dim).nodes(w * h * d);
@@ -1120,7 +1115,8 @@ namespace Rodin::Geometry
       }
       default:
       {
-        assert(false);
+        Alert::MemberFunctionException(Mesh(), __func__)
+          << "Unsupported uniform-grid geometry type " << g << "." << Alert::Raise;
         return build.nodes(0).finalize();
       }
     };

--- a/src/Rodin/Geometry/Mesh.h
+++ b/src/Rodin/Geometry/Mesh.h
@@ -21,7 +21,9 @@
  * - Attribute-based region marking
  */
 
+#include <algorithm>
 #include <deque>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 #include <boost/serialization/access.hpp>
@@ -954,9 +956,10 @@ namespace Rodin::Geometry
           }
 
           /// @brief Adds a polytope and returns its index via @p index.
-          Builder& polytope(Polytope::Type t, std::initializer_list<Index> vs, Index& index)
+          Builder& polytope(
+            Polytope::Type t, std::initializer_list<Index> vs, Index& index)
           {
-            return polytope(t, IndexArray({ vs }), index);
+            return polytope(t, IndexArray({vs}), index);
           }
 
           /**
@@ -1115,6 +1118,8 @@ namespace Rodin::Geometry
        * @param[in] g Geometry type of the cells (e.g., Triangle,
        * Quadrilateral)
        * @param[in] l Number of nodes in each coordinate direction
+       * @throws Alert::MemberFunctionException If the shape dimension does
+       * not match the geometry or an axis contains fewer than two grid points.
        */
       static Mesh UniformGrid(Polytope::Type g, std::initializer_list<size_t> l)
       {
@@ -1151,6 +1156,8 @@ namespace Rodin::Geometry
        * @param[in] g Geometry type of the cells (e.g., Triangle,
        * Quadrilateral)
        * @param[in] shape Number of nodes in each coordinate direction
+       * @throws Alert::MemberFunctionException If the shape dimension does
+       * not match the geometry or an axis contains fewer than two grid points.
        */
       static Mesh UniformGrid(Polytope::Type g, const Array<size_t>& shape);
 
@@ -1382,49 +1389,51 @@ namespace Rodin::Geometry
        * @param[in] f Inclusion predicate
        * @returns Deque of FlatSet<Index>, each set being one connected component.
        *
-       * Uses a breadth-first search algorithm to discover connected components
+       * Uses a graph traversal to discover connected components
        * among polytopes of the specified dimension. Requires that the adjacency
        * connectivity @f$ d \rightarrow d @f$ has been computed beforehand.
        */
       template <class BinaryPredicate, class UnitaryPredicate>
       CCL ccl(size_t d, const BinaryPredicate& p, const UnitaryPredicate& f) const
       {
-        FlatSet<Index> visited;
-        visited.reserve(getPolytopeCount(d));
-        std::deque<Index> searchQueue;
+        const size_t count = getPolytopeCount(d);
+        std::vector<Boolean> visited(count, false);
+        std::vector<Index> searchStack;
+        searchStack.reserve(count);
+        std::vector<Index> component;
         std::deque<FlatSet<Index>> res;
 
         // Perform the labelling
         for (auto it = getPolytope(d); it; ++it)
         {
           const Index i = it->getIndex();
-          if (!visited.count(i))
+          if (!visited[i] && f(*it))
           {
-            if (f(*it))
+            searchStack.push_back(i);
+            visited[i] = true;
+            component.clear();
+
+            while (!searchStack.empty())
             {
-              res.push_back({});
-              searchQueue.push_back(i);
-            }
-            while (searchQueue.size() > 0)
-            {
-              const Index idx = searchQueue.back();
+              const Index idx = searchStack.back();
               const auto el = getPolytope(d, idx);
-              searchQueue.pop_back();
-              const auto result = visited.insert(idx);
-              const Boolean inserted = result.second;
-              if (inserted)
+              searchStack.pop_back();
+              component.push_back(idx);
+
+              for (auto adj = el->getAdjacent(); adj; ++adj)
               {
-                res.back().insert(idx);
-                for (auto adj = el->getAdjacent(); adj; ++adj)
+                const Index adjacent = adj->getIndex();
+                if (!visited[adjacent] && p(*el, *adj) && f(*adj))
                 {
-                  if (p(*el, *adj))
-                  {
-                    if (f(*adj))
-                      searchQueue.push_back(adj->getIndex());
-                  }
+                  visited[adjacent] = true;
+                  searchStack.push_back(adjacent);
                 }
               }
             }
+
+            std::sort(component.begin(), component.end());
+            res.emplace_back(
+              boost::container::ordered_unique_range, component.begin(), component.end());
           }
         }
         return res;

--- a/src/Rodin/Geometry/MeshBuilder.cpp
+++ b/src/Rodin/Geometry/MeshBuilder.cpp
@@ -89,8 +89,8 @@ namespace Rodin::Geometry
     return *this;
   }
 
-  Mesh<Context::Local>::Builder&
-  Mesh<Context::Local>::Builder::polytope(Polytope::Type t, const Array<Index>& vs, Index& index)
+  Mesh<Context::Local>::Builder& Mesh<Context::Local>::Builder::polytope(
+    Polytope::Type t, const Array<Index>& vs, Index& index)
   {
     m_connectivity.polytope(t, vs, index);
     return *this;
@@ -103,8 +103,8 @@ namespace Rodin::Geometry
     return *this;
   }
 
-  Mesh<Context::Local>::Builder&
-  Mesh<Context::Local>::Builder::polytope(Polytope::Type t, Array<Index>&& vs, Index& index)
+  Mesh<Context::Local>::Builder& Mesh<Context::Local>::Builder::polytope(
+    Polytope::Type t, Array<Index>&& vs, Index& index)
   {
     m_connectivity.polytope(t, std::move(vs), index);
     return *this;

--- a/src/Rodin/Geometry/MinSTCut.cpp
+++ b/src/Rodin/Geometry/MinSTCut.cpp
@@ -19,21 +19,23 @@ namespace Rodin::Geometry
       public:
         struct Arc
         {
-          Index to;
-          Index rev;
-          Real cap;
+            Index to;
+            Index rev;
+            Real cap;
         };
 
         explicit Dinic(Index n)
-          : m_graph(n), m_level(n), m_next(n)
+          : m_graph(n),
+            m_level(n),
+            m_next(n)
         {}
 
         void addDirected(Index from, Index to, Real capacity)
         {
           if (capacity < 0)
             throw std::invalid_argument("MinSTCut received a negative graph capacity.");
-          Arc fwd{ to, m_graph[to].size(), capacity };
-          Arc rev{ from, m_graph[from].size(), 0 };
+          Arc fwd{to, m_graph[to].size(), capacity};
+          Arc rev{from, m_graph[from].size(), 0};
           m_graph[from].push_back(fwd);
           m_graph[to].push_back(rev);
         }
@@ -143,30 +145,24 @@ namespace Rodin::Geometry
     return volume * std::max<Real>(0, -moment);
   }
 
-  MinSTCut::Result MinSTCut::classify(
-      const std::vector<Real>& volumes,
-      const std::vector<Real>& moments,
-      const std::vector<Edge>& edges) const
+  MinSTCut::Result MinSTCut::classify(const std::vector<Real>& volumes,
+    const std::vector<Real>& moments, const std::vector<Edge>& edges) const
   {
     return classify(volumes, moments, edges, Options{});
   }
 
-  MinSTCut::Result MinSTCut::classify(
-      const std::vector<Real>& volumes,
-      const std::vector<Real>& moments,
-      const std::vector<Edge>& edges,
-      const Options& options) const
+  MinSTCut::Result MinSTCut::classify(const std::vector<Real>& volumes,
+    const std::vector<Real>& moments, const std::vector<Edge>& edges,
+    const Options& options) const
   {
     if (volumes.size() != moments.size())
       throw std::invalid_argument("MinSTCut volumes and moments have different sizes.");
-    if (!options.perEdgeLambda.empty()
-        && options.perEdgeLambda.size() != edges.size())
+    if (!options.perEdgeLambda.empty() && options.perEdgeLambda.size() != edges.size())
       throw std::invalid_argument(
-          "MinSTCut perEdgeLambda size does not match the number of edges.");
-    if (!options.cellInBand.empty()
-        && options.cellInBand.size() != volumes.size())
+        "MinSTCut perEdgeLambda size does not match the number of edges.");
+    if (!options.cellInBand.empty() && options.cellInBand.size() != volumes.size())
       throw std::invalid_argument(
-          "MinSTCut cellInBand size does not match the number of cells.");
+        "MinSTCut cellInBand size does not match the number of cells.");
 
     // Pin-cost: should dominate any conceivable unary on the same cell.
     // We compute it from the sum of unscaled unaries plus the sum of all
@@ -176,8 +172,8 @@ namespace Rodin::Geometry
     {
       if (volumes[i] < 0)
         throw std::invalid_argument("MinSTCut received a negative cell volume.");
-      totalUnary += getInsideCost(volumes[i], moments[i])
-                  + getOutsideCost(volumes[i], moments[i]);
+      totalUnary +=
+        getInsideCost(volumes[i], moments[i]) + getOutsideCost(volumes[i], moments[i]);
     }
     Real totalPairwise = 0;
     for (const Edge& e : edges)
@@ -186,10 +182,9 @@ namespace Rodin::Geometry
         throw std::invalid_argument("MinSTCut received a negative pairwise capacity.");
       totalPairwise += e.capacity;
     }
-    const Real pinCost =
-      Real(1e3) * (options.unaryScale * totalUnary
-                   + std::max(options.lambdaScale, Real(1)) * totalPairwise
-                   + Real(1));
+    const Real pinCost = Real(1e3) *
+      (options.unaryScale * totalUnary +
+        std::max(options.lambdaScale, Real(1)) * totalPairwise + Real(1));
 
     std::vector<Real> insideCosts(volumes.size());
     std::vector<Real> outsideCosts(volumes.size());
@@ -198,11 +193,9 @@ namespace Rodin::Geometry
       insideCosts[i] = options.unaryScale * getInsideCost(volumes[i], moments[i]);
       outsideCosts[i] = options.unaryScale * getOutsideCost(volumes[i], moments[i]);
 
-      const Boolean inBand =
-        options.cellInBand.empty() ? true : options.cellInBand[i];
-      const Boolean farField =
-        options.farFieldThreshold >= 0
-        && std::abs(moments[i]) >= options.farFieldThreshold;
+      const Boolean inBand = options.cellInBand.empty() ? true : options.cellInBand[i];
+      const Boolean farField = options.farFieldThreshold >= 0 &&
+        std::abs(moments[i]) >= options.farFieldThreshold;
 
       if (!inBand || farField)
       {
@@ -220,9 +213,7 @@ namespace Rodin::Geometry
     for (Index e = 0; e < scaledEdges.size(); ++e)
     {
       const Real lambda =
-        options.perEdgeLambda.empty()
-        ? options.lambdaScale
-        : options.perEdgeLambda[e];
+        options.perEdgeLambda.empty() ? options.lambdaScale : options.perEdgeLambda[e];
       if (lambda < 0)
         throw std::invalid_argument("MinSTCut perEdgeLambda contains a negative value.");
       scaledEdges[e].capacity *= lambda;
@@ -231,10 +222,8 @@ namespace Rodin::Geometry
     return solve(insideCosts, outsideCosts, scaledEdges);
   }
 
-  MinSTCut::Result MinSTCut::solve(
-      const std::vector<Real>& insideCosts,
-      const std::vector<Real>& outsideCosts,
-      const std::vector<Edge>& edges) const
+  MinSTCut::Result MinSTCut::solve(const std::vector<Real>& insideCosts,
+    const std::vector<Real>& outsideCosts, const std::vector<Edge>& edges) const
   {
     if (insideCosts.size() != outsideCosts.size())
       throw std::invalid_argument("MinSTCut unary cost arrays have different sizes.");

--- a/src/Rodin/Geometry/MinSTCut.h
+++ b/src/Rodin/Geometry/MinSTCut.h
@@ -29,8 +29,7 @@ namespace Rodin::Geometry
       /// @brief Label value for cells outside the level set.
       static constexpr int Outside = 1;
       /// @brief Sentinel index denoting an absent edge/index.
-      static constexpr Index InvalidIndex =
-        std::numeric_limits<Index>::max();
+      static constexpr Index InvalidIndex = std::numeric_limits<Index>::max();
 
       /// @brief A weighted graph edge between two cells.
       struct Edge
@@ -105,25 +104,18 @@ namespace Rodin::Geometry
 
       /// @brief Classifies cells into Inside/Outside via a Potts min s-t cut
       /// built from per-cell volumes and moments.
-      Result classify(
-          const std::vector<Real>& volumes,
-          const std::vector<Real>& moments,
-          const std::vector<Edge>& edges) const;
+      Result classify(const std::vector<Real>& volumes, const std::vector<Real>& moments,
+        const std::vector<Edge>& edges) const;
 
       /// @brief Classifies cells with additional @ref Options (narrow-band
       /// restriction, far-field pinning, per-edge weighting).
-      Result classify(
-          const std::vector<Real>& volumes,
-          const std::vector<Real>& moments,
-          const std::vector<Edge>& edges,
-          const Options& options) const;
+      Result classify(const std::vector<Real>& volumes, const std::vector<Real>& moments,
+        const std::vector<Edge>& edges, const Options& options) const;
 
       /// @brief Solves the s-t min cut directly from precomputed unary costs
       /// and edges.
-      Result solve(
-          const std::vector<Real>& insideCosts,
-          const std::vector<Real>& outsideCosts,
-          const std::vector<Edge>& edges) const;
+      Result solve(const std::vector<Real>& insideCosts,
+        const std::vector<Real>& outsideCosts, const std::vector<Edge>& edges) const;
   };
 }
 

--- a/src/Rodin/Geometry/ParametricTransformation.h
+++ b/src/Rodin/Geometry/ParametricTransformation.h
@@ -39,10 +39,10 @@ namespace Rodin::Geometry
   template <class FE>
   class ParametricTransformation final : public PolytopeTransformation
   {
-    static_assert(std::is_same_v<typename FE::RangeType, Real>,
+      static_assert(std::is_same_v<typename FE::RangeType, Real>,
         "Type of finite element must be scalar valued.");
 
-    friend class boost::serialization::access;
+      friend class boost::serialization::access;
 
     public:
       /// @brief Parent class type.
@@ -115,9 +115,7 @@ namespace Rodin::Geometry
         return m_fe.getOrder();
       }
 
-      void transform(
-          Math::SpatialPoint& pc,
-          const Math::SpatialPoint& rc) const override
+      void transform(Math::SpatialPoint& pc, const Math::SpatialPoint& rc) const override
       {
         const size_t pdim = getPhysicalDimension();
         assert(static_cast<size_t>(rc.size()) == getReferenceDimension());
@@ -131,8 +129,7 @@ namespace Rodin::Geometry
       }
 
       void jacobian(
-          Math::SpatialMatrix<Real>& pc,
-          const Math::SpatialPoint& rc) const override
+        Math::SpatialMatrix<Real>& pc, const Math::SpatialPoint& rc) const override
       {
         const size_t rdim = getReferenceDimension();
         assert(static_cast<size_t>(rc.size()) == rdim);
@@ -158,10 +155,10 @@ namespace Rodin::Geometry
       }
 
       /// @brief Serializes the transformation (for boost::serialization).
-      template<class Archive>
+      template <class Archive>
       void serialize(Archive& ar, const unsigned int)
       {
-        ar & boost::serialization::base_object<PolytopeTransformation>(*this);
+        ar& boost::serialization::base_object<PolytopeTransformation>(*this);
         ar & m_pm;
         ar & m_fe;
       }
@@ -172,6 +169,11 @@ namespace Rodin::Geometry
       }
 
     private:
+      // Boost constructs this empty state before loading all serialized fields.
+      ParametricTransformation()
+        : Parent(0, 0)
+      {}
+
       PointCloud m_pm;
       FE m_fe;
   };

--- a/src/Rodin/Geometry/Polytope.cpp
+++ b/src/Rodin/Geometry/Polytope.cpp
@@ -884,84 +884,51 @@ namespace Rodin::Geometry
     {
       case Type::Point:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          Math::Matrix<Real>{},
-          Math::Vector<Real>{}
-        };
+        static const HalfSpace s_hs = {Math::Matrix<Real>{}, Math::Vector<Real>{}};
         return s_hs;
       }
       case Type::Segment:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // local 0: x=0  -> -x <= 0
+        static const HalfSpace s_hs = {          // local 0: x=0  -> -x <= 0
           // local 1: x=1  ->  x <= 1
-          Math::Matrix<Real>{{ -1 }, { 1 }},
-          Math::Vector<Real>{{ 0, 1 }}
-        };
+          Math::Matrix<Real>{{-1}, {1}}, Math::Vector<Real>{{0, 1}}};
         return s_hs;
       }
       case Type::Triangle:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // local 0: y=0                ->  -y <= 0
+        static const HalfSpace s_hs = {// local 0: y=0                ->  -y <= 0
           // local 1: x+y=1              ->  (x+y)/√2 <= 1/√2
           // local 2: x=0                ->  -x <= 0
-          Math::Matrix<Real>{
-            {  0, -1 },
-            {  1 / std::sqrt(2.0),  1 / std::sqrt(2.0) },
-            { -1,  0 }
-          },
-          Math::Vector<Real>{{ 0, 1 / std::sqrt(2.0), 0 }}
-        };
+          Math::Matrix<Real>{{0, -1}, {1 / std::sqrt(2.0), 1 / std::sqrt(2.0)}, {-1, 0}},
+          Math::Vector<Real>{{0, 1 / std::sqrt(2.0), 0}}};
         return s_hs;
       }
       case Type::Hexahedron:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // local 0: z=0   -> -z <= 0
+        static const HalfSpace s_hs = {// local 0: z=0   -> -z <= 0
           // local 1: y=0   -> -y <= 0
           // local 2: x=1   ->  x <= 1
           // local 3: y=1   ->  y <= 1
           // local 4: x=0   -> -x <= 0
           // local 5: z=1   ->  z <= 1
           Math::Matrix<Real>{
-            {  0,  0, -1 },
-            {  0, -1,  0 },
-            {  1,  0,  0 },
-            {  0,  1,  0 },
-            { -1,  0,  0 },
-            {  0,  0,  1 }
-          },
-          Math::Vector<Real>{{ 0, 0, 1, 1, 0, 1 }}
-        };
+            {0, 0, -1}, {0, -1, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, 0, 1}},
+          Math::Vector<Real>{{0, 0, 1, 1, 0, 1}}};
         return s_hs;
       }
       case Type::Quadrilateral:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // local 0: y=0   -> -y <= 0
+        static const HalfSpace s_hs = {// local 0: y=0   -> -y <= 0
           // local 1: x=1   ->  x <= 1
           // local 2: y=1   ->  y <= 1
           // local 3: x=0   -> -x <= 0
-          Math::Matrix<Real>{
-            {  0, -1 },
-            {  1,  0 },
-            {  0,  1 },
-            { -1,  0 }
-          },
-          Math::Vector<Real>{{ 0, 1, 1, 0 }}
-        };
+          Math::Matrix<Real>{{0, -1}, {1, 0}, {0, 1}, {-1, 0}},
+          Math::Vector<Real>{{0, 1, 1, 0}}};
         return s_hs;
       }
       case Type::Tetrahedron:
       {
-        static thread_local const HalfSpace s_hs =
-        {
+        static const HalfSpace s_hs = {
           // Must match Connectivity::getSubPolytopes tetra face order:
           //
           // face 0: (1,2,3)  -> x+y+z=1   ->  (x+y+z)/sqrt(3) <= 1/sqrt(3)
@@ -969,20 +936,17 @@ namespace Rodin::Geometry
           // face 2: (0,1,3)  -> y=0       ->  -y <= 0
           // face 3: (0,2,1)  -> z=0       ->  -z <= 0
           Math::Matrix<Real>{
-            {  1 / std::sqrt(3.0),  1 / std::sqrt(3.0),  1 / std::sqrt(3.0) }, // x+y+z <= 1
-            { -1,  0,  0 },                                                    // x >= 0
-            {  0, -1,  0 },                                                    // y >= 0
-            {  0,  0, -1 }                                                     // z >= 0
+            {1 / std::sqrt(3.0), 1 / std::sqrt(3.0), 1 / std::sqrt(3.0)}, // x+y+z <= 1
+            {-1, 0, 0}, // x >= 0
+            {0, -1, 0}, // y >= 0
+            {0, 0, -1} // z >= 0
           },
-          Math::Vector<Real>{{ 1 / std::sqrt(3.0), 0, 0, 0 }}
-        };
+          Math::Vector<Real>{{1 / std::sqrt(3.0), 0, 0, 0}}};
         return s_hs;
       }
       case Type::Pyramid:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // Reference pyramid:
+        static const HalfSpace s_hs = {// Reference pyramid:
           //   z >= 0, y >= 0, x + z <= 1, y + z <= 1, x >= 0.
           //
           // Face order matches Connectivity::getSubPolytopes:
@@ -991,40 +955,27 @@ namespace Rodin::Geometry
           // local 2: side x+z=1  (1,2,4)
           // local 3: side y+z=1  (2,3,4)
           // local 4: side x = 0  (3,0,4)
-          Math::Matrix<Real>{
-            {  0,  0, -1 },
-            {  0, -1,  0 },
-            {  1 / std::sqrt(2.0),  0,  1 / std::sqrt(2.0) },
-            {  0,  1 / std::sqrt(2.0),  1 / std::sqrt(2.0) },
-            { -1,  0,  0 }
-          },
-          Math::Vector<Real>{{ 0, 0, 1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0 }}
-        };
+          Math::Matrix<Real>{{0, 0, -1}, {0, -1, 0},
+            {1 / std::sqrt(2.0), 0, 1 / std::sqrt(2.0)},
+            {0, 1 / std::sqrt(2.0), 1 / std::sqrt(2.0)}, {-1, 0, 0}},
+          Math::Vector<Real>{{0, 0, 1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0}}};
         return s_hs;
       }
       case Type::Wedge:
       {
-        static thread_local const HalfSpace s_hs =
-        {
-          // local 0: z=0                ->  -z <= 0
+        static const HalfSpace s_hs = {// local 0: z=0                ->  -z <= 0
           // local 1: y=0                ->  -y <= 0
           // local 2: x+y=1              ->  (x+y)/√2 <= 1/√2
           // local 3: x=0                ->  -x <= 0
           // local 4: z=1                ->   z <= 1
-          Math::Matrix<Real>{
-            {  0,  0, -1 },
-            {  0, -1,  0 },
-            {  1 / std::sqrt(2.0),  1 / std::sqrt(2.0), 0 },
-            { -1,  0,  0 },
-            {  0,  0,  1 }
-          },
-          Math::Vector<Real>{{ 0, 0, 1 / std::sqrt(2.0), 0, 1 }}
-        };
+          Math::Matrix<Real>{{0, 0, -1}, {0, -1, 0},
+            {1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0}, {-1, 0, 0}, {0, 0, 1}},
+          Math::Vector<Real>{{0, 0, 1 / std::sqrt(2.0), 0, 1}}};
         return s_hs;
       }
     }
     assert(false);
-    static thread_local const HalfSpace s_null;
+    static const HalfSpace s_null;
     return s_null;
   }
 

--- a/src/Rodin/Geometry/PolytopeIterator.cpp
+++ b/src/Rodin/Geometry/PolytopeIterator.cpp
@@ -36,12 +36,19 @@ namespace Rodin::Geometry
     return *this;
   }
 
-  Polytope* PolytopeIterator::generate() const
+  Polytope PolytopeIterator::make() const
   {
-    if (this->end()) return nullptr;
+    assert(!this->end());
     const auto& gen = getIndexGenerator();
     const auto& index = *gen;
-    return new Polytope(getDimension(), index, getMesh());
+    return Polytope(getDimension(), index, getMesh());
+  }
+
+  Polytope* PolytopeIterator::generate() const
+  {
+    if (this->end())
+      return nullptr;
+    return new Polytope(make());
   }
 
   // ---- CellIterator -------------------------------------------------------
@@ -49,12 +56,19 @@ namespace Rodin::Geometry
     : Parent(mesh.getDimension(), mesh, std::move(gen))
   {}
 
-  Cell* CellIterator::generate() const
+  Cell CellIterator::make() const
   {
-    if (this->end()) return nullptr;
+    assert(!this->end());
     const auto& gen = getIndexGenerator();
     const auto& index = *gen;
-    return new Cell(index, getMesh());
+    return Cell(index, getMesh());
+  }
+
+  Cell* CellIterator::generate() const
+  {
+    if (this->end())
+      return nullptr;
+    return new Cell(make());
   }
 
   // ---- FaceIterator -------------------------------------------------------
@@ -62,12 +76,19 @@ namespace Rodin::Geometry
     : Parent(mesh.getDimension() - 1, mesh, std::move(gen))
   {}
 
-  Face* FaceIterator::generate() const
+  Face FaceIterator::make() const
   {
-    if (this->end()) return nullptr;
+    assert(!this->end());
     const auto& gen = getIndexGenerator();
     const auto& index = *gen;
-    return new Face(index, getMesh());
+    return Face(index, getMesh());
+  }
+
+  Face* FaceIterator::generate() const
+  {
+    if (this->end())
+      return nullptr;
+    return new Face(make());
   }
 
   // ---- VertexIterator -----------------------------------------------------
@@ -75,11 +96,18 @@ namespace Rodin::Geometry
     : Parent(0, mesh, std::move(gen))
   {}
 
-  Vertex* VertexIterator::generate() const
+  Vertex VertexIterator::make() const
   {
-    if (this->end()) return nullptr;
+    assert(!this->end());
     const auto& gen = getIndexGenerator();
     const auto& index = *gen;
-    return new Vertex(index, getMesh());
+    return Vertex(index, getMesh());
+  }
+
+  Vertex* VertexIterator::generate() const
+  {
+    if (this->end())
+      return nullptr;
+    return new Vertex(make());
   }
 }

--- a/src/Rodin/Geometry/PolytopeIterator.h
+++ b/src/Rodin/Geometry/PolytopeIterator.h
@@ -79,7 +79,20 @@ namespace Rodin::Geometry
       /**
        * @brief Move assignment operator.
        */
-      PolytopeIteratorBase& operator=(PolytopeIteratorBase&&) = default;
+      PolytopeIteratorBase& operator=(PolytopeIteratorBase&& other)
+      {
+        if (this != &other)
+        {
+          m_dimension = other.m_dimension;
+          m_mesh = std::move(other.m_mesh);
+          m_gen = std::move(other.m_gen);
+          m_dirty = other.m_dirty;
+          m_polytope.reset();
+          if (other.m_polytope)
+            m_polytope.emplace(std::move(*other.m_polytope));
+        }
+        return *this;
+      }
 
       /**
        * @brief Conversion to bool (checks if iterator is valid).
@@ -117,9 +130,9 @@ namespace Rodin::Geometry
       const T& operator*() const noexcept
       {
         if (!m_polytope || m_dirty)
-          m_polytope.reset(this->generate());
+          m_polytope.emplace(static_cast<const Derived&>(*this).make());
         m_dirty = false;
-        return *(m_polytope);
+        return *m_polytope;
       }
 
       /**
@@ -129,9 +142,9 @@ namespace Rodin::Geometry
       const T* operator->() const noexcept
       {
         if (!m_polytope || m_dirty)
-          m_polytope.reset(this->generate());
+          m_polytope.emplace(static_cast<const Derived&>(*this).make());
         m_dirty = false;
-        return m_polytope.get();
+        return &*m_polytope;
       }
 
       /**
@@ -144,8 +157,9 @@ namespace Rodin::Geometry
       {
         if (!m_polytope || m_dirty)
           return generate();
-        else
-          return m_polytope.release();
+        auto ptr = std::make_unique<T>(std::move(*m_polytope));
+        m_polytope.reset();
+        return ptr.release();
       }
 
       /**
@@ -210,7 +224,7 @@ namespace Rodin::Geometry
       Optional<std::reference_wrapper<const MeshBase>> m_mesh;
       std::unique_ptr<IndexGeneratorBase> m_gen;
       mutable bool m_dirty;
-      mutable std::unique_ptr<T> m_polytope;
+      mutable Optional<T> m_polytope;
   };
 
   /**
@@ -283,6 +297,12 @@ namespace Rodin::Geometry
       PolytopeIterator& operator=(VertexIterator it);
 
       /**
+       * @brief Constructs the polytope at the current iterator position.
+       * @returns Polytope value stored directly by the iterator
+       */
+      Polytope make() const;
+
+      /**
        * @brief Generates a polytope at current position.
        * @returns Pointer to new Polytope object
        */
@@ -343,6 +363,12 @@ namespace Rodin::Geometry
        * @brief Move assignment operator.
        */
       CellIterator& operator=(CellIterator&&) = default;
+
+      /**
+       * @brief Constructs the cell at the current iterator position.
+       * @returns Cell value stored directly by the iterator
+       */
+      Cell make() const;
 
       /**
        * @brief Generates a cell at current position.
@@ -408,6 +434,12 @@ namespace Rodin::Geometry
       FaceIterator& operator=(FaceIterator&&) = default;
 
       /**
+       * @brief Constructs the face at the current iterator position.
+       * @returns Face value stored directly by the iterator
+       */
+      Face make() const;
+
+      /**
        * @brief Generates a face at current position.
        * @returns Pointer to new Face object
        */
@@ -469,6 +501,12 @@ namespace Rodin::Geometry
        * @brief Move assignment operator.
        */
       VertexIterator& operator=(VertexIterator&&) = default;
+
+      /**
+       * @brief Constructs the vertex at the current iterator position.
+       * @returns Vertex value stored directly by the iterator
+       */
+      Vertex make() const;
 
       /**
        * @brief Generates a vertex at current position.

--- a/src/Rodin/Geometry/PolytopeQuadrature.h
+++ b/src/Rodin/Geometry/PolytopeQuadrature.h
@@ -72,14 +72,15 @@
  * same logical formula has a stable object identity.
  */
 
-#include <cassert>
-#include <utility>
+#include <algorithm>
+#include <atomic>
 #include <array>
+#include <cassert>
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
-#include <shared_mutex>
 
 #include <boost/serialization/split_member.hpp>
 
@@ -153,36 +154,22 @@ namespace Rodin::Geometry
   /**
    * @brief Thread-safe cache of polytope quadratures.
    *
-   * This class maintains a mesh-owned cache of @ref PolytopeQuadrature objects,
-   * indexed by:
-   * - polytope dimension,
-   * - polytope index,
-   * - quadrature formula identity.
+   * This class maintains a mesh-owned cache of @ref PolytopeQuadrature objects.
+   * Within each dimension, it first resolves a quadrature formula and then
+   * indexes a dense array by polytope index.
    *
-   * # Slot design
+   * # Cache design
    *
-   * Each polytope slot contains:
-   * - a hot entry storing a non-owning mirror of the most recently promoted
-   *   cached quadrature,
-   * - a fixed-capacity array of owned entries used as a bounded ring buffer.
-   *
-   * The hot entry exists only to accelerate repeated hits. Ownership remains
-   * solely in the bounded cache entries.
-   *
-   * # Eviction policy
-   *
-   * The bounded cache uses round-robin replacement once full. This is
-   * appropriate because:
-   * - the per-polytope cache is intentionally small,
-   * - the lookup cost is linear in a tiny fixed capacity,
-   * - the hot entry captures the most common repeated access pattern.
+   * A formula cache owns one stable slot per polytope. Repeated assembly with a
+   * fixed formula therefore resolves one atomically published formula pointer
+   * and one atomically published quadrature pointer. Cached objects remain valid
+   * until the mesh geometry is flushed.
    *
    * # Thread safety
    *
-   * - Each dimension bucket owns a shared mutex.
-   * - Each polytope slot owns its own shared mutex.
-   * - Reads first take shared locks.
-   * - Misses upgrade to exclusive slot access only where insertion is required.
+   * - Repeated cache hits are lock-free.
+   * - Formula creation and storage growth are serialized per dimension.
+   * - First quadrature construction is serialized through striped locks.
    *
    * # Lifecycle
    *
@@ -258,9 +245,9 @@ namespace Rodin::Geometry
       {
         assert(d < m_dimensions.size());
         auto& dim = m_dimensions[d];
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
-        if (dim.slots.size() < count)
-          dim.slots.resize(count);
+        std::lock_guard<std::mutex> lock(dim.mutex);
+        for (auto& formula : dim.formulas)
+          formula->resize(count);
       }
 
       /**
@@ -273,8 +260,11 @@ namespace Rodin::Geometry
       {
         for (auto& dim : m_dimensions)
         {
-          std::unique_lock<std::shared_mutex> wr(dim.mutex);
-          dim.slots.clear();
+          std::lock_guard<std::mutex> lock(dim.mutex);
+          dim.hot.store(nullptr, std::memory_order_relaxed);
+          for (auto& entry : dim.lookup)
+            entry.store(nullptr, std::memory_order_relaxed);
+          dim.formulas.clear();
         }
       }
 
@@ -288,15 +278,12 @@ namespace Rodin::Geometry
        * @param[in] factory Nullary factory called only on cache miss
        * @returns Reference to the cached polytope quadrature
        *
-       * Lookup proceeds in three stages:
-       * - check the hot entry,
-       * - scan the bounded owned cache,
-       * - lazily construct and insert on miss.
+       * Formula and quadrature pointers are resolved atomically on repeated
+       * accesses. A miss creates stable owned storage under a narrow lock.
        *
-       * On hits in the bounded cache, the entry is promoted to the hot slot.
-       * On misses, a new owned entry is inserted into the bounded cache, using
-       * round-robin replacement once the slot is full, and is then promoted to
-       * the hot slot.
+       * @note Cache mutation, including clear(), must not overlap use of a
+       *       returned reference. Mesh geometry must remain unchanged during
+       *       variational evaluation.
        *
        * @throws Rodin::Alert::Exception if:
        * - the dimension is outside the initialized range,
@@ -331,82 +318,62 @@ namespace Rodin::Geometry
         }
 
         auto& dim = m_dimensions[d];
-
-        // --------------------------------------------------------------------
-        // Fast path: shared lookup in an existing slot
-        // --------------------------------------------------------------------
+        Formula* formula = dim.hot.load(std::memory_order_acquire);
+        if (!formula || formula->qf != &qf)
         {
-          std::shared_lock<std::shared_mutex> rd(dim.mutex);
-          if (idx < dim.slots.size())
+          formula = nullptr;
+          for (const auto& entry : dim.lookup)
           {
-            const auto& slot = dim.slots[idx];
-            std::shared_lock<std::shared_mutex> rdslot(slot.mutex);
-
-            // Hot entry: fastest repeated-hit path.
-            if (slot.hot.qf == &qf)
+            Formula* candidate = entry.load(std::memory_order_acquire);
+            if (candidate && candidate->qf == &qf)
             {
-              assert(slot.hot.ptr);
-              return *slot.hot.ptr;
+              formula = candidate;
+              break;
             }
+          }
 
-            // Bounded cache lookup.
-            for (size_t i = 0; i < slot.size; ++i)
-            {
-              const auto& entry = slot.entries[i];
-              if (entry.valid && entry.qf == &qf)
+          if (!formula)
+          {
+            std::lock_guard<std::mutex> lock(dim.mutex);
+            for (const auto& candidate : dim.formulas)
+              if (candidate->qf == &qf)
               {
-                assert(entry.owner);
-                return *entry.owner;
+                formula = candidate.get();
+                break;
               }
-            }
-          }
-        }
 
-        // --------------------------------------------------------------------
-        // Ensure slot exists
-        // --------------------------------------------------------------------
-        {
-          std::unique_lock<std::shared_mutex> wr(dim.mutex);
-          if (dim.slots.size() < count)
-            dim.slots.resize(count);
-        }
-
-        assert(idx < dim.slots.size());
-        auto& slot = dim.slots[idx];
-
-        // --------------------------------------------------------------------
-        // Slow path: exclusive slot access
-        // --------------------------------------------------------------------
-        {
-          std::unique_lock<std::shared_mutex> wrslot(slot.mutex);
-
-          // Re-check hot entry under exclusive access.
-          if (slot.hot.qf == &qf)
-          {
-            assert(slot.hot.ptr);
-            return *slot.hot.ptr;
-          }
-
-          // Re-check bounded cache under exclusive access.
-          for (size_t i = 0; i < slot.size; ++i)
-          {
-            auto& entry = slot.entries[i];
-            if (entry.valid && entry.qf == &qf)
+            if (!formula)
             {
-              assert(entry.owner);
-              slot.promote(entry);
-              return *entry.owner;
+              dim.formulas.emplace_back(std::make_unique<Formula>(&qf, count));
+              formula = dim.formulas.back().get();
+              for (auto& entry : dim.lookup)
+                if (!entry.load(std::memory_order_relaxed))
+                {
+                  entry.store(formula, std::memory_order_release);
+                  break;
+                }
             }
           }
-
-          // Miss: build and insert into bounded cache.
-          CacheEntry& entry = slot.insert(&qf, factory());
-          assert(entry.owner);
-
-          // Promote inserted entry to the hot path.
-          slot.promote(entry);
-          return *entry.owner;
+          dim.hot.store(formula, std::memory_order_release);
         }
+
+        if (idx >= formula->publishedSize.load(std::memory_order_acquire))
+          formula->resize(count);
+
+        auto& slot = formula->slots[idx];
+        if (auto* quadrature = slot.ptr.load(std::memory_order_acquire))
+          return *quadrature;
+
+        std::lock_guard<std::mutex> lock(
+          formula->mutexes[static_cast<size_t>(idx) % formula->mutexes.size()]);
+        PolytopeQuadrature* quadrature = slot.ptr.load(std::memory_order_relaxed);
+        if (!quadrature)
+        {
+          slot.owner = factory();
+          quadrature = slot.owner.get();
+          slot.ptr.store(quadrature, std::memory_order_release);
+        }
+        return *quadrature;
       }
 
       /**
@@ -419,213 +386,87 @@ namespace Rodin::Geometry
       }
 
     private:
-      /**
-       * @brief Single owned cache entry.
-       *
-       * This is the owning storage unit for a cached polytope quadrature.
-       */
-      struct CacheEntry
-      {
-        const QF::QuadratureFormulaBase* qf = nullptr; ///< Cache key
-        std::unique_ptr<PolytopeQuadrature> owner;     ///< Owned cached quadrature
-        bool valid = false;                            ///< Whether this entry is populated
-      };
-
-      /**
-       * @brief Non-owning hot entry.
-       *
-       * The hot entry mirrors one of the owned cache entries to accelerate the
-       * most common repeated-hit case.
-       */
-      struct HotEntry
-      {
-        const QF::QuadratureFormulaBase* qf = nullptr; ///< Hot key
-        PolytopeQuadrature* ptr = nullptr;             ///< Non-owning pointer to owned entry
-      };
-
-      /**
-       * @brief Cache slot associated with one concrete polytope.
-       *
-       * Each slot stores:
-       * - one hot entry,
-       * - one bounded ring buffer of owned entries.
-       *
-       * Ownership remains solely in the bounded cache entries. The hot entry is
-       * only a mirror of one owned entry.
-       */
       struct Slot
       {
-        /**
-         * @brief Maximum number of owned quadratures cached per polytope.
-         *
-         * Lookup is linear in this value, so it is intentionally kept small.
-         */
-        static constexpr size_t Capacity = 8;
-
-        Slot() = default;
-        Slot(const Slot&) = delete;
-        Slot& operator=(const Slot&) = delete;
-
-        /**
-         * @brief Move constructor.
-         *
-         * The mutex is intentionally default-constructed in the moved instance.
-         */
-        Slot(Slot&& other) noexcept
-          : hot(other.hot),
-            entries(std::move(other.entries)),
-            size(std::exchange(other.size, 0)),
-            next(std::exchange(other.next, 0))
-        {}
-
-        /**
-         * @brief Move assignment operator.
-         *
-         * The mutex is intentionally default-constructed in the moved instance.
-         */
-        Slot& operator=(Slot&& other) noexcept
-        {
-          hot = other.hot;
-          entries = std::move(other.entries);
-          size = std::exchange(other.size, 0);
-          next = std::exchange(other.next, 0);
-          return *this;
-        }
-
-        /**
-         * @brief Promotes an owned entry to the hot path.
-         * @param[in] entry Cache entry to mirror in the hot slot
-         *
-         * The hot entry never owns. It only mirrors the provided owned entry.
-         */
-        void promote(const CacheEntry& entry)
-        {
-          assert(entry.valid);
-          assert(entry.qf);
-          assert(entry.owner);
-          hot.qf = entry.qf;
-          hot.ptr = entry.owner.get();
-        }
-
-        /**
-         * @brief Inserts an entry into the bounded cache.
-         * @param[in] qf Quadrature formula key
-         * @param[in] owner Newly constructed cached quadrature
-         * @returns Reference to the inserted owned entry
-         *
-         * If the cache is not full, the entry is appended.
-         * Otherwise, the next entry is overwritten in round-robin order.
-         *
-         * If the overwritten entry is currently mirrored by the hot slot,
-         * the hot slot is first invalidated to avoid a stale non-owning pointer.
-         */
-        CacheEntry& insert(
-            const QF::QuadratureFormulaBase* qf,
-            std::unique_ptr<PolytopeQuadrature> owner)
-        {
-          assert(qf);
-          assert(owner);
-
-          size_t i;
-          if (size < Capacity)
-          {
-            i = size++;
-          }
-          else
-          {
-            i = next;
-            next = (next + 1) % Capacity;
-
-            // Refinement:
-            // If the entry being overwritten is currently mirrored in the hot
-            // slot, invalidate the hot entry first to avoid keeping a stale
-            // non-owning pointer.
-            if (hot.ptr == entries[i].owner.get())
-            {
-              hot.qf = nullptr;
-              hot.ptr = nullptr;
-            }
-          }
-
-          auto& entry = entries[i];
-          entry.qf = qf;
-          entry.owner = std::move(owner);
-          entry.valid = true;
-          return entry;
-        }
-
-        HotEntry hot;                                ///< Non-owning fast path
-        std::array<CacheEntry, Capacity> entries;    ///< Owned bounded cache
-        size_t size = 0;                             ///< Number of valid entries
-        size_t next = 0;                             ///< Round-robin eviction pointer
-        mutable std::shared_mutex mutex;             ///< Slot-level synchronization
-
-
-        template <class Archive>
-        void save(Archive& ar, const unsigned int) const
-        {
-          // Intentionally serialize no cache content.
-        }
-
-        template <class Archive>
-        void load(Archive& ar, const unsigned int)
-        {
-          hot.qf = nullptr;
-          hot.ptr = nullptr;
-          entries = {};
-          size = 0;
-          next = 0;
-        }
-
-        BOOST_SERIALIZATION_SPLIT_MEMBER()
+          std::atomic<PolytopeQuadrature*> ptr{nullptr};
+          std::unique_ptr<PolytopeQuadrature> owner;
       };
 
-      /**
-       * @brief Storage bucket for all polytopes in a fixed dimension.
-       *
-       * A dimension bucket stores all slots for one polytope dimension.
-       */
+      struct Formula
+      {
+          static constexpr size_t MutexCount = 64;
+
+          Formula(const QF::QuadratureFormulaBase* qf, size_t count)
+            : qf(qf),
+              slots(count),
+              publishedSize(count)
+          {}
+
+          void resize(size_t count)
+          {
+            if (count <= publishedSize.load(std::memory_order_acquire))
+              return;
+            std::lock_guard<std::mutex> lock(resizeMutex);
+            if (slots.size() < count)
+              slots.resize(count);
+            publishedSize.store(slots.size(), std::memory_order_release);
+        }
+
+        const QF::QuadratureFormulaBase* qf;
+        std::deque<Slot> slots;
+        std::atomic<size_t> publishedSize;
+        std::mutex resizeMutex;
+        std::array<std::mutex, MutexCount> mutexes;
+      };
+
       struct Dimension
       {
-        Dimension() = default;
-        Dimension(const Dimension&) = delete;
-        Dimension& operator=(const Dimension&) = delete;
+          static constexpr size_t LookupCapacity = 16;
 
-        /**
-         * @brief Move constructor.
-         *
-         * The mutex is intentionally default-constructed in the moved instance.
-         */
-        Dimension(Dimension&& other) noexcept
-          : slots(std::move(other.slots))
-        {}
+          Dimension() = default;
+          Dimension(const Dimension&) = delete;
+          Dimension& operator=(const Dimension&) = delete;
 
-        /**
-         * @brief Move assignment operator.
-         *
-         * The mutex is intentionally default-constructed in the moved instance.
-         */
+          Dimension(Dimension&& other) noexcept
+            : formulas(std::move(other.formulas))
+          {
+            rebuildLookup();
+          }
+
         Dimension& operator=(Dimension&& other) noexcept
         {
-          slots = std::move(other.slots);
+          formulas = std::move(other.formulas);
+          rebuildLookup();
           return *this;
         }
 
-        template <class Archive>
-        void serialize(Archive& ar, const unsigned int)
+        void rebuildLookup()
         {
-          ar & slots; // mutex is not serialized
+          hot.store(nullptr, std::memory_order_relaxed);
+          for (auto& entry : lookup)
+            entry.store(nullptr, std::memory_order_relaxed);
+          const size_t count = std::min(formulas.size(), lookup.size());
+          for (size_t i = 0; i < count; ++i)
+            lookup[i].store(formulas[i].get(), std::memory_order_relaxed);
         }
 
-        std::deque<Slot> slots;              ///< Polytope slots for this dimension
-        mutable std::shared_mutex mutex;     ///< Dimension-level synchronization
+        std::vector<std::unique_ptr<Formula>> formulas;
+        std::array<std::atomic<Formula*>, LookupCapacity> lookup{};
+        std::atomic<Formula*> hot{nullptr};
+        mutable std::mutex mutex;
       };
 
-        template <class Archive>
-        void serialize(Archive& ar, const unsigned int)
-        {
-          ar & m_dimensions; // mutex is not serialized
-        }
+      template <class Archive>
+      void save(Archive&, const unsigned int) const
+      {}
+
+      template <class Archive>
+      void load(Archive&, const unsigned int)
+      {
+        clear();
+      }
+
+      BOOST_SERIALIZATION_SPLIT_MEMBER()
 
       mutable std::vector<Dimension> m_dimensions; ///< Dimension-partitioned storage
   };

--- a/src/Rodin/Geometry/PolytopeTransformationIndex.h
+++ b/src/Rodin/Geometry/PolytopeTransformationIndex.h
@@ -19,7 +19,6 @@
 #include <vector>
 #include <cassert>
 #include <utility>
-#include <shared_mutex>
 
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/deque.hpp>
@@ -61,6 +60,7 @@ namespace Rodin::Geometry
     {
       std::atomic<PolytopeTransformation*> ptr{nullptr}; ///< Atomic pointer for fast access
       std::unique_ptr<PolytopeTransformation> owner;     ///< Unique pointer owning the transformation
+      mutable std::mutex mutex; ///< Serializes construction
 
       /**
        * @brief Serialization save method.
@@ -94,13 +94,15 @@ namespace Rodin::Geometry
     /**
      * @brief Storage for transformations of polytopes in a single dimension.
      *
-     * Contains a deque of transformation slots along with a shared mutex
-     * for thread-safe concurrent access.
+     * Contains stable transformation slots and publishes their initialized
+     * extent atomically. The dimension mutex is only used when storage grows;
+     * repeated accesses use the published extent and slot pointer directly.
      */
     struct Dimension
     {
       std::deque<Slot> slots;          ///< Storage for transformation slots
-      mutable std::shared_mutex mutex; ///< Mutex for thread-safe access
+      std::atomic<size_t> publishedSize{0}; ///< Lock-free readable slot count
+      mutable std::mutex mutex; ///< Serializes storage growth
 
       /**
        * @brief Default constructor.
@@ -121,7 +123,9 @@ namespace Rodin::Geometry
        * @brief Move constructor.
        */
       Dimension(Dimension&& other) noexcept
-        : slots(std::move(other.slots)) {}
+        : slots(std::move(other.slots)),
+          publishedSize(other.publishedSize.load(std::memory_order_relaxed))
+      {}
 
       /**
        * @brief Move assignment operator.
@@ -129,6 +133,8 @@ namespace Rodin::Geometry
       Dimension& operator=(Dimension&& other) noexcept
       {
         slots = std::move(other.slots);
+        publishedSize.store(
+          other.publishedSize.load(std::memory_order_relaxed), std::memory_order_relaxed);
         return *this;
       }
 
@@ -208,9 +214,10 @@ namespace Rodin::Geometry
     {
       assert(d < m_dimensions.size());
       auto& dim = m_dimensions[d];
-      std::unique_lock<std::shared_mutex> wr(dim.mutex);
+      std::lock_guard<std::mutex> lock(dim.mutex);
       if (dim.slots.size() < count)
         dim.slots.resize(count);
+      dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
     }
 
     /**
@@ -229,12 +236,17 @@ namespace Rodin::Geometry
 
       assert(d < m_dimensions.size());
       auto& dim = m_dimensions[d];
-      std::unique_lock<std::shared_mutex> wr(dim.mutex);
-      if (dim.slots.size() <= idx)
-        dim.slots.resize(idx + 1);
+      if (idx >= dim.publishedSize.load(std::memory_order_acquire))
+      {
+        std::lock_guard<std::mutex> lock(dim.mutex);
+        if (dim.slots.size() <= idx)
+          dim.slots.resize(idx + 1);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
+      }
 
       assert(idx < dim.slots.size());
       Slot& s = dim.slots[idx];
+      std::lock_guard<std::mutex> lock(s.mutex);
       s.owner = std::move(obj);
       s.ptr.store(s.owner.get(), std::memory_order_release);
     }
@@ -258,12 +270,17 @@ namespace Rodin::Geometry
 
       assert(d < m_dimensions.size());
       auto& dim = m_dimensions[d];
-      std::unique_lock<std::shared_mutex> wr(dim.mutex);
-      if (dim.slots.size() < count)
-        dim.slots.resize(count);
+      if (count > dim.publishedSize.load(std::memory_order_acquire))
+      {
+        std::lock_guard<std::mutex> lock(dim.mutex);
+        if (dim.slots.size() < count)
+          dim.slots.resize(count);
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
+      }
 
       assert(idx < dim.slots.size());
       Slot& s = dim.slots[idx];
+      std::lock_guard<std::mutex> lock(s.mutex);
       s.owner = std::move(obj);
       s.ptr.store(s.owner.get(), std::memory_order_release);
     }
@@ -276,9 +293,13 @@ namespace Rodin::Geometry
      * @param[in] factory Factory function to create transformation if needed
      * @returns Reference to the transformation
      *
-     * Uses a two-phase locking strategy: first tries a fast shared-lock read,
-     * then upgrades to exclusive lock only if the transformation needs to be
-     * created. The factory is called at most once per polytope.
+     * Uses an atomic pointer on repeated accesses. Storage growth is serialized
+     * per dimension, while first construction is serialized per polytope. The
+     * factory is called at most once per polytope.
+     *
+     * @note Cache mutation, including clear() and set(), must not overlap use of
+     *       a reference returned by this function. Mesh evaluation already
+     *       requires geometry to remain unchanged for the duration of assembly.
      *
      * @note The Factory must be callable with signature:
      *       `std::unique_ptr<PolytopeTransformation>(size_t d, Index idx)`
@@ -293,49 +314,51 @@ namespace Rodin::Geometry
       assert(d < m_dimensions.size());
       auto& dim = m_dimensions[d];
 
-      // Fast path: read under shared lock
+      // Fast path: the deque is stable below the atomically published extent.
+      const size_t publishedSize = dim.publishedSize.load(std::memory_order_acquire);
+      if (idx < publishedSize)
       {
-        std::shared_lock<std::shared_mutex> rd(dim.mutex);
-        if (idx < dim.slots.size())
-        {
-          assert(idx < count);
-          const Slot& s = dim.slots[idx];
-          if (auto* q = s.ptr.load(std::memory_order_acquire)) return *q;
-        }
+        assert(idx < count);
+        const Slot& s = dim.slots[idx];
+        if (auto* q = s.ptr.load(std::memory_order_acquire))
+          return *q;
       }
 
-      // Slow path: exclusive lock, ensure size, init in-place
+      // Slow path: grow the stable slot storage if necessary.
+      if (idx >= publishedSize)
       {
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
-
+        std::lock_guard<std::mutex> lock(dim.mutex);
         if (dim.slots.size() < count)
           dim.slots.resize(count);
-
-        assert(idx < dim.slots.size());
-        Slot& s = dim.slots[idx];
-        PolytopeTransformation* q = s.ptr.load(std::memory_order_relaxed);
-        if (!q)
-        {
-          auto up = factory(d, idx);
-          s.owner = std::move(up);
-          q = s.owner.get();
-          s.ptr.store(q, std::memory_order_release);
-        }
-        return *q; // still under wr; safe
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_release);
       }
+
+      assert(idx < dim.slots.size());
+      Slot& s = dim.slots[idx];
+      std::lock_guard<std::mutex> lock(s.mutex);
+      PolytopeTransformation* q = s.ptr.load(std::memory_order_relaxed);
+      if (!q)
+      {
+        auto up = factory(d, idx);
+        s.owner = std::move(up);
+        q = s.owner.get();
+        s.ptr.store(q, std::memory_order_release);
+      }
+      return *q;
     }
 
     /**
      * @brief Clears all stored transformations.
      *
      * Releases all transformation objects and resets internal storage.
-     * Thread-safe with respect to concurrent operations.
+     * This operation must not overlap transformation evaluation.
      */
     void clear()
     {
       for (auto& dim : m_dimensions)
       {
-        std::unique_lock<std::shared_mutex> wr(dim.mutex);
+        std::lock_guard<std::mutex> lock(dim.mutex);
+        dim.publishedSize.store(0, std::memory_order_release);
         dim.slots.clear();
       }
     }
@@ -370,6 +393,8 @@ namespace Rodin::Geometry
     {
       clear();
       ar & m_dimensions;
+      for (auto& dim : m_dimensions)
+        dim.publishedSize.store(dim.slots.size(), std::memory_order_relaxed);
       // ptr fields restored by Slot::load
     }
 

--- a/src/Rodin/Geometry/SubMeshBuilder.cpp
+++ b/src/Rodin/Geometry/SubMeshBuilder.cpp
@@ -120,6 +120,15 @@ namespace Rodin::Geometry
     // Finalize construction
     SubMesh res(parent);
     res.Parent::operator=(m_build.finalize());
+    for (size_t d = 1; d < m_s2ps.size(); ++d)
+    {
+      for (size_t child = 0; child < m_s2ps[d].left.size(); ++child)
+      {
+        const Index parentIdx = m_s2ps[d].left[child];
+        res.setPolytopeTransformation({d, static_cast<Index>(child)},
+          parent.getPolytopeTransformation(d, parentIdx).copy());
+      }
+    }
     res.m_s2ps = std::move(m_s2ps);
     return res;
   }

--- a/src/Rodin/IO/HDF5.h
+++ b/src/Rodin/IO/HDF5.h
@@ -644,27 +644,32 @@ namespace Rodin::IO
      * exported node count/order is independent of Rodin's internal geometry
      * basis and node layout.
      */
-    inline
-    U64 getXDMFQuadraticMixedTopologyId(Geometry::Polytope::Type t)
+    inline U64 getXDMFQuadraticMixedTopologyId(Geometry::Polytope::Type t)
     {
       using PT = Geometry::Polytope::Type;
       switch (t)
       {
-        case PT::Segment:       return 34; // Edge_3
-        case PT::Triangle:      return 36; // Triangle_6
-        case PT::Quadrilateral: return 35; // Quadrilateral_9
-        case PT::Tetrahedron:   return 38; // Tetrahedron_10
-        case PT::Pyramid:       return 39; // Pyramid_13
-        case PT::Wedge:         return 41; // Wedge_18
-        case PT::Hexahedron:    return 50; // Hexahedron_27
+        case PT::Segment:
+          return 34; // Edge_3
+        case PT::Triangle:
+          return 36; // Triangle_6
+        case PT::Quadrilateral:
+          return 35; // Quadrilateral_9
+        case PT::Tetrahedron:
+          return 38; // Tetrahedron_10
+        case PT::Pyramid:
+          return 39; // Pyramid_13
+        case PT::Wedge:
+          return 41; // Wedge_18
+        case PT::Hexahedron:
+          return 50; // Hexahedron_27
         case PT::Point:
           return getXDMFMixedTopologyId(t);
       }
 
-      Alert::Exception()
-        << "XDMF curved visualization does not support quadratic Rodin "
-        << "polytope type " << static_cast<int>(t) << "."
-        << Alert::Raise;
+      Alert::Exception() << "XDMF curved visualization does not support quadratic Rodin "
+                         << "polytope type " << static_cast<int>(t) << "."
+                         << Alert::Raise;
       return std::numeric_limits<U64>::max();
     }
 
@@ -673,27 +678,32 @@ namespace Rodin::IO
      * @param[in] t Polytope geometry type.
      * @returns XDMF topology name string.
      */
-    inline
-    const char* getXDMFQuadraticTopologyName(Geometry::Polytope::Type t)
+    inline const char* getXDMFQuadraticTopologyName(Geometry::Polytope::Type t)
     {
       using PT = Geometry::Polytope::Type;
       switch (t)
       {
-        case PT::Segment:       return "Edge_3";
-        case PT::Triangle:      return "Triangle_6";
-        case PT::Quadrilateral: return "Quadrilateral_9";
-        case PT::Tetrahedron:   return "Tetrahedron_10";
-        case PT::Pyramid:       return "Pyramid_13";
-        case PT::Wedge:         return "Wedge_18";
-        case PT::Hexahedron:    return "Hexahedron_27";
+        case PT::Segment:
+          return "Edge_3";
+        case PT::Triangle:
+          return "Triangle_6";
+        case PT::Quadrilateral:
+          return "Quadrilateral_9";
+        case PT::Tetrahedron:
+          return "Tetrahedron_10";
+        case PT::Pyramid:
+          return "Pyramid_13";
+        case PT::Wedge:
+          return "Wedge_18";
+        case PT::Hexahedron:
+          return "Hexahedron_27";
         case PT::Point:
           return "Polyvertex";
       }
 
-      Alert::Exception()
-        << "XDMF curved visualization does not support quadratic Rodin "
-        << "polytope type " << static_cast<int>(t) << "."
-        << Alert::Raise;
+      Alert::Exception() << "XDMF curved visualization does not support quadratic Rodin "
+                         << "polytope type " << static_cast<int>(t) << "."
+                         << Alert::Raise;
       return nullptr;
     }
 
@@ -722,8 +732,7 @@ namespace Rodin::IO
      * @param[in] values Coordinate values in reference-cell coordinates.
      * @returns Spatial point with the same dimension as @p values.
      */
-    inline
-    Math::SpatialPoint xdmfReferencePoint(std::initializer_list<Real> values)
+    inline Math::SpatialPoint xdmfReferencePoint(std::initializer_list<Real> values)
     {
       Math::SpatialPoint p;
       p.resize(static_cast<Eigen::Index>(values.size()));
@@ -741,10 +750,8 @@ namespace Rodin::IO
      * visualization independent of Rodin's internal finite-element node layout
      * while intentionally approximating higher-order geometry by quadratic XDMF.
      */
-    inline
-    std::vector<Math::SpatialPoint> getXDMFReferenceNodes(
-        Geometry::Polytope::Type t,
-        size_t order)
+    inline std::vector<Math::SpatialPoint> getXDMFReferenceNodes(
+      Geometry::Polytope::Type t, size_t order)
     {
       using PT = Geometry::Polytope::Type;
       if (order <= 1)
@@ -752,164 +759,94 @@ namespace Rodin::IO
         switch (t)
         {
           case PT::Point:
-            return { xdmfReferencePoint({}) };
+            return {xdmfReferencePoint({})};
           case PT::Segment:
-            return { xdmfReferencePoint({0}), xdmfReferencePoint({1}) };
+            return {xdmfReferencePoint({0}), xdmfReferencePoint({1})};
           case PT::Triangle:
-            return {
-              xdmfReferencePoint({0, 0}),
-              xdmfReferencePoint({1, 0}),
-              xdmfReferencePoint({0, 1}) };
+            return {xdmfReferencePoint({0, 0}), xdmfReferencePoint({1, 0}),
+              xdmfReferencePoint({0, 1})};
           case PT::Quadrilateral:
-            return {
-              xdmfReferencePoint({0, 0}),
-              xdmfReferencePoint({1, 0}),
-              xdmfReferencePoint({1, 1}),
-              xdmfReferencePoint({0, 1}) };
+            return {xdmfReferencePoint({0, 0}), xdmfReferencePoint({1, 0}),
+              xdmfReferencePoint({1, 1}), xdmfReferencePoint({0, 1})};
           case PT::Tetrahedron:
-            return {
-              xdmfReferencePoint({0, 0, 0}),
-              xdmfReferencePoint({1, 0, 0}),
-              xdmfReferencePoint({0, 1, 0}),
-              xdmfReferencePoint({0, 0, 1}) };
+            return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+              xdmfReferencePoint({0, 1, 0}), xdmfReferencePoint({0, 0, 1})};
           case PT::Pyramid:
-            return {
-              xdmfReferencePoint({0, 0, 0}),
-              xdmfReferencePoint({1, 0, 0}),
-              xdmfReferencePoint({1, 1, 0}),
-              xdmfReferencePoint({0, 1, 0}),
-              xdmfReferencePoint({0, 0, 1}) };
+            return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+              xdmfReferencePoint({1, 1, 0}), xdmfReferencePoint({0, 1, 0}),
+              xdmfReferencePoint({0, 0, 1})};
           case PT::Wedge:
-            return {
-              xdmfReferencePoint({0, 0, 0}),
-              xdmfReferencePoint({1, 0, 0}),
-              xdmfReferencePoint({0, 1, 0}),
-              xdmfReferencePoint({0, 0, 1}),
-              xdmfReferencePoint({1, 0, 1}),
-              xdmfReferencePoint({0, 1, 1}) };
+            return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+              xdmfReferencePoint({0, 1, 0}), xdmfReferencePoint({0, 0, 1}),
+              xdmfReferencePoint({1, 0, 1}), xdmfReferencePoint({0, 1, 1})};
           case PT::Hexahedron:
-            return {
-              xdmfReferencePoint({0, 0, 0}),
-              xdmfReferencePoint({1, 0, 0}),
-              xdmfReferencePoint({1, 1, 0}),
-              xdmfReferencePoint({0, 1, 0}),
-              xdmfReferencePoint({0, 0, 1}),
-              xdmfReferencePoint({1, 0, 1}),
-              xdmfReferencePoint({1, 1, 1}),
-              xdmfReferencePoint({0, 1, 1}) };
+            return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+              xdmfReferencePoint({1, 1, 0}), xdmfReferencePoint({0, 1, 0}),
+              xdmfReferencePoint({0, 0, 1}), xdmfReferencePoint({1, 0, 1}),
+              xdmfReferencePoint({1, 1, 1}), xdmfReferencePoint({0, 1, 1})};
         }
       }
 
       switch (t)
       {
         case PT::Point:
-          return { xdmfReferencePoint({}) };
+          return {xdmfReferencePoint({})};
         case PT::Segment:
           return {
-            xdmfReferencePoint({0}),
-            xdmfReferencePoint({1}),
-            xdmfReferencePoint({0.5}) };
+            xdmfReferencePoint({0}), xdmfReferencePoint({1}), xdmfReferencePoint({0.5})};
         case PT::Triangle:
-          return {
-            xdmfReferencePoint({0, 0}),
-            xdmfReferencePoint({1, 0}),
-            xdmfReferencePoint({0, 1}),
-            xdmfReferencePoint({0.5, 0}),
-            xdmfReferencePoint({0.5, 0.5}),
-            xdmfReferencePoint({0, 0.5}) };
+          return {xdmfReferencePoint({0, 0}), xdmfReferencePoint({1, 0}),
+            xdmfReferencePoint({0, 1}), xdmfReferencePoint({0.5, 0}),
+            xdmfReferencePoint({0.5, 0.5}), xdmfReferencePoint({0, 0.5})};
         case PT::Quadrilateral:
-          return {
-            xdmfReferencePoint({0, 0}),
-            xdmfReferencePoint({1, 0}),
-            xdmfReferencePoint({1, 1}),
-            xdmfReferencePoint({0, 1}),
-            xdmfReferencePoint({0.5, 0}),
-            xdmfReferencePoint({1, 0.5}),
-            xdmfReferencePoint({0.5, 1}),
-            xdmfReferencePoint({0, 0.5}),
-            xdmfReferencePoint({0.5, 0.5}) };
+          return {xdmfReferencePoint({0, 0}), xdmfReferencePoint({1, 0}),
+            xdmfReferencePoint({1, 1}), xdmfReferencePoint({0, 1}),
+            xdmfReferencePoint({0.5, 0}), xdmfReferencePoint({1, 0.5}),
+            xdmfReferencePoint({0.5, 1}), xdmfReferencePoint({0, 0.5}),
+            xdmfReferencePoint({0.5, 0.5})};
         case PT::Tetrahedron:
-          return {
-            xdmfReferencePoint({0, 0, 0}),
-            xdmfReferencePoint({1, 0, 0}),
-            xdmfReferencePoint({0, 1, 0}),
-            xdmfReferencePoint({0, 0, 1}),
-            xdmfReferencePoint({0.5, 0, 0}),
-            xdmfReferencePoint({0.5, 0.5, 0}),
-            xdmfReferencePoint({0, 0.5, 0}),
-            xdmfReferencePoint({0, 0, 0.5}),
-            xdmfReferencePoint({0.5, 0, 0.5}),
-            xdmfReferencePoint({0, 0.5, 0.5}) };
+          return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+            xdmfReferencePoint({0, 1, 0}), xdmfReferencePoint({0, 0, 1}),
+            xdmfReferencePoint({0.5, 0, 0}), xdmfReferencePoint({0.5, 0.5, 0}),
+            xdmfReferencePoint({0, 0.5, 0}), xdmfReferencePoint({0, 0, 0.5}),
+            xdmfReferencePoint({0.5, 0, 0.5}), xdmfReferencePoint({0, 0.5, 0.5})};
         case PT::Wedge:
-          return {
-            xdmfReferencePoint({0, 0, 0}),
-            xdmfReferencePoint({1, 0, 0}),
-            xdmfReferencePoint({0, 1, 0}),
-            xdmfReferencePoint({0, 0, 1}),
-            xdmfReferencePoint({1, 0, 1}),
-            xdmfReferencePoint({0, 1, 1}),
-            xdmfReferencePoint({0.5, 0, 0}),
-            xdmfReferencePoint({0.5, 0.5, 0}),
-            xdmfReferencePoint({0, 0.5, 0}),
-            xdmfReferencePoint({0, 0, 0.5}),
-            xdmfReferencePoint({1, 0, 0.5}),
-            xdmfReferencePoint({0, 1, 0.5}),
-            xdmfReferencePoint({0.5, 0, 1}),
-            xdmfReferencePoint({0.5, 0.5, 1}),
-            xdmfReferencePoint({0, 0.5, 1}),
-            xdmfReferencePoint({0.5, 0, 0.5}),
-            xdmfReferencePoint({0.5, 0.5, 0.5}),
-            xdmfReferencePoint({0, 0.5, 0.5}) };
+          return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+            xdmfReferencePoint({0, 1, 0}), xdmfReferencePoint({0, 0, 1}),
+            xdmfReferencePoint({1, 0, 1}), xdmfReferencePoint({0, 1, 1}),
+            xdmfReferencePoint({0.5, 0, 0}), xdmfReferencePoint({0.5, 0.5, 0}),
+            xdmfReferencePoint({0, 0.5, 0}), xdmfReferencePoint({0, 0, 0.5}),
+            xdmfReferencePoint({1, 0, 0.5}), xdmfReferencePoint({0, 1, 0.5}),
+            xdmfReferencePoint({0.5, 0, 1}), xdmfReferencePoint({0.5, 0.5, 1}),
+            xdmfReferencePoint({0, 0.5, 1}), xdmfReferencePoint({0.5, 0, 0.5}),
+            xdmfReferencePoint({0.5, 0.5, 0.5}), xdmfReferencePoint({0, 0.5, 0.5})};
         case PT::Pyramid:
-          return {
-            xdmfReferencePoint({0, 0, 0}),
-            xdmfReferencePoint({1, 0, 0}),
-            xdmfReferencePoint({1, 1, 0}),
-            xdmfReferencePoint({0, 1, 0}),
-            xdmfReferencePoint({0, 0, 1}),
-            xdmfReferencePoint({0.5, 0, 0}),
-            xdmfReferencePoint({1, 0.5, 0}),
-            xdmfReferencePoint({0.5, 1, 0}),
-            xdmfReferencePoint({0, 0.5, 0}),
-            xdmfReferencePoint({0, 0, 0.5}),
-            xdmfReferencePoint({0.5, 0, 0.5}),
-            xdmfReferencePoint({0.5, 0.5, 0.5}),
-            xdmfReferencePoint({0, 0.5, 0.5}) };
+          return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+            xdmfReferencePoint({1, 1, 0}), xdmfReferencePoint({0, 1, 0}),
+            xdmfReferencePoint({0, 0, 1}), xdmfReferencePoint({0.5, 0, 0}),
+            xdmfReferencePoint({1, 0.5, 0}), xdmfReferencePoint({0.5, 1, 0}),
+            xdmfReferencePoint({0, 0.5, 0}), xdmfReferencePoint({0, 0, 0.5}),
+            xdmfReferencePoint({0.5, 0, 0.5}), xdmfReferencePoint({0.5, 0.5, 0.5}),
+            xdmfReferencePoint({0, 0.5, 0.5})};
         case PT::Hexahedron:
-          return {
-            xdmfReferencePoint({0, 0, 0}),
-            xdmfReferencePoint({1, 0, 0}),
-            xdmfReferencePoint({1, 1, 0}),
-            xdmfReferencePoint({0, 1, 0}),
-            xdmfReferencePoint({0, 0, 1}),
-            xdmfReferencePoint({1, 0, 1}),
-            xdmfReferencePoint({1, 1, 1}),
-            xdmfReferencePoint({0, 1, 1}),
-            xdmfReferencePoint({0.5, 0, 0}),
-            xdmfReferencePoint({1, 0.5, 0}),
-            xdmfReferencePoint({0.5, 1, 0}),
-            xdmfReferencePoint({0, 0.5, 0}),
-            xdmfReferencePoint({0, 0, 0.5}),
-            xdmfReferencePoint({1, 0, 0.5}),
-            xdmfReferencePoint({1, 1, 0.5}),
-            xdmfReferencePoint({0, 1, 0.5}),
-            xdmfReferencePoint({0.5, 0, 1}),
-            xdmfReferencePoint({1, 0.5, 1}),
-            xdmfReferencePoint({0.5, 1, 1}),
-            xdmfReferencePoint({0, 0.5, 1}),
-            xdmfReferencePoint({0.5, 0.5, 0}),
-            xdmfReferencePoint({0.5, 0, 0.5}),
-            xdmfReferencePoint({1, 0.5, 0.5}),
-            xdmfReferencePoint({0.5, 1, 0.5}),
-            xdmfReferencePoint({0, 0.5, 0.5}),
-            xdmfReferencePoint({0.5, 0.5, 1}),
-            xdmfReferencePoint({0.5, 0.5, 0.5}) };
+          return {xdmfReferencePoint({0, 0, 0}), xdmfReferencePoint({1, 0, 0}),
+            xdmfReferencePoint({1, 1, 0}), xdmfReferencePoint({0, 1, 0}),
+            xdmfReferencePoint({0, 0, 1}), xdmfReferencePoint({1, 0, 1}),
+            xdmfReferencePoint({1, 1, 1}), xdmfReferencePoint({0, 1, 1}),
+            xdmfReferencePoint({0.5, 0, 0}), xdmfReferencePoint({1, 0.5, 0}),
+            xdmfReferencePoint({0.5, 1, 0}), xdmfReferencePoint({0, 0.5, 0}),
+            xdmfReferencePoint({0, 0, 0.5}), xdmfReferencePoint({1, 0, 0.5}),
+            xdmfReferencePoint({1, 1, 0.5}), xdmfReferencePoint({0, 1, 0.5}),
+            xdmfReferencePoint({0.5, 0, 1}), xdmfReferencePoint({1, 0.5, 1}),
+            xdmfReferencePoint({0.5, 1, 1}), xdmfReferencePoint({0, 0.5, 1}),
+            xdmfReferencePoint({0.5, 0.5, 0}), xdmfReferencePoint({0.5, 0, 0.5}),
+            xdmfReferencePoint({1, 0.5, 0.5}), xdmfReferencePoint({0.5, 1, 0.5}),
+            xdmfReferencePoint({0, 0.5, 0.5}), xdmfReferencePoint({0.5, 0.5, 1}),
+            xdmfReferencePoint({0.5, 0.5, 0.5})};
       }
 
-      Alert::Exception()
-        << "Unsupported order-2 XDMF reference nodes for polytope type "
-        << static_cast<int>(t) << "."
-        << Alert::Raise;
+      Alert::Exception() << "Unsupported order-2 XDMF reference nodes for polytope type "
+                         << static_cast<int>(t) << "." << Alert::Raise;
       return {};
     }
 
@@ -918,8 +855,7 @@ namespace Rodin::IO
      * @param[in] mesh Mesh to inspect.
      * @returns True when at least one exported cell has order greater than one.
      */
-    inline
-    bool hasCurvedXDMFGeometry(const Geometry::MeshBase& mesh)
+    inline bool hasCurvedXDMFGeometry(const Geometry::MeshBase& mesh)
     {
       for (auto it = mesh.getCell(); !it.end(); ++it)
       {
@@ -939,8 +875,7 @@ namespace Rodin::IO
      * as a ghost). For a plain `Mesh<Context::Local>` this returns
      * nullptr and the writers iterate every cell.
      */
-    inline
-    const Geometry::Shard* asShard(const Geometry::MeshBase& mesh)
+    inline const Geometry::Shard* asShard(const Geometry::MeshBase& mesh)
     {
       return dynamic_cast<const Geometry::Shard*>(&mesh);
     }
@@ -951,9 +886,7 @@ namespace Rodin::IO
      * On a `Shard` this means `isOwned(D, i)`. On a non-shard local mesh
      * the predicate is identically true.
      */
-    inline
-    bool isXDMFOwnedCell(
-        const Geometry::Shard* shard, std::size_t D, Index i)
+    inline bool isXDMFOwnedCell(const Geometry::Shard* shard, std::size_t D, Index i)
     {
       return !shard || shard->isOwned(D, i);
     }
@@ -964,8 +897,7 @@ namespace Rodin::IO
      * Equals the shard's owned-cell count when `mesh` is a `Shard`,
      * otherwise `mesh.getCellCount()`.
      */
-    inline
-    std::size_t getXDMFRenderedCellCount(const Geometry::MeshBase& mesh)
+    inline std::size_t getXDMFRenderedCellCount(const Geometry::MeshBase& mesh)
     {
       const auto* shard = asShard(mesh);
       if (!shard)
@@ -984,8 +916,7 @@ namespace Rodin::IO
      * @param[in] mesh Mesh to inspect.
      * @returns Vertex count for the XDMF geometry dataset.
      */
-    inline
-    size_t getXDMFVisualizationVertexCount(const Geometry::MeshBase& mesh)
+    inline size_t getXDMFVisualizationVertexCount(const Geometry::MeshBase& mesh)
     {
       // Linear meshes share vertices across cells; vertex emission is
       // by vertex index, not per-cell. We deliberately do NOT filter the
@@ -1063,10 +994,8 @@ namespace Rodin::IO
      * @param[in] allowUniformCurvedTopology Whether uniform curved topology is allowed.
      * @returns Topology layout metadata.
      */
-    inline
-    XDMFTopologyLayout getXDMFTopologyLayout(
-        const Geometry::MeshBase& mesh,
-        bool allowUniformCurvedTopology = true)
+    inline XDMFTopologyLayout getXDMFTopologyLayout(
+      const Geometry::MeshBase& mesh, bool allowUniformCurvedTopology = true)
     {
       XDMFTopologyLayout layout;
       layout.entryCount = getXDMFMixedTopologySize(mesh);
@@ -1074,8 +1003,7 @@ namespace Rodin::IO
       if (!allowUniformCurvedTopology || !hasCurvedXDMFGeometry(mesh))
         return layout;
 
-      const auto& localMesh =
-          static_cast<const Geometry::Mesh<Context::Local>&>(mesh);
+      const auto& localMesh = static_cast<const Geometry::Mesh<Context::Local>&>(mesh);
       const auto& connectivity = localMesh.getConnectivity();
       const size_t D = connectivity.getDimension();
       const auto* shard = asShard(mesh);
@@ -1417,11 +1345,8 @@ namespace Rodin::IO
      * @param[in] mesh  Local mesh whose cells provide the topology data.
      * @param[in] allowUniformCurvedTopology Whether uniform curved topology is allowed.
      */
-    inline
-    void writeXDMFTopology(
-        hid_t file,
-        const Geometry::MeshBase& mesh,
-        bool allowUniformCurvedTopology = true)
+    inline void writeXDMFTopology(
+      hid_t file, const Geometry::MeshBase& mesh, bool allowUniformCurvedTopology = true)
     {
       {
         const auto g =
@@ -1437,8 +1362,7 @@ namespace Rodin::IO
       const auto& connectivity =
           static_cast<const Geometry::Mesh<Context::Local>&>(mesh).getConnectivity();
       const size_t D = connectivity.getDimension();
-      const auto layout =
-        getXDMFTopologyLayout(mesh, allowUniformCurvedTopology);
+      const auto layout = getXDMFTopologyLayout(mesh, allowUniformCurvedTopology);
       const auto* shard = asShard(mesh);
 
       if (layout.isUniform)
@@ -1449,16 +1373,11 @@ namespace Rodin::IO
           for (size_t k = 0; k < layout.columnCount; ++k)
             topology[i * layout.columnCount + k] = nextNode++;
 
-        writeMatrixDataset(
-            file,
-            Path::MeshXDMFTopology,
-            topology,
-            static_cast<hsize_t>(layout.rowCount),
-            static_cast<hsize_t>(layout.columnCount));
+        writeMatrixDataset(file, Path::MeshXDMFTopology, topology,
+          static_cast<hsize_t>(layout.rowCount),
+          static_cast<hsize_t>(layout.columnCount));
         writeScalarDataset(
-            file,
-            Path::MeshXDMFTopologySize,
-            static_cast<U64>(layout.entryCount));
+          file, Path::MeshXDMFTopologySize, static_cast<U64>(layout.entryCount));
         return;
       }
 
@@ -1478,9 +1397,8 @@ namespace Rodin::IO
           const size_t order = trans.getOrder();
           const auto nodes = getXDMFReferenceNodes(geometry, order);
 
-          topology.push_back(order > 1
-              ? getXDMFQuadraticMixedTopologyId(geometry)
-              : getXDMFMixedTopologyId(geometry));
+          topology.push_back(order > 1 ? getXDMFQuadraticMixedTopologyId(geometry)
+                                       : getXDMFMixedTopologyId(geometry));
 
           if (geometry == Geometry::Polytope::Type::Segment && order <= 1)
             topology.push_back(static_cast<U64>(nodes.size()));
@@ -1490,7 +1408,8 @@ namespace Rodin::IO
         }
 
         writeVectorDataset(file, Path::MeshXDMFTopology, topology);
-        writeScalarDataset(file, Path::MeshXDMFTopologySize, static_cast<U64>(topology.size()));
+        writeScalarDataset(
+          file, Path::MeshXDMFTopologySize, static_cast<U64>(topology.size()));
         return;
       }
 
@@ -1529,11 +1448,8 @@ namespace Rodin::IO
      * @param[in] mesh      Local mesh whose cells provide the topology data.
      * @param[in] allowUniformCurvedTopology Whether uniform curved topology is allowed.
      */
-    inline
-    void writeXDMFTopology(
-        const boost::filesystem::path& filename,
-        const Geometry::MeshBase& mesh,
-        bool allowUniformCurvedTopology = true)
+    inline void writeXDMFTopology(const boost::filesystem::path& filename,
+      const Geometry::MeshBase& mesh, bool allowUniformCurvedTopology = true)
     {
       const auto file = File(H5Fopen(filename.c_str(), H5F_ACC_RDWR, H5P_DEFAULT));
       if (!file)
@@ -1601,12 +1517,8 @@ namespace Rodin::IO
           }
         }
 
-        writeMatrixDataset(
-            file,
-            Path::MeshGeometryVertices,
-            packed,
-            static_cast<hsize_t>(nv),
-            static_cast<hsize_t>(sdim));
+        writeMatrixDataset(file, Path::MeshGeometryVertices, packed,
+          static_cast<hsize_t>(nv), static_cast<hsize_t>(sdim));
         return;
       }
 
@@ -1711,11 +1623,8 @@ namespace Rodin::IO
      * @see writeXDMFTopology, writeXDMFVertices, writeXDMFRegionAttribute,
      *      MeshPrinter<FileFormat::HDF5, Context::Local>
      */
-    inline
-    void writeXDMFMesh(
-        const boost::filesystem::path& filename,
-        const Geometry::MeshBase& mesh,
-        bool allowUniformCurvedTopology = true)
+    inline void writeXDMFMesh(const boost::filesystem::path& filename,
+      const Geometry::MeshBase& mesh, bool allowUniformCurvedTopology = true)
     {
       const auto file =
         File(H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT));
@@ -1745,10 +1654,8 @@ namespace Rodin::IO
     /// @cond
     // Forward declaration of the explicit-mesh overload, defined below.
     template <class GridFunctionType>
-    void writeXDMFNodeAttribute(
-        const GridFunctionType& gf,
-        const Geometry::MeshBase& visMesh,
-        const boost::filesystem::path& filename);
+    void writeXDMFNodeAttribute(const GridFunctionType& gf,
+      const Geometry::MeshBase& visMesh, const boost::filesystem::path& filename);
     /// @endcond
 
     /**
@@ -1790,16 +1697,15 @@ namespace Rodin::IO
     {
       const auto& fesMesh = gf.getFiniteElementSpace().getMesh();
       const auto* localMesh =
-          dynamic_cast<const Geometry::Mesh<Context::Local>*>(&fesMesh);
+        dynamic_cast<const Geometry::Mesh<Context::Local>*>(&fesMesh);
       if (!localMesh)
       {
-        Alert::Exception()
-          << "writeXDMFNodeAttribute(gf, path): the grid function's FES "
-             "mesh is not a Mesh<Context::Local>. In MPI mode, pass the "
-             "shard explicitly via writeXDMFNodeAttribute(gf, "
-             "mpiMesh.getShard(), path), or use IO::XDMF with "
-             "setMesh(mpiMesh) which forwards the shard automatically."
-          << Alert::Raise;
+        Alert::Exception() << "writeXDMFNodeAttribute(gf, path): the grid function's FES "
+                              "mesh is not a Mesh<Context::Local>. In MPI mode, pass the "
+                              "shard explicitly via writeXDMFNodeAttribute(gf, "
+                              "mpiMesh.getShard(), path), or use IO::XDMF with "
+                              "setMesh(mpiMesh) which forwards the shard automatically."
+                           << Alert::Raise;
       }
       writeXDMFNodeAttribute(gf, *localMesh, filename);
     }
@@ -1830,10 +1736,8 @@ namespace Rodin::IO
      */
     // Forward declaration of the explicit-mesh overload, defined below.
     template <class GridFunctionType>
-    void writeXDMFCellAttribute(
-        const GridFunctionType& gf,
-        const Geometry::MeshBase& visMesh,
-        const boost::filesystem::path& filename);
+    void writeXDMFCellAttribute(const GridFunctionType& gf,
+      const Geometry::MeshBase& visMesh, const boost::filesystem::path& filename);
     /// @endcond
 
     /**
@@ -1858,16 +1762,15 @@ namespace Rodin::IO
       // silently emit a malformed dataset. Fail loudly instead.
       const auto& fesMesh = gf.getFiniteElementSpace().getMesh();
       const auto* localMesh =
-          dynamic_cast<const Geometry::Mesh<Context::Local>*>(&fesMesh);
+        dynamic_cast<const Geometry::Mesh<Context::Local>*>(&fesMesh);
       if (!localMesh)
       {
-        Alert::Exception()
-          << "writeXDMFCellAttribute(gf, path): the grid function's FES "
-             "mesh is not a Mesh<Context::Local>. In MPI mode, pass the "
-             "shard explicitly via writeXDMFCellAttribute(gf, "
-             "mpiMesh.getShard(), path), or use IO::XDMF with "
-             "setMesh(mpiMesh) which forwards the shard automatically."
-          << Alert::Raise;
+        Alert::Exception() << "writeXDMFCellAttribute(gf, path): the grid function's FES "
+                              "mesh is not a Mesh<Context::Local>. In MPI mode, pass the "
+                              "shard explicitly via writeXDMFCellAttribute(gf, "
+                              "mpiMesh.getShard(), path), or use IO::XDMF with "
+                              "setMesh(mpiMesh) which forwards the shard automatically."
+                           << Alert::Raise;
       }
       writeXDMFCellAttribute(gf, *localMesh, filename);
     }
@@ -1971,8 +1874,7 @@ namespace Rodin::IO
             const auto visCell = visMesh.getPolytope(D, i);
             const auto gfCell = gfMesh.getPolytope(D, i);
             const auto nodes = getXDMFReferenceNodes(
-                visCell->getGeometry(),
-                visCell->getTransformation().getOrder());
+              visCell->getGeometry(), visCell->getTransformation().getOrder());
             for (const auto& rc : nodes)
             {
               Math::SpatialPoint pc;
@@ -1983,11 +1885,10 @@ namespace Rodin::IO
           }
           if (out != nv)
           {
-            Alert::Exception()
-              << "writeXDMFNodeAttribute (curved): emitted " << out
-              << " values but expected " << nv
-              << " — visMesh and gfMesh cardinalities disagree."
-              << Alert::Raise;
+            Alert::Exception() << "writeXDMFNodeAttribute (curved): emitted " << out
+                               << " values but expected " << nv
+                               << " — visMesh and gfMesh cardinalities disagree."
+                               << Alert::Raise;
           }
           HDF5::writeVectorDataset(file.get(), Path::GridFunctionValuesData, values);
         }
@@ -2002,8 +1903,7 @@ namespace Rodin::IO
             const auto visCell = visMesh.getPolytope(D, i);
             const auto gfCell = gfMesh.getPolytope(D, i);
             const auto nodes = getXDMFReferenceNodes(
-                visCell->getGeometry(),
-                visCell->getTransformation().getOrder());
+              visCell->getGeometry(), visCell->getTransformation().getOrder());
             for (const auto& rc : nodes)
             {
               Math::SpatialPoint pc;
@@ -2017,18 +1917,13 @@ namespace Rodin::IO
           }
           if (out != nv)
           {
-            Alert::Exception()
-              << "writeXDMFNodeAttribute (curved): emitted " << out
-              << " values but expected " << nv
-              << " — visMesh and gfMesh cardinalities disagree."
-              << Alert::Raise;
+            Alert::Exception() << "writeXDMFNodeAttribute (curved): emitted " << out
+                               << " values but expected " << nv
+                               << " — visMesh and gfMesh cardinalities disagree."
+                               << Alert::Raise;
           }
-          HDF5::writeMatrixDataset(
-              file.get(),
-              Path::GridFunctionValuesData,
-              values,
-              static_cast<hsize_t>(nv),
-              static_cast<hsize_t>(vdim));
+          HDF5::writeMatrixDataset(file.get(), Path::GridFunctionValuesData, values,
+            static_cast<hsize_t>(nv), static_cast<hsize_t>(vdim));
         }
         return;
       }
@@ -2102,9 +1997,8 @@ namespace Rodin::IO
       // shard-aware) so that XDMF associates each value with the right
       // cell.
       const auto* shard = asShard(visMesh);
-      const size_t nc = shard
-        ? getXDMFRenderedCellCount(visMesh)
-        : visMesh.getCellCount();
+      const size_t nc =
+        shard ? getXDMFRenderedCellCount(visMesh) : visMesh.getCellCount();
       const size_t vdim = gf.getDimension();
       const size_t D = visMesh.getDimension();
 
@@ -2174,11 +2068,10 @@ namespace Rodin::IO
         // Defensive: invariant on (visMesh, gfMesh) cardinality (T2).
         if (values.size() != nc)
         {
-          Alert::Exception()
-            << "writeXDMFCellAttribute: emitted " << values.size()
-            << " values but expected " << nc
-            << " — visMesh and gfMesh cell cardinalities disagree."
-            << Alert::Raise;
+          Alert::Exception() << "writeXDMFCellAttribute: emitted " << values.size()
+                             << " values but expected " << nc
+                             << " — visMesh and gfMesh cell cardinalities disagree."
+                             << Alert::Raise;
         }
         HDF5::writeVectorDataset(file.get(), Path::GridFunctionValuesData, values);
       }
@@ -2199,11 +2092,10 @@ namespace Rodin::IO
         }
         if (values.size() != nc * vdim)
         {
-          Alert::Exception()
-            << "writeXDMFCellAttribute: emitted " << values.size()
-            << " values but expected " << (nc * vdim)
-            << " — visMesh and gfMesh cell cardinalities disagree."
-            << Alert::Raise;
+          Alert::Exception() << "writeXDMFCellAttribute: emitted " << values.size()
+                             << " values but expected " << (nc * vdim)
+                             << " — visMesh and gfMesh cell cardinalities disagree."
+                             << Alert::Raise;
         }
         HDF5::writeMatrixDataset(
             file.get(),

--- a/src/Rodin/IO/MEDIT.cpp
+++ b/src/Rodin/IO/MEDIT.cpp
@@ -127,7 +127,7 @@ namespace Rodin::IO
                 << Alert::Raise;
             }
             m_build.vertex(std::move(data->vertex));
-            m_build.attribute({ 0, vertex++ }, data->attribute);
+            m_build.attribute({0, vertex++}, data->attribute);
           }
           continue; // Continue the while loop
         }
@@ -148,8 +148,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Segment, std::move(data->vertices), index);
-            m_build.attribute({ 1, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Segment, std::move(data->vertices), index);
+            m_build.attribute({1, index}, data->attribute);
           }
           continue; // Continue the while loop
         }
@@ -170,8 +171,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Triangle, std::move(data->vertices), index);
-            m_build.attribute({ 2, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Triangle, std::move(data->vertices), index);
+            m_build.attribute({2, index}, data->attribute);
           }
           continue; // Continue the while loop
         }
@@ -192,8 +194,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Quadrilateral, std::move(data->vertices), index);
-            m_build.attribute({ 2, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Quadrilateral, std::move(data->vertices), index);
+            m_build.attribute({2, index}, data->attribute);
           }
           continue; // Continue the while loop
         }
@@ -214,8 +217,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Wedge, std::move(data->vertices), index);
-            m_build.attribute({ 3, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Wedge, std::move(data->vertices), index);
+            m_build.attribute({3, index}, data->attribute);
           }
           continue;
         }
@@ -236,8 +240,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Pyramid, std::move(data->vertices), index);
-            m_build.attribute({ 3, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Pyramid, std::move(data->vertices), index);
+            m_build.attribute({3, index}, data->attribute);
           }
           continue;
         }
@@ -258,8 +263,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Tetrahedron, std::move(data->vertices), index);
-            m_build.attribute({ 3, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Tetrahedron, std::move(data->vertices), index);
+            m_build.attribute({3, index}, data->attribute);
           }
           continue; // Continue the while loop
         }
@@ -280,8 +286,9 @@ namespace Rodin::IO
             }
             data->vertices -= 1;
             Index index;
-            m_build.polytope(Geometry::Polytope::Type::Hexahedron, std::move(data->vertices), index);
-            m_build.attribute({ 3, index }, data->attribute);
+            m_build.polytope(
+              Geometry::Polytope::Type::Hexahedron, std::move(data->vertices), index);
+            m_build.attribute({3, index}, data->attribute);
           }
           continue; // Continue the while loop
         }

--- a/src/Rodin/IO/XDMF.cpp
+++ b/src/Rodin/IO/XDMF.cpp
@@ -307,8 +307,7 @@ namespace Rodin::IO
       snapshot.cellCount = HDF5::getXDMFRenderedCellCount(*gr.mesh);
       snapshot.meshDimension = gr.mesh->getDimension();
       snapshot.spaceDimension = gr.mesh->getSpaceDimension();
-      const auto topologyLayout =
-        HDF5::getXDMFTopologyLayout(*gr.mesh, !m_distributed);
+      const auto topologyLayout = HDF5::getXDMFTopologyLayout(*gr.mesh, !m_distributed);
       snapshot.topologySize = topologyLayout.entryCount;
       snapshot.topologyIsUniform = topologyLayout.isUniform;
       snapshot.topologyType = topologyLayout.topologyType;
@@ -432,9 +431,8 @@ namespace Rodin::IO
     os << indent(bi) << "<Grid Name=\"" << gridName << "\" GridType=\"Uniform\">\n";
     os << indent(bi + 1) << "<Time Value=\"" << snap.time << "\" />\n";
 
-    os << indent(bi + 1) << "<Topology TopologyType=\""
-       << snap.topologyType << "\" NumberOfElements=\""
-       << snap.cellCount << "\">\n";
+    os << indent(bi + 1) << "<Topology TopologyType=\"" << snap.topologyType
+       << "\" NumberOfElements=\"" << snap.cellCount << "\">\n";
     // Precision="8" is required here because the HDF5 topology dataset is U64.
     // Without Precision, some XDMF readers may assume 32-bit UInt and misread
     // the dataset.
@@ -444,8 +442,7 @@ namespace Rodin::IO
       os << snap.topologyRows << " " << snap.topologyColumns;
     else
       os << snap.topologySize;
-    os << "\">" << meshH5 << ":" << HDF5::Path::MeshXDMFTopology
-       << "</DataItem>\n";
+    os << "\">" << meshH5 << ":" << HDF5::Path::MeshXDMFTopology << "</DataItem>\n";
     os << indent(bi + 1) << "</Topology>\n";
 
     os << indent(bi + 1) << "<Geometry GeometryType=\""

--- a/src/Rodin/MMG/Common.cpp
+++ b/src/Rodin/MMG/Common.cpp
@@ -10,16 +10,16 @@ namespace Rodin::MMG
 {
   const char* getISCDMshdistExecutable()
   {
-   return ISCD_MSHDIST_EXECUTABLE;
+    return iscdMshdistExecutable;
   }
 
   const char* getISCDAdvectExecutable()
   {
-   return ISCD_ADVECTION_EXECUTABLE;
+    return iscdAdvectionExecutable;
   }
 
   int getMMGVerbosityLevel()
   {
-   return VERBOSITY_LEVEL;
+    return verbosityLevel;
   }
 }

--- a/src/Rodin/MMG/Configure.h.in
+++ b/src/Rodin/MMG/Configure.h.in
@@ -19,25 +19,25 @@ namespace Rodin::MMG
   /**
    * @brief Path to the ISCD Mshdist executable.
    */
-  inline constexpr const char* ISCD_MSHDIST_EXECUTABLE =
+  inline constexpr const char* iscdMshdistExecutable =
     "@RODIN_ISCD_MSHDIST_EXECUTABLE@";
 
   /**
    * @brief Path to the Mshdist executable used by MMG helpers.
    */
-  inline constexpr const char* MSHDIST_EXECUTABLE =
+  inline constexpr const char* mshdistExecutable =
     "@RODIN_ISCD_MSHDIST_EXECUTABLE@";
 
   /**
    * @brief Path to the ISCD Mshdist executable.
    */
-  inline constexpr const char* ISCD_ADVECTION_EXECUTABLE =
+  inline constexpr const char* iscdAdvectionExecutable =
     "@RODIN_ISCD_ADVECTION_EXECUTABLE@";
 
   /**
    * @brief Path to the ISCD advection executable used by MMG helpers.
    */
-  inline constexpr const char* ADVECTION_EXECUTABLE =
+  inline constexpr const char* advectionExecutable =
     "@RODIN_ISCD_ADVECTION_EXECUTABLE@";
 
   /**
@@ -45,7 +45,9 @@ namespace Rodin::MMG
    *
    * Ranges from -1 to INT_MAX. A higher number means more verbose output.
    */
-  inline constexpr const int VERBOSITY_LEVEL = @RODIN_MMG_VERBOSITY_LEVEL@;
+  // clang-format off
+  inline constexpr const int verbosityLevel = @RODIN_MMG_VERBOSITY_LEVEL@;
+  // clang-format on
 }
 
 #endif

--- a/src/Rodin/MMG/LevelSetDiscretizer.cpp
+++ b/src/Rodin/MMG/LevelSetDiscretizer.cpp
@@ -287,8 +287,8 @@ namespace Rodin::MMG
       if (newna > 0)
       {
         MMG5_SAFE_CALLOC(edges, newna + 1, MMG5_Edge,
-            Alert::MemberFunctionException(*this, __func__)
-              << "Failed to reallocate edge memory." << Alert::Raise);
+          Alert::MemberFunctionException(*this, __func__)
+            << "Failed to reallocate edge memory." << Alert::Raise);
         for (size_t i = 1; i <= newna; i++)
           edges[i] = mesh->edge[ids[i - 1]];
         mesh->namax = newna;
@@ -315,8 +315,8 @@ namespace Rodin::MMG
       if (newnt > 0)
       {
         MMG5_SAFE_CALLOC(triangles, newnt + 1, MMG5_Tria,
-            Alert::MemberFunctionException(*this, __func__)
-              << "Failed to reallocate triangles." << Alert::Raise);
+          Alert::MemberFunctionException(*this, __func__)
+            << "Failed to reallocate triangles." << Alert::Raise);
         for (size_t i = 1; i <= newnt; i++)
           triangles[i] = mesh->tria[ids[i - 1]];
         mesh->ntmax = newnt;

--- a/src/Rodin/MMG/MMG5.cpp
+++ b/src/Rodin/MMG/MMG5.cpp
@@ -316,8 +316,8 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
   assert(isSurface || (src.getSpaceDimension() == src.getDimension()));
   const auto* ptr = dynamic_cast<const MMG::Mesh*>(&src);
 
-  MMG5_pMesh res = createMesh(
-      s_meshVersionFormatted, src.getDimension(), src.getSpaceDimension());
+  MMG5_pMesh res =
+    createMesh(sMeshVersionFormatted, src.getDimension(), src.getSpaceDimension());
 
   res->npi = 0;
   res->nai = 0;
@@ -507,8 +507,7 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
     constexpr size_t cellDim = 3;
     const bool hasFaceCellIncidence =
       src.getConnectivity().getIncidence(faceDim, cellDim).size() > 0;
-    const auto isMMG3DBoundaryTriangle = [&](Index faceIdx)
-    {
+    const auto isMMG3DBoundaryTriangle = [&](Index faceIdx) {
       return !hasFaceCellIncidence || src.isBoundary(faceIdx);
     };
 
@@ -825,9 +824,8 @@ MMG5_pMesh MMG5::rodinToMesh(const Rodin::Geometry::LocalMesh& src)
             static_cast<size_t>(src->tria[i].v[1] - 1),
             static_cast<size_t>(src->tria[i].v[2] - 1) });
       build.attribute({ 2, i - 1 }, src->tria[i].ref );
-      if ((src->tria[i].tag[0] & MG_REQ) &&
-          (src->tria[i].tag[1] & MG_REQ) &&
-          (src->tria[i].tag[2] & MG_REQ))
+      if ((src->tria[i].tag[0] & MG_REQ) && (src->tria[i].tag[1] & MG_REQ) &&
+        (src->tria[i].tag[2] & MG_REQ))
         build.requiredTriangle(i - 1);
     }
     // Add tetrahedra

--- a/src/Rodin/MMG/MMG5.h
+++ b/src/Rodin/MMG/MMG5.h
@@ -72,7 +72,7 @@ namespace Rodin::MMG
   {
     public:
       /// MMG mesh version tag used in generated MMG mesh objects.
-      static constexpr int s_meshVersionFormatted = 2;
+      static constexpr int sMeshVersionFormatted = 2;
 
       // ---- Mesh methods ---------------------------------------------------
       /**

--- a/src/Rodin/MMG/Mesh.h
+++ b/src/Rodin/MMG/Mesh.h
@@ -300,8 +300,10 @@ namespace Rodin::MMG
           RidgeIndex  m_ridgeIndex; ///< Ridge edge set accumulated during build.
           RequiredVertexIndex m_requiredVertexIndex; ///< Required-vertex set accumulated during build.
           RequiredEdgeIndex m_requiredEdgeIndex; ///< Required-edge set accumulated during build.
-          RequiredTriangleIndex m_requiredTriangleIndex; ///< Required-triangle set accumulated during build.
-          RequiredTetrahedronIndex m_requiredTetrahedronIndex; ///< Required-tetrahedron set accumulated during build.
+          RequiredTriangleIndex
+            m_requiredTriangleIndex; ///< Required-triangle set accumulated during build.
+          RequiredTetrahedronIndex
+            m_requiredTetrahedronIndex; ///< Required-tetrahedron set accumulated during build.
       };
 
       /**
@@ -574,8 +576,10 @@ namespace Rodin::MMG
     private:
       CornerIndex m_cornerIndex; ///< Corner vertex indices (`MG_CRN`).
       RequiredVertexIndex m_requiredVertexIndex; ///< Required vertex indices (`MG_REQ` on vertices).
-      RequiredTriangleIndex m_requiredTriangleIndex; ///< Required triangle indices (`MG_REQ` on triangle entities).
-      RequiredTetrahedronIndex m_requiredTetrahedronIndex; ///< Required tetrahedron indices (`MG_REQ` on tetrahedra).
+      RequiredTriangleIndex
+        m_requiredTriangleIndex; ///< Required triangle indices (`MG_REQ` on triangle entities).
+      RequiredTetrahedronIndex
+        m_requiredTetrahedronIndex; ///< Required tetrahedron indices (`MG_REQ` on tetrahedra).
 
       RidgeIndex  m_ridgeIndex; ///< Ridge edge indices (`MG_GEO`).
       RequiredEdgeIndex m_requiredEdgeIndex; ///< Required edge indices (`MG_REQ` on edges).

--- a/src/Rodin/MMG/MeshOptimizer.h
+++ b/src/Rodin/MMG/MeshOptimizer.h
@@ -112,7 +112,8 @@ namespace Rodin::MMG
             mesh.setRequiredEdge(idx);
         }
         mesh.getRequiredTriangles().clear();
-        const size_t triangleCount = mesh.getPolytopeCount(Geometry::Polytope::Type::Triangle);
+        const size_t triangleCount =
+          mesh.getPolytopeCount(Geometry::Polytope::Type::Triangle);
         for (const auto& idx : requiredTriangles)
         {
           if (idx < triangleCount)

--- a/src/Rodin/MMG/MeshPrinter.cpp
+++ b/src/Rodin/MMG/MeshPrinter.cpp
@@ -75,10 +75,8 @@ namespace Rodin::MMG
   void MeshPrinter::printRequiredTriangles(std::ostream& os)
   {
     const auto& mesh = getObject();
-    os << IO::MEDIT::Keyword::RequiredTriangles
-       << '\n'
-       << mesh.getRequiredTriangles().size()
-       << '\n';
+    os << IO::MEDIT::Keyword::RequiredTriangles << '\n'
+       << mesh.getRequiredTriangles().size() << '\n';
     for (const auto& r : mesh.getRequiredTriangles())
       os << r + 1 << '\n';
     os << '\n';
@@ -87,10 +85,8 @@ namespace Rodin::MMG
   void MeshPrinter::printRequiredTetrahedra(std::ostream& os)
   {
     const auto& mesh = getObject();
-    os << IO::MEDIT::Keyword::RequiredTetrahedra
-       << '\n'
-       << mesh.getRequiredTetrahedra().size()
-       << '\n';
+    os << IO::MEDIT::Keyword::RequiredTetrahedra << '\n'
+       << mesh.getRequiredTetrahedra().size() << '\n';
     for (const auto& r : mesh.getRequiredTetrahedra())
       os << r + 1 << '\n';
     os << '\n';

--- a/src/Rodin/MPI/Assembly/MPI.h
+++ b/src/Rodin/MPI/Assembly/MPI.h
@@ -275,9 +275,9 @@ namespace Rodin::Assembly
         const auto& u = input.getOperand();
         auto& Av = const_cast<ValueType&>(input.getShapeFunction());
         const auto& essBdr = input.getEssentialBoundary();
-        const auto& fes_u = u.getFiniteElementSpace();
-        const auto& fes_v = Av.getLeaf().getFiniteElementSpace();
-        const auto& mesh  = fes_u.getMesh();
+        const auto& fesU = u.getFiniteElementSpace();
+        const auto& fesV = Av.getLeaf().getFiniteElementSpace();
+        const auto& mesh = fesU.getMesh();
         const size_t faceDim = mesh.getDimension() - 1;
 
         res.clear();
@@ -292,16 +292,14 @@ namespace Rodin::Assembly
             if (!a || !essBdr.contains(*a)) return;
           }
 
-          const auto& fe_u = fes_u.getFiniteElement(faceDim, fi);
-          const auto& fe_v = fes_v.getFiniteElement(faceDim, fi);
-          const auto& slaveDOFs  = fes_u.getDOFs(faceDim, fi);
-          const auto& masterDOFs = fes_v.getDOFs(faceDim, fi);
+          const auto& feU = fesU.getFiniteElement(faceDim, fi);
+          const auto& feV = fesV.getFiniteElement(faceDim, fi);
+          const auto& slaveDOFs = fesU.getDOFs(faceDim, fi);
+          const auto& masterDOFs = fesV.getDOFs(faceDim, fi);
 
-          const Index nMasters = static_cast<Index>(fe_v.getCount());
+          const Index nMasters = static_cast<Index>(feV.getCount());
 
-          for (Index s = 0;
-               s < static_cast<Index>(fe_u.getCount());
-               s++)
+          for (Index s = 0; s < static_cast<Index>(feU.getCount()); s++)
           {
             const Index slave = slaveDOFs[s];
             auto pos = res.find(slave);
@@ -322,9 +320,8 @@ namespace Rodin::Assembly
                 return Av.getBasis(static_cast<size_t>(j));
               };
               const auto mapping =
-                fes_u.getPullback({ faceDim, fi }, std::move(basisCallable));
-              const Scalar c =
-                static_cast<Scalar>(fe_u.getLinearForm(s)(mapping));
+                fesU.getPullback({faceDim, fi}, std::move(basisCallable));
+              const Scalar c = static_cast<Scalar>(feU.getLinearForm(s)(mapping));
               if (c != Scalar(0))
               {
                 mIdx.push_back(masterDOFs[j]);

--- a/src/Rodin/MPI/Variational/FiniteElementSpace.h
+++ b/src/Rodin/MPI/Variational/FiniteElementSpace.h
@@ -120,6 +120,44 @@ namespace Rodin::Variational
       {
         return static_cast<const Derived&>(*this).geInverseMapping(idx, v);
       }
+
+      /**
+       * @brief Evaluates a distributed finite element expansion on a physical element.
+       *
+       * The local reference expansion is formed from the shard coefficients and
+       * the derived space pushforward is applied once to the complete function:
+       * @f[
+       *   u_h(x)
+       *   =
+       *   \psi_K^{-1}
+       *   \left(
+       *     \sum_i c_i \widehat{\varphi}_i
+       *   \right)(x).
+       * @f]
+       * The operation is independent of the range transformation used by the
+       * space and therefore also applies to Piola-mapped finite elements.
+       *
+       * @tparam Range Range type of the finite element expansion.
+       * @tparam Coefficient Callable returning a local shard coefficient.
+       * @param[out] out Value of the expansion.
+       * @param[in] idx Dimension and local index of the physical element.
+       * @param[in] coefficient Local coefficient accessor.
+       * @param[in] p Point on the physical element.
+       */
+      template <class Range, class Coefficient>
+      void evaluate(Range& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& derived = static_cast<const Derived&>(*this);
+        const auto& fe = derived.getFiniteElement(idx.first, idx.second);
+        const auto expansion = [&](const Math::SpatialPoint& rc) {
+          Range value;
+          fe.evaluate(value, coefficient, rc);
+          return value;
+        };
+        const auto mapping = derived.getPushforward(idx, expansion);
+        out = mapping(p);
+      }
   };
 }
 

--- a/src/Rodin/MPI/Variational/H1/H1.h
+++ b/src/Rodin/MPI/Variational/H1/H1.h
@@ -261,7 +261,7 @@ namespace Rodin::Variational
        */
       Index getGlobalIndex(Index localIdx) const
       {
-        return m_local_to_global.left.at(localIdx);
+        return m_localToGlobal.left.at(localIdx);
       }
 
       /**
@@ -269,8 +269,8 @@ namespace Rodin::Variational
        */
       Optional<Index> getLocalIndex(Index globalIdx) const
       {
-        auto it = m_local_to_global.right.find(globalIdx);
-        if (it == m_local_to_global.right.end())
+        auto it = m_localToGlobal.right.find(globalIdx);
+        if (it == m_localToGlobal.right.end())
           return std::nullopt;
         return it->second;
       }
@@ -348,8 +348,7 @@ namespace Rodin::Variational
        * @brief Returns a pushforward wrapper on local polytope @f$(d, i)@f$.
        */
       template <class CallableType>
-      auto getPushforward(
-          const std::pair<size_t, Index>&, CallableType&& v) const
+      auto getPushforward(const std::pair<size_t, Index>&, CallableType&& v) const
       {
         return Pushforward<CallableType>(std::forward<CallableType>(v));
       }
@@ -361,6 +360,18 @@ namespace Rodin::Variational
       auto getPushforward(const Geometry::Polytope&, CallableType&& v) const
       {
         return Pushforward<CallableType>(std::forward<CallableType>(v));
+      }
+
+      /**
+       * @brief Evaluates the local shard expansion directly at reference coordinates.
+       */
+      template <class Coefficient>
+      void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:
@@ -424,22 +435,21 @@ namespace Rodin::Variational
             // Fekete tet ordering.
             // tetraTotal = (K+1)(K+2)(K+3)/6
             // For (i,j,k) with i+j+k <= K, i,j,k >= 0:
-            //   offset_k = tetraTotal - (K-k+1)(K-k+2)(K-k+3)/6
-            //   offset_j = j*(K-k+1) - j*(j-1)/2
-            //   idx      = offset_k + offset_j + i
+            //   offsetK = tetraTotal - (K-k+1)(K-k+2)(K-k+3)/6
+            //   offsetJ = j*(K-k+1) - j*(j-1)/2
+            //   idx      = offsetK + offsetJ + i
             // Interior: i > 0, j > 0, k > 0, i+j+k < K
             const size_t tetraTotal = (K + 1) * (K + 2) * (K + 3) / 6;
             for (size_t k = 1; k + 2 < K; ++k)          // k <= K-3
             {
-              const size_t m_tail   = K - k;
-              const size_t tetraTail =
-                  (m_tail + 1) * (m_tail + 2) * (m_tail + 3) / 6;
-              const size_t offset_k = tetraTotal - tetraTail;
+              const size_t tail = K - k;
+              const size_t tetraTail = (tail + 1) * (tail + 2) * (tail + 3) / 6;
+              const size_t offsetK = tetraTotal - tetraTail;
               for (size_t j = 1; j + k + 1 < K; ++j)    // j <= K-k-2
               {
-                const size_t offset_j = j * (K - k + 1) - j * (j - 1) / 2;
+                const size_t offsetJ = j * (K - k + 1) - j * (j - 1) / 2;
                 for (size_t i = 1; i + j + k < K; ++i)  // i <= K-j-k-1
-                  res.push_back(offset_k + offset_j + i);
+                  res.push_back(offsetK + offsetJ + i);
               }
             }
             break;
@@ -682,7 +692,7 @@ namespace Rodin::Variational
       }
 
       /**
-       * @brief Core DOF-numbering algorithm: builds m_local_to_global.
+       * @brief Core DOF-numbering algorithm: builds m_localToGlobal.
        *
        * For each entity dimension d = 0..D, owned entities receive contiguous
        * global DOF indices.  Non-owned entities obtain their global DOF
@@ -743,8 +753,7 @@ namespace Rodin::Variational
         // Step 3: pre-allocate local_to_global.left.
         // ------------------------------------------------------------------
         const size_t localDofCount = m_fes.getSize();
-        m_local_to_global.left.assign(
-            localDofCount, std::numeric_limits<Index>::max());
+        m_localToGlobal.left.assign(localDofCount, std::numeric_limits<Index>::max());
 
         // ------------------------------------------------------------------
         // Step 4: for each dimension, assign owned global indices and
@@ -802,7 +811,7 @@ namespace Rodin::Variational
 
             const auto& entityDOFs = m_fes.getDOFs(d, i);
             for (const size_t p : pos)
-              m_local_to_global.left[entityDOFs(p)] = dofIdx++;
+              m_localToGlobal.left[entityDOFs(p)] = dofIdx++;
           }
 
           // ----------------------------------------------------------------
@@ -811,9 +820,9 @@ namespace Rodin::Variational
           //     owner rank.  The halo is complete after reconcile() runs
           //     the holder-set propagation, so no all_to_all is required.
           // ----------------------------------------------------------------
-          const auto& halo_d = shard.getHalo(d);
+          const auto& dimensionHalo = shard.getHalo(d);
 
-          std::vector<std::vector<EntityMsg>> push_send(static_cast<size_t>(P));
+          std::vector<std::vector<EntityMsg>> pushSend(static_cast<size_t>(P));
 
           for (Index i = 0; i < static_cast<Index>(count); ++i)
           {
@@ -825,12 +834,12 @@ namespace Rodin::Variational
             if (pos.empty())
               continue;
 
-            auto hit = halo_d.find(i);
-            if (hit == halo_d.end())
+            auto hit = dimensionHalo.find(i);
+            if (hit == dimensionHalo.end())
               continue;
 
             const auto& entityDOFs = m_fes.getDOFs(d, i);
-            const Index  firstGDOF = m_local_to_global.left[entityDOFs(pos[0])];
+            const Index firstGDOF = m_localToGlobal.left[entityDOFs(pos[0])];
             const Index  gid       = mesh.getGlobalIndex(d, i);
             const auto   orderedVertexIDs = getOrderedVertexIDs(i);
 
@@ -839,40 +848,39 @@ namespace Rodin::Variational
               const int rh = static_cast<int>(h);
               if (rh == rank)
                 continue;
-              push_send[static_cast<size_t>(rh)].push_back(
-                  { gid, { firstGDOF, orderedVertexIDs } });
+              pushSend[static_cast<size_t>(rh)].push_back(
+                {gid, {firstGDOF, orderedVertexIDs}});
             }
           }
 
           // Build the symmetric neighbor set for dimension d from halo(d) ∪ owner(d).
           // Using all neighbors ensures every isend has a matching irecv and
           // no messages are orphaned between sequential FES constructions.
-          std::vector<int> neighbors_d;
+          std::vector<int> dimensionNeighbors;
           {
             UnorderedSet<int> nbrs;
-            const auto& halo_d_nbrs = shard.getHalo(d);
-            for (const auto& [i, peers] : halo_d_nbrs)
+            const auto& dimensionHaloNeighbors = shard.getHalo(d);
+            for (const auto& [i, peers] : dimensionHaloNeighbors)
               for (const Index r : peers)
                 if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
             for (const auto& [i, r] : owner)
               if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
-            neighbors_d.assign(nbrs.begin(), nbrs.end());
+            dimensionNeighbors.assign(nbrs.begin(), nbrs.end());
           }
 
           // Tag 100+d is reserved for H1 entity-push DOF exchange at dimension d
           // and does not overlap with SubMesh (10,11) or other FES (50,51,52) tags.
-          const int tag_push = 100 + static_cast<int>(d);
+          const int pushTag = 100 + static_cast<int>(d);
 
-          UnorderedMap<int, std::vector<EntityMsg>> push_recv;
+          UnorderedMap<int, std::vector<EntityMsg>> pushReceive;
           std::vector<boost::mpi::request> reqs;
-          reqs.reserve(2 * neighbors_d.size());
+          reqs.reserve(2 * dimensionNeighbors.size());
 
-          for (int r : neighbors_d)
+          for (int r : dimensionNeighbors)
           {
-            push_recv[r]; // default-construct
-            reqs.push_back(comm.irecv(r, tag_push, push_recv[r]));
-            reqs.push_back(comm.isend(r, tag_push,
-                push_send[static_cast<size_t>(r)]));
+            pushReceive[r]; // default-construct
+            reqs.push_back(comm.irecv(r, pushTag, pushReceive[r]));
+            reqs.push_back(comm.isend(r, pushTag, pushSend[static_cast<size_t>(r)]));
           }
 
           boost::mpi::wait_all(reqs.begin(), reqs.end());
@@ -880,7 +888,7 @@ namespace Rodin::Variational
           // ----------------------------------------------------------------
           // 4c. Install received global DOF numbering for non-owned entities.
           // ----------------------------------------------------------------
-          for (auto& [r, msgs] : push_recv)
+          for (auto& [r, msgs] : pushReceive)
           {
             for (const auto& [gid, payload] : msgs)
             {
@@ -899,8 +907,8 @@ namespace Rodin::Variational
               {
                 const auto ownerK = orientedOwnerOrdinal(
                     g, pos, k, localVertexIDs, ownerVertexIDs);
-                m_local_to_global.left[entityDOFs(pos[k])] =
-                    firstGDOF + static_cast<Index>(ownerK.value_or(k));
+                m_localToGlobal.left[entityDOFs(pos[k])] =
+                  firstGDOF + static_cast<Index>(ownerK.value_or(k));
               }
             }
           }
@@ -913,13 +921,13 @@ namespace Rodin::Variational
         // ------------------------------------------------------------------
 #ifndef NDEBUG
         for (size_t local = 0; local < localDofCount; ++local)
-          assert(m_local_to_global.left[local] != std::numeric_limits<Index>::max());
+          assert(m_localToGlobal.left[local] != std::numeric_limits<Index>::max());
 #endif
 
         for (size_t local = 0; local < localDofCount; ++local)
         {
-          const Index global = m_local_to_global.left[local];
-          m_local_to_global.right.emplace(global, static_cast<Index>(local));
+          const Index global = m_localToGlobal.left[local];
+          m_localToGlobal.right.emplace(global, static_cast<Index>(local));
         }
       }
 
@@ -929,7 +937,7 @@ namespace Rodin::Variational
       size_t m_offset;
       size_t m_owned;
       size_t m_globalSize;
-      IndexBimap m_local_to_global;
+      IndexBimap m_localToGlobal;
   };
 
 
@@ -1157,8 +1165,7 @@ namespace Rodin::Variational
         //   [scalarBegin * vdim, scalarEnd * vdim)
         // ------------------------------------------------------------------
         const size_t localVecSize = m_fes.getSize();
-        m_local_to_global.left.assign(
-            localVecSize, std::numeric_limits<Index>::max());
+        m_localToGlobal.left.assign(localVecSize, std::numeric_limits<Index>::max());
 
         for (size_t localScalar = 0; localScalar < scalarLocalSize; ++localScalar)
         {
@@ -1172,19 +1179,19 @@ namespace Rodin::Variational
             const Index globalVec =
                 static_cast<Index>(globalScalar * vdim + c);
 
-            m_local_to_global.left[localVec] = globalVec;
+            m_localToGlobal.left[localVec] = globalVec;
           }
         }
 
 #ifndef NDEBUG
         for (size_t local = 0; local < localVecSize; ++local)
-          assert(m_local_to_global.left[local] != std::numeric_limits<Index>::max());
+          assert(m_localToGlobal.left[local] != std::numeric_limits<Index>::max());
 #endif
 
         for (size_t local = 0; local < localVecSize; ++local)
         {
-          const Index global = m_local_to_global.left[local];
-          m_local_to_global.right.emplace(global, static_cast<Index>(local));
+          const Index global = m_localToGlobal.left[local];
+          m_localToGlobal.right.emplace(global, static_cast<Index>(local));
         }
       }
 
@@ -1217,7 +1224,7 @@ namespace Rodin::Variational
        */
       Index getGlobalIndex(Index localIdx) const
       {
-        return m_local_to_global.left.at(localIdx);
+        return m_localToGlobal.left.at(localIdx);
       }
 
       /**
@@ -1225,8 +1232,8 @@ namespace Rodin::Variational
        */
       Optional<Index> getLocalIndex(Index globalIdx) const
       {
-        auto it = m_local_to_global.right.find(globalIdx);
-        if (it == m_local_to_global.right.end())
+        auto it = m_localToGlobal.right.find(globalIdx);
+        if (it == m_localToGlobal.right.end())
           return std::nullopt;
         return it->second;
       }
@@ -1304,8 +1311,7 @@ namespace Rodin::Variational
        * @brief Returns a pushforward wrapper on local polytope @f$(d, i)@f$.
        */
       template <class CallableType>
-      auto getPushforward(
-          const std::pair<size_t, Index>&, CallableType&& v) const
+      auto getPushforward(const std::pair<size_t, Index>&, CallableType&& v) const
       {
         return Pushforward<CallableType>(std::forward<CallableType>(v));
       }
@@ -1319,6 +1325,18 @@ namespace Rodin::Variational
         return Pushforward<CallableType>(std::forward<CallableType>(v));
       }
 
+      /**
+       * @brief Evaluates the local shard expansion directly at reference coordinates.
+       */
+      template <class Coefficient>
+      void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
+      }
+
     private:
       std::reference_wrapper<const MeshType> m_mesh;
       FESType m_fes;
@@ -1327,7 +1345,7 @@ namespace Rodin::Variational
       size_t m_offset;
       size_t m_owned;
       size_t m_globalSize;
-      IndexBimap m_local_to_global;
+      IndexBimap m_localToGlobal;
   };
 }
 

--- a/src/Rodin/MPI/Variational/P0/P0.h
+++ b/src/Rodin/MPI/Variational/P0/P0.h
@@ -280,7 +280,7 @@ namespace Rodin::Variational
 
         // For P0, the local DOF index for cell i equals i (the cell index).
         // Pre-allocate the left map with an invalid sentinel.
-        m_local_to_global.left.assign(localCellCount, std::numeric_limits<Index>::max());
+        m_localToGlobal.left.assign(localCellCount, std::numeric_limits<Index>::max());
 
         // send[r]: messages to rank r — pairs (globalCellID, globalDOF).
         // Keyed by rank so every neighbor gets an entry (possibly empty).
@@ -313,8 +313,8 @@ namespace Rodin::Variational
           const Index gid    = mesh.getGlobalIndex(D, i);
           const Index global = m_offset + dofIdx++;
 
-          m_local_to_global.left[i] = global;
-          m_local_to_global.right.emplace(global, static_cast<Index>(i));
+          m_localToGlobal.left[i] = global;
+          m_localToGlobal.right.emplace(global, static_cast<Index>(i));
 
           // Notify all neighbors that have this cell as a ghost.
           auto hit = halo.find(i);
@@ -364,14 +364,14 @@ namespace Rodin::Variational
             const Index li = *liOpt;
             assert(!shard.isOwned(D, li));
 
-            m_local_to_global.left[li] = global;
-            m_local_to_global.right.emplace(global, li);
+            m_localToGlobal.left[li] = global;
+            m_localToGlobal.right.emplace(global, li);
           }
         }
 
 #ifndef NDEBUG
         for (size_t i = 0; i < localCellCount; ++i)
-          assert(m_local_to_global.left[i] != std::numeric_limits<Index>::max());
+          assert(m_localToGlobal.left[i] != std::numeric_limits<Index>::max());
 #endif
       }
 
@@ -425,7 +425,7 @@ namespace Rodin::Variational
        */
       Index getGlobalIndex(Index localIdx) const
       {
-        return m_local_to_global.left.at(localIdx);
+        return m_localToGlobal.left.at(localIdx);
       }
 
       /**
@@ -439,8 +439,8 @@ namespace Rodin::Variational
        */
       Optional<Index> getLocalIndex(Index globalIdx) const
       {
-        auto it = m_local_to_global.right.find(globalIdx);
-        if (it == m_local_to_global.right.end())
+        auto it = m_localToGlobal.right.find(globalIdx);
+        if (it == m_localToGlobal.right.end())
           return std::nullopt;
         return it->second;
       }
@@ -585,7 +585,7 @@ namespace Rodin::Variational
 
       size_t m_offset;
       size_t m_owned;
-      IndexBimap m_local_to_global;
+      IndexBimap m_localToGlobal;
   };
 }
 

--- a/src/Rodin/MPI/Variational/P1/P1.h
+++ b/src/Rodin/MPI/Variational/P1/P1.h
@@ -353,8 +353,8 @@ namespace Rodin::Variational
           send[r]; // default-construct empty entry
 
         // owned + non-owned is a good upper bound
-        std::vector<std::pair<Index, Index>> gl_pairs;
-        gl_pairs.reserve(shard.getVertexCount());
+        std::vector<std::pair<Index, Index>> globalLocalPairs;
+        globalLocalPairs.reserve(shard.getVertexCount());
 
         // Number every owned local vertex.
         Index dofIdx = 0;
@@ -367,7 +367,7 @@ namespace Rodin::Variational
           const Index local  = m_fes.getDOFs(0, lv)[0];
           const Index global = m_offset + dofIdx++;
 
-          gl_pairs.push_back({ global, local });
+          globalLocalPairs.push_back({global, local});
 
           // Notify all neighbors that also hold this vertex.
           auto hit = halo.find(lv);
@@ -420,35 +420,33 @@ namespace Rodin::Variational
             assert(!shard.isOwned(0, lv));
 
             const Index local = m_fes.getDOFs(0, lv)[0];
-            gl_pairs.push_back({ global, local });
+            globalLocalPairs.push_back({global, local});
           }
         }
 
-        std::sort(gl_pairs.begin(), gl_pairs.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        std::sort(globalLocalPairs.begin(), globalLocalPairs.end(),
+          [](const auto& a, const auto& b) { return a.first < b.first; });
 
-        gl_pairs.erase(
-            std::unique(gl_pairs.begin(), gl_pairs.end(),
-                        [](const auto& a, const auto& b)
-                        {
-                          return a.first == b.first;
-                        }),
-            gl_pairs.end());
+        globalLocalPairs.erase(
+          std::unique(globalLocalPairs.begin(), globalLocalPairs.end(),
+            [](const auto& a, const auto& b) { return a.first == b.first; }),
+          globalLocalPairs.end());
 
-        m_local_to_global.right = FlatMap<Index, Index>(gl_pairs.begin(), gl_pairs.end());
+        m_localToGlobal.right =
+          FlatMap<Index, Index>(globalLocalPairs.begin(), globalLocalPairs.end());
 
         const size_t localDofCount = m_fes.getSize();
-        m_local_to_global.left.assign(localDofCount, std::numeric_limits<Index>::max());
+        m_localToGlobal.left.assign(localDofCount, std::numeric_limits<Index>::max());
 
-        for (const auto& [global, local] : m_local_to_global.right)
+        for (const auto& [global, local] : m_localToGlobal.right)
         {
           assert(local < localDofCount);
-          m_local_to_global.left[local] = global;
+          m_localToGlobal.left[local] = global;
         }
 
 #ifndef NDEBUG
         for (size_t local = 0; local < localDofCount; ++local)
-          assert(m_local_to_global.left[local] != std::numeric_limits<Index>::max());
+          assert(m_localToGlobal.left[local] != std::numeric_limits<Index>::max());
 #endif
       }
 
@@ -523,7 +521,7 @@ namespace Rodin::Variational
               const Index global = m_offset + dofIdx;
               s_send.push_back(global);
 
-              const auto [it, inserted] = m_local_to_global.right.emplace(global, local);
+              const auto [it, inserted] = m_localToGlobal.right.emplace(global, local);
               assert(inserted);
 
               ++dofIdx;
@@ -580,24 +578,25 @@ namespace Rodin::Variational
 
             for (size_t k = 0; k < global.size(); ++k)
             {
-              const auto [it, inserted] = m_local_to_global.right.emplace(global[k], dofs[k]);
+              const auto [it, inserted] =
+                m_localToGlobal.right.emplace(global[k], dofs[k]);
               assert(inserted);
             }
           }
         }
 
         const size_t localDofCount = m_fes.getSize();
-        m_local_to_global.left.assign(localDofCount, std::numeric_limits<Index>::max());
+        m_localToGlobal.left.assign(localDofCount, std::numeric_limits<Index>::max());
 
-        for (const auto& [global, local] : m_local_to_global.right)
+        for (const auto& [global, local] : m_localToGlobal.right)
         {
           assert(local < localDofCount);
-          m_local_to_global.left[local] = global;
+          m_localToGlobal.left[local] = global;
         }
 
 #ifndef NDEBUG
         for (size_t local = 0; local < localDofCount; ++local)
-          assert(m_local_to_global.left[local] != std::numeric_limits<Index>::max());
+          assert(m_localToGlobal.left[local] != std::numeric_limits<Index>::max());
 #endif
       }
 
@@ -649,7 +648,7 @@ namespace Rodin::Variational
        */
       Index getGlobalIndex(Index localIdx) const
       {
-        return m_local_to_global.left.at(localIdx);
+        return m_localToGlobal.left.at(localIdx);
       }
 
       /**
@@ -663,8 +662,8 @@ namespace Rodin::Variational
        */
       Optional<Index> getLocalIndex(Index globalIdx) const
       {
-        auto find = m_local_to_global.right.find(globalIdx);
-        if (find == m_local_to_global.right.end())
+        auto find = m_localToGlobal.right.find(globalIdx);
+        if (find == m_localToGlobal.right.end())
           return std::nullopt;
         else
           return *find;
@@ -803,7 +802,7 @@ namespace Rodin::Variational
         const auto& [d, i] = p;
         const auto& mesh = getMesh();
         return CallablePullback<CallableType>(
-            *mesh.getPolytope(d, i), std::forward<CallableType>(v));
+          *mesh.getPolytope(d, i), std::forward<CallableType>(v));
       }
 
       /**
@@ -817,7 +816,7 @@ namespace Rodin::Variational
       auto getPushforward(const std::pair<size_t, Index>&, CallableType&& v) const
       {
         return typename FESType::template Pushforward<CallableType>(
-            std::forward<CallableType>(v));
+          std::forward<CallableType>(v));
       }
 
       /**
@@ -831,7 +830,19 @@ namespace Rodin::Variational
       auto getPushforward(const Geometry::Polytope&, CallableType&& v) const
       {
         return typename FESType::template Pushforward<CallableType>(
-            std::forward<CallableType>(v));
+          std::forward<CallableType>(v));
+      }
+
+      /**
+       * @brief Evaluates the local shard expansion directly at reference coordinates.
+       */
+      template <class Coefficient>
+      void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:
@@ -840,7 +851,7 @@ namespace Rodin::Variational
 
       size_t m_offset;
       size_t m_owned;
-      IndexBimap m_local_to_global;
+      IndexBimap m_localToGlobal;
   };
 }
 

--- a/src/Rodin/Math/Common.h
+++ b/src/Rodin/Math/Common.h
@@ -83,7 +83,7 @@ namespace Rodin::Math
   constexpr
   auto conj(const Eigen::MatrixBase<T>& x)
   {
-    return x.conjugate();
+    return x.conjugate().eval();
   }
 
   /**

--- a/src/Rodin/Math/SpatialMatrix.h
+++ b/src/Rodin/Math/SpatialMatrix.h
@@ -1270,8 +1270,7 @@ namespace Rodin::Math
       }
 
       /// @brief Returns the componentwise additive inverse of this matrix.
-      constexpr
-      SpatialMatrix operator-() const noexcept
+      constexpr SpatialMatrix operator-() const noexcept
       {
         SpatialMatrix result(*this);
         result *= Scalar(-1);

--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -89,14 +89,11 @@ namespace Rodin::Assembly
         const size_t ownedSize = end - begin;
 
         PetscErrorCode ierr;
-        ierr = PETSc::Assembly::VectorSetup(res).prepare({
-          static_cast<PetscInt>(ownedSize),
-          static_cast<PetscInt>(globalSize),
-          nullptr,
-          true
-        });
+        ierr =
+          PETSc::Assembly::VectorSetup(res).prepare({static_cast<PetscInt>(ownedSize),
+            static_cast<PetscInt>(globalSize), nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         for (auto& lfi : input.getLFIs())
         {
@@ -126,18 +123,18 @@ namespace Rodin::Assembly
               const PetscScalar v = lfi.integrate(i);
               ierr = VecSetValue(res, r, v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
 
         ierr = VecAssemblyBegin(res);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ierr = VecAssemblyEnd(res);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         (void) ierr;
       }
@@ -211,16 +208,12 @@ namespace Rodin::Assembly
         const size_t globalCols = trialFES.getSize();
 
         PetscErrorCode ierr;
-        ierr = PETSc::Assembly::MatrixSetup(res).prepare({
-          static_cast<PetscInt>(localRows),
-          static_cast<PetscInt>(localCols),
-          static_cast<PetscInt>(globalRows),
-          static_cast<PetscInt>(globalCols),
-          nullptr,
-          true
-        });
+        ierr =
+          PETSc::Assembly::MatrixSetup(res).prepare({static_cast<PetscInt>(localRows),
+            static_cast<PetscInt>(localCols), static_cast<PetscInt>(globalRows),
+            static_cast<PetscInt>(globalCols), nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         for (auto& bfi : input.getLocalBFIs())
         {
@@ -254,7 +247,7 @@ namespace Rodin::Assembly
                 const PetscScalar v = bfi.integrate(j, i);
                 ierr = MatSetValue(res, r, c, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
           }
@@ -262,11 +255,11 @@ namespace Rodin::Assembly
 
         ierr = MatAssemblyBegin(res, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ierr = MatAssemblyEnd(res, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         (void) ierr;
       }
@@ -336,10 +329,8 @@ namespace Rodin::Assembly
        * @param[in] input Single-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -360,10 +351,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         static_assert(
           std::is_same_v<MeshContextType, Rodin::Context::MPI>,
@@ -407,16 +395,12 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(localCols),
-            static_cast<PetscInt>(globalRows),
-            static_cast<PetscInt>(globalCols),
-            nullptr,
-            true
-          });
+          ierr =
+            PETSc::Assembly::MatrixSetup(A).prepare({static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(localCols), static_cast<PetscInt>(globalRows),
+              static_cast<PetscInt>(globalCols), nullptr, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -425,30 +409,21 @@ namespace Rodin::Assembly
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(globalRows),
-            nullptr,
-            true,
-            true
-          });
+          ierr =
+            PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(globalRows), nullptr, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(localCols),
-          static_cast<PetscInt>(globalCols),
-          nullptr,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(localCols),
+          static_cast<PetscInt>(globalCols), nullptr, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ConstraintMap<PetscScalar> constraints(std::max(globalRows, globalCols));
         using DBCBaseType = Variational::DirichletBCBase<PetscScalar>;
@@ -503,8 +478,7 @@ namespace Rodin::Assembly
             << Alert::Raise;
         }
 
-        auto matrix_entry = [&](Index row, Index col, PetscScalar val)
-        {
+        auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -519,7 +493,7 @@ namespace Rodin::Assembly
               {
                 ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
             if (doMatrix)
@@ -527,14 +501,13 @@ namespace Rodin::Assembly
               for (const auto& c : constraints.expand(col))
               {
                 const PetscInt J = static_cast<PetscInt>(c.index);
-                const PetscScalar v =
-                  r.coefficient * val * c.coefficient;
+                const PetscScalar v = r.coefficient * val * c.coefficient;
                 // Insert unconditionally. PETSc decides whether zero-valued
                 // insertions affect the pattern according to its current
                 // matrix options.
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
           }
@@ -550,7 +523,7 @@ namespace Rodin::Assembly
             const PetscScalar v = r.coefficient * val;
             ierr = VecSetValue(b, I, v, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         };
 
@@ -566,8 +539,8 @@ namespace Rodin::Assembly
 
             for (auto it = seq.getIterator(); it; ++it)
             {
-              const size_t d   = it->getDimension();
-              const Index  idx = it->getIndex();
+              const size_t d = it->getDimension();
+              const Index idx = it->getIndex();
 
               if (!shard.isOwned(d, idx))
                 continue;
@@ -605,15 +578,15 @@ namespace Rodin::Assembly
           for (auto& bfi : pb.getGlobalBFIs())
           {
             const auto& trialAttrs = bfi.getTrialAttributes();
-            const auto& testAttrs  = bfi.getTestAttributes();
+            const auto& testAttrs = bfi.getTestAttributes();
 
             MPIIteration trialseq(mesh, bfi.getTrialRegion());
-            MPIIteration testseq(mesh,  bfi.getTestRegion());
+            MPIIteration testseq(mesh, bfi.getTestRegion());
 
             for (auto teIt = testseq.getIterator(); teIt; ++teIt)
             {
-              const size_t td   = teIt->getDimension();
-              const Index  tidx = teIt->getIndex();
+              const size_t td = teIt->getDimension();
+              const Index tidx = teIt->getIndex();
 
               if (!shard.isOwned(td, tidx))
                 continue;
@@ -629,8 +602,8 @@ namespace Rodin::Assembly
 
               for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
               {
-                const size_t rd   = trIt->getDimension();
-                const Index  ridx = trIt->getIndex();
+                const size_t rd = trIt->getDimension();
+                const Index ridx = trIt->getIndex();
 
                 if (!trialAttrs.empty())
                 {
@@ -666,7 +639,7 @@ namespace Rodin::Assembly
             PetscInt opStart, opEnd;
             ierr = MatGetOwnershipRange(op, &opStart, &opEnd);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = opStart; i < opEnd; ++i)
             {
               PetscInt nc;
@@ -674,12 +647,12 @@ namespace Rodin::Assembly
               const PetscScalar* vals;
               ierr = MatGetRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (PetscInt j = 0; j < nc; ++j)
                 matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
               ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
@@ -689,10 +662,10 @@ namespace Rodin::Assembly
         {
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -708,8 +681,8 @@ namespace Rodin::Assembly
 
             for (auto it = seq.getIterator(); it; ++it)
             {
-              const size_t d   = it->getDimension();
-              const Index  idx = it->getIndex();
+              const size_t d = it->getDimension();
+              const Index idx = it->getIndex();
 
               if (!shard.isOwned(d, idx))
                 continue;
@@ -741,11 +714,11 @@ namespace Rodin::Assembly
             PetscInt lo, hi;
             ierr = VecGetOwnershipRange(vec, &lo, &hi);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             const PetscScalar* arr;
             ierr = VecGetArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = lo; i < hi; ++i)
             {
               const PetscScalar val = arr[i - lo];
@@ -754,7 +727,7 @@ namespace Rodin::Assembly
             }
             ierr = VecRestoreArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -763,10 +736,10 @@ namespace Rodin::Assembly
         {
           ierr = VecAssemblyBegin(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         if (doMatrix)
@@ -784,7 +757,7 @@ namespace Rodin::Assembly
               nullptr,
               nullptr);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           for (const Index gs : constraints.getIdentifiedRows())
           {
@@ -794,38 +767,38 @@ namespace Rodin::Assembly
             const PetscScalar one = 1.0;
             ierr = MatSetValue(A, I, I, one, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (const auto& e : constraints.expand(gs))
             {
               const PetscInt J = static_cast<PetscInt>(e.index);
               const PetscScalar v = -e.coefficient;
               ierr = MatSetValue(A, I, J, v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
             const PetscScalar rhs = constraints.getIdentificationValue(gs);
             if (doVector)
             {
               ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
 
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           if (doVector)
           {
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -846,65 +819,49 @@ namespace Rodin::Assembly
             Vec bcVec;
             ierr = VecDuplicate(b, &bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecZeroEntries(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
-            ierr = VecSetValues(
-                bcVec,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.empty() ? nullptr : bcIdx.data(),
-                bcVals.empty() ? nullptr : bcVals.data(),
-                INSERT_VALUES);
+            (void)ierr;
+            ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(),
+              bcVals.empty() ? nullptr : bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
-            ierr = MatZeroRowsColumns(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.empty() ? nullptr : bcIdx.data(),
-                1.0,
-                bcVec,
-                b);
+            (void)ierr;
+            ierr = MatZeroRowsColumns(A, static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(), 1.0, bcVec, b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecDestroy(&bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else if (mode == AssemblyMode::LHS)
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.empty() ? nullptr : bcIdx.data(),
-                1.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(), 1.0, nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else
           {
-            ierr = VecSetValues(
-                b,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.empty() ? nullptr : bcIdx.data(),
-                bcVals.empty() ? nullptr : bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()),
+              bcIdx.empty() ? nullptr : bcIdx.data(),
+              bcVals.empty() ? nullptr : bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -972,10 +929,8 @@ namespace Rodin::Assembly
        * @param[in] input Multi-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -996,10 +951,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         auto& A = axb.getOperator();
         auto& b = axb.getVector();
@@ -1115,16 +1067,11 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(localCols),
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            nullptr,
-            true
-          });
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare(
+            {static_cast<PetscInt>(localRows), static_cast<PetscInt>(localCols),
+              static_cast<PetscInt>(nrows), static_cast<PetscInt>(ncols), nullptr, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -1133,30 +1080,21 @@ namespace Rodin::Assembly
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(localRows),
-            static_cast<PetscInt>(nrows),
-            nullptr,
-            true,
-            true
-          });
+          ierr =
+            PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(localRows),
+              static_cast<PetscInt>(nrows), nullptr, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(localCols),
-          static_cast<PetscInt>(ncols),
-          nullptr,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(localCols),
+          static_cast<PetscInt>(ncols), nullptr, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ConstraintMap<PetscScalar> constraints(std::max(nrows, ncols));
         using DBCBaseType = Variational::DirichletBCBase<PetscScalar>;
@@ -1234,8 +1172,7 @@ namespace Rodin::Assembly
           return owned;
         };
 
-        auto matrix_entry = [&](Index row, Index col, PetscScalar val)
-        {
+        auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -1248,7 +1185,7 @@ namespace Rodin::Assembly
               const PetscScalar rhsShift = -r.coefficient * val * colValue;
               ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
             for (const auto& c : constraints.expand(col))
             {
@@ -1260,7 +1197,7 @@ namespace Rodin::Assembly
               // matrix options.
               ierr = MatSetValue(A, I, J, v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         };
@@ -1275,7 +1212,7 @@ namespace Rodin::Assembly
             const PetscScalar v = r.coefficient * val;
             ierr = VecSetValue(b, I, v, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         };
 
@@ -1307,8 +1244,8 @@ namespace Rodin::Assembly
 
             for (auto it = seq.getIterator(); it; ++it)
             {
-              const size_t d   = it->getDimension();
-              const Index  idx = it->getIndex();
+              const size_t d = it->getDimension();
+              const Index idx = it->getIndex();
 
               if (!shard.isOwned(d, idx))
                 continue;
@@ -1353,15 +1290,15 @@ namespace Rodin::Assembly
             const auto& vFES = getTestFESByUUID(vUUID);
 
             const auto& trialAttrs = bfi.getTrialAttributes();
-            const auto& testAttrs  = bfi.getTestAttributes();
+            const auto& testAttrs = bfi.getTestAttributes();
 
             MPIIteration trialseq(mesh, bfi.getTrialRegion());
-            MPIIteration testseq(mesh,  bfi.getTestRegion());
+            MPIIteration testseq(mesh, bfi.getTestRegion());
 
             for (auto teIt = testseq.getIterator(); teIt; ++teIt)
             {
-              const size_t td   = teIt->getDimension();
-              const Index  tidx = teIt->getIndex();
+              const size_t td = teIt->getDimension();
+              const Index tidx = teIt->getIndex();
 
               if (!shard.isOwned(td, tidx))
                 continue;
@@ -1377,8 +1314,8 @@ namespace Rodin::Assembly
 
               for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
               {
-                const size_t rd   = trIt->getDimension();
-                const Index  ridx = trIt->getIndex();
+                const size_t rd = trIt->getDimension();
+                const Index ridx = trIt->getIndex();
 
                 if (!trialAttrs.empty())
                 {
@@ -1422,7 +1359,7 @@ namespace Rodin::Assembly
             PetscInt rStart, rEnd;
             ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             for (PetscInt i = rStart; i < rEnd; ++i)
             {
@@ -1431,27 +1368,25 @@ namespace Rodin::Assembly
               const PetscScalar* vals;
               ierr = MatGetRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (PetscInt j = 0; j < nc; ++j)
               {
-                matrix_entry(
-                  static_cast<Index>(vOff) + static_cast<Index>(i),
-                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
-                  vals[j]);
+                matrix_entry(static_cast<Index>(vOff) + static_cast<Index>(i),
+                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]), vals[j]);
               }
               ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
 
           // Assemble A
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -1464,7 +1399,7 @@ namespace Rodin::Assembly
           {
             const auto vUUID = lfi.getTestFunction().getUUID();
             const size_t vBlock = findTestBlock(vUUID);
-            const size_t vOff   = testOffsets[vBlock];
+            const size_t vOff = testOffsets[vBlock];
 
             const auto& vFES = getTestFESByUUID(vUUID);
 
@@ -1473,8 +1408,8 @@ namespace Rodin::Assembly
 
             for (auto it = seq.getIterator(); it; ++it)
             {
-              const size_t d   = it->getDimension();
-              const Index  idx = it->getIndex();
+              const size_t d = it->getDimension();
+              const Index idx = it->getIndex();
 
               if (!shard.isOwned(d, idx))
                 continue;
@@ -1504,18 +1439,18 @@ namespace Rodin::Assembly
           {
             const auto vUUID = lf.getTestFunction().getUUID();
             const size_t vBlock = findTestBlock(vUUID);
-            const size_t vOff   = testOffsets[vBlock];
+            const size_t vOff = testOffsets[vBlock];
 
             const auto& vec = lf.getVector();
             PetscInt lo, hi;
             ierr = VecGetOwnershipRange(vec, &lo, &hi);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             const PetscScalar* arr;
             ierr = VecGetArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = lo; i < hi; ++i)
             {
               const PetscScalar val = arr[i - lo];
@@ -1524,16 +1459,16 @@ namespace Rodin::Assembly
             }
             ierr = VecRestoreArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
 
           // Assemble b
           ierr = VecAssemblyBegin(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         if (doMatrix)
@@ -1551,7 +1486,7 @@ namespace Rodin::Assembly
               nullptr,
               nullptr);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           for (const Index gs : constraints.getIdentifiedRows())
           {
@@ -1561,38 +1496,38 @@ namespace Rodin::Assembly
             const PetscScalar one = 1.0;
             ierr = MatSetValue(A, I, I, one, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (const auto& e : constraints.expand(gs))
             {
               const PetscInt J = static_cast<PetscInt>(e.index);
               const PetscScalar v = -e.coefficient;
               ierr = MatSetValue(A, I, J, v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
             const PetscScalar rhs = constraints.getIdentificationValue(gs);
             if (doVector)
             {
               ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
 
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           if (doVector)
           {
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -1612,10 +1547,10 @@ namespace Rodin::Assembly
           Vec bcVec;
           ierr = VecDuplicate(b, &bcVec);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecZeroEntries(bcVec);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecSetValues(
               bcVec,
               static_cast<PetscInt>(bcIdx.size()),
@@ -1623,13 +1558,13 @@ namespace Rodin::Assembly
               bcVals.empty() ? nullptr : bcVals.data(),
               INSERT_VALUES);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyBegin(bcVec);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(bcVec);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatZeroRowsColumns(
               A,
               static_cast<PetscInt>(bcIdx.size()),
@@ -1638,39 +1573,31 @@ namespace Rodin::Assembly
               bcVec,
               b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecDestroy(&bcVec);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
         else if (mode == AssemblyMode::LHS)
         {
-          ierr = MatZeroRows(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              1.0,
-              nullptr,
-              nullptr);
+          ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()),
+            bcIdx.empty() ? nullptr : bcIdx.data(), 1.0, nullptr, nullptr);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
         else
         {
-          ierr = VecSetValues(
-              b,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              bcVals.empty() ? nullptr : bcVals.data(),
-              INSERT_VALUES);
+          ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()),
+            bcIdx.empty() ? nullptr : bcIdx.data(),
+            bcVals.empty() ? nullptr : bcVals.data(), INSERT_VALUES);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyBegin(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         (void) ierr;

--- a/src/Rodin/PETSc/Assembly/MatrixSetup.h
+++ b/src/Rodin/PETSc/Assembly/MatrixSetup.h
@@ -101,52 +101,47 @@ namespace Rodin::PETSc::Assembly
         PetscInt curCols = 0;
         PetscErrorCode ierr = MatGetSize(m_matrix, &curRows, &curCols);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         PetscBool assembled = PETSC_FALSE;
         ierr = MatAssembled(m_matrix, &assembled);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         // A virgin matrix must be set up. An already-assembled matrix whose
         // dimensions match is reused. Different dimensions violate the
         // constant-space contract: use a fresh LinearSystem for a different
         // finite element space or mesh.
-        assert(
-            (assembled != PETSC_TRUE ||
-             (curRows == options.globalRows && curCols == options.globalCols)) &&
-            "MatrixSetup cannot resize an assembled matrix; use a fresh "
-            "LinearSystem for a different space or mesh.");
+        assert((assembled != PETSC_TRUE ||
+                 (curRows == options.globalRows && curCols == options.globalCols)) &&
+          "MatrixSetup cannot resize an assembled matrix; use a fresh "
+          "LinearSystem for a different space or mesh.");
 
         const bool needsSetup = (assembled != PETSC_TRUE);
         if (needsSetup)
         {
-          ierr = MatSetSizes(
-              m_matrix,
-              options.localRows,
-              options.localCols,
-              options.globalRows,
-              options.globalCols);
+          ierr = MatSetSizes(m_matrix, options.localRows, options.localCols,
+            options.globalRows, options.globalCols);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           if (options.type)
           {
             ierr = MatSetType(m_matrix, options.type);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
 
           if (options.setFromOptions)
           {
             ierr = MatSetFromOptions(m_matrix);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
 
           ierr = MatSetUp(m_matrix);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         return MatZeroEntries(m_matrix);

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -105,14 +105,9 @@ namespace Rodin::Assembly
         PetscErrorCode ierr;
         const PetscInt n = PetscInt(input.getFES().getSize());
 
-        ierr = PETSc::Assembly::VectorSetup(res).prepare({
-          n,
-          n,
-          nullptr,
-          true
-        });
+        ierr = PETSc::Assembly::VectorSetup(res).prepare({n, n, nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         const auto& mesh = input.getFES().getMesh();
         const int tc     = static_cast<int>(getThreadCount());
@@ -147,8 +142,8 @@ namespace Rodin::Assembly
                 if (!a || !attrs.count(*a)) continue;
               }
 
-              auto it = seq.getIterator(i);
-              integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(i);
+              integrator->setPolytope(polytope);
 
               const auto& dofs = input.getFES().getDOFs(dim, i);
               for (size_t k = 0; k < dofs.size(); ++k)
@@ -177,14 +172,10 @@ namespace Rodin::Assembly
                   rows.push_back(row);
                   vals.push_back(value);
                 }
-                PetscErrorCode e = VecSetValues(
-                    res,
-                    static_cast<PetscInt>(rows.size()),
-                    rows.data(),
-                    vals.data(),
-                    ADD_VALUES);
+                PetscErrorCode e = VecSetValues(res, static_cast<PetscInt>(rows.size()),
+                  rows.data(), vals.data(), ADD_VALUES);
                 assert(e == PETSC_SUCCESS);
-                (void) e;
+                (void)e;
               }
             }
           } // end parallel
@@ -192,10 +183,10 @@ namespace Rodin::Assembly
 
         PetscErrorCode ierr2 = VecAssemblyBegin(res);
         assert(ierr2 == PETSC_SUCCESS);
-        (void) ierr2;
+        (void)ierr2;
         ierr2 = VecAssemblyEnd(res);
         assert(ierr2 == PETSC_SUCCESS);
-        (void) ierr2;
+        (void)ierr2;
       }
 
       /// @brief Creates a heap-allocated copy of this assembly backend.
@@ -291,24 +282,17 @@ namespace Rodin::Assembly
         const PetscInt m = input.getTestFES().getSize();
         const PetscInt n = input.getTrialFES().getSize();
 
-        ierr = PETSc::Assembly::MatrixSetup(res).prepare({
-          static_cast<PetscInt>(m),
-          static_cast<PetscInt>(n),
-          static_cast<PetscInt>(m),
-          static_cast<PetscInt>(n),
-          nullptr,
-          true
-        });
+        ierr = PETSc::Assembly::MatrixSetup(res).prepare(
+          {static_cast<PetscInt>(m), static_cast<PetscInt>(n), static_cast<PetscInt>(m),
+            static_cast<PetscInt>(n), nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         const auto& mesh = input.getTestFES().getMesh();
         const int tc = static_cast<int>(getThreadCount());
         using MatrixEntry = std::tuple<PetscInt, PetscInt, PetscScalar>;
 
-        auto flush_matrix_entries =
-          [&](std::vector<std::vector<MatrixEntry>>& chunks)
-        {
+        auto flush_matrix_entries = [&](std::vector<std::vector<MatrixEntry>>& chunks) {
           std::vector<MatrixEntry> entries;
           size_t total = 0;
           for (const auto& chunk : chunks)
@@ -316,20 +300,17 @@ namespace Rodin::Assembly
           entries.reserve(total);
           for (auto& chunk : chunks)
           {
-            entries.insert(
-                entries.end(),
-                std::make_move_iterator(chunk.begin()),
-                std::make_move_iterator(chunk.end()));
+            entries.insert(entries.end(), std::make_move_iterator(chunk.begin()),
+              std::make_move_iterator(chunk.end()));
             chunk.clear();
           }
 
           std::sort(entries.begin(), entries.end(),
-              [](const MatrixEntry& a, const MatrixEntry& b)
-              {
-                if (std::get<0>(a) != std::get<0>(b))
-                  return std::get<0>(a) < std::get<0>(b);
-                return std::get<1>(a) < std::get<1>(b);
-              });
+            [](const MatrixEntry& a, const MatrixEntry& b) {
+              if (std::get<0>(a) != std::get<0>(b))
+                return std::get<0>(a) < std::get<0>(b);
+              return std::get<1>(a) < std::get<1>(b);
+            });
 
           std::vector<PetscInt> cols;
           std::vector<PetscScalar> vals;
@@ -344,16 +325,10 @@ namespace Rodin::Assembly
               vals.push_back(std::get<2>(entries[pos]));
               ++pos;
             }
-            PetscErrorCode e = MatSetValues(
-                res,
-                1,
-                &row,
-                static_cast<PetscInt>(cols.size()),
-                cols.data(),
-                vals.data(),
-                ADD_VALUES);
+            PetscErrorCode e = MatSetValues(res, 1, &row,
+              static_cast<PetscInt>(cols.size()), cols.data(), vals.data(), ADD_VALUES);
             assert(e == PETSC_SUCCESS);
-            (void) e;
+            (void)e;
           }
         };
 
@@ -385,8 +360,8 @@ namespace Rodin::Assembly
                 if (!a || !attrs.count(*a)) continue;
               }
 
-              auto it = seq.getIterator(i);
-              integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(i);
+              integrator->setPolytope(polytope);
 
               const auto& rows = input.getTestFES().getDOFs(dim, i);
               const auto& cols = input.getTrialFES().getDOFs(dim, i);
@@ -395,9 +370,7 @@ namespace Rodin::Assembly
                 {
                   const PetscScalar v = Math::conj(integrator->integrate(c, r));
                   local.emplace_back(
-                      static_cast<PetscInt>(rows[r]),
-                      static_cast<PetscInt>(cols[c]),
-                      v);
+                    static_cast<PetscInt>(rows[r]), static_cast<PetscInt>(cols[c]), v);
                 }
             }
 
@@ -414,7 +387,7 @@ namespace Rodin::Assembly
         for (auto& bfi : input.getGlobalBFIs())
         {
           const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
+          const auto& testAttrs = bfi.getTestAttributes();
 
           OpenMPIteration trialseq(mesh, bfi.getTrialRegion());
           OpenMPIteration testseq(mesh, bfi.getTestRegion());
@@ -431,34 +404,39 @@ namespace Rodin::Assembly
           {
             const int tid = omp_get_thread_num();
             auto integrator =
-              std::unique_ptr<Variational::GlobalBilinearFormIntegratorBase<PetscScalar>>(bfi.copy());
+              std::unique_ptr<Variational::GlobalBilinearFormIntegratorBase<PetscScalar>>(
+                bfi.copy());
             std::vector<MatrixEntry> local;
             local.reserve(static_cast<size_t>(tcnt));
 
 #pragma omp for
             for (PetscInt te = 0; te < tcnt; ++te)
             {
-              if (!testseq.filter(te)) continue;
+              if (!testseq.filter(te))
+                continue;
               if (!testAttrs.empty())
               {
                 const auto a = mesh.getAttribute(tdim, te);
-                if (!a || !testAttrs.count(*a)) continue;
+                if (!a || !testAttrs.count(*a))
+                  continue;
               }
 
-              auto teIt = testseq.getIterator(te);
+              const auto testPolytope = testseq.getPolytope(te);
               const auto& rows = input.getTestFES().getDOFs(tdim, te);
 
               for (PetscInt tr = 0; tr < rcnt; ++tr)
               {
-                if (!trialseq.filter(tr)) continue;
+                if (!trialseq.filter(tr))
+                  continue;
                 if (!trialAttrs.empty())
                 {
                   const auto a = mesh.getAttribute(rdim, tr);
-                  if (!a || !trialAttrs.count(*a)) continue;
+                  if (!a || !trialAttrs.count(*a))
+                    continue;
                 }
 
-                auto trIt = trialseq.getIterator(tr);
-                integrator->setPolytope(*trIt, *teIt);
+                const auto trialPolytope = trialseq.getPolytope(tr);
+                integrator->setPolytope(trialPolytope, testPolytope);
 
                 const auto& cols = input.getTrialFES().getDOFs(rdim, tr);
                 for (size_t r = 0; r < rows.size(); ++r)
@@ -466,9 +444,7 @@ namespace Rodin::Assembly
                   {
                     const PetscScalar v = Math::conj(integrator->integrate(c, r));
                     local.emplace_back(
-                        static_cast<PetscInt>(rows[r]),
-                        static_cast<PetscInt>(cols[c]),
-                        v);
+                      static_cast<PetscInt>(rows[r]), static_cast<PetscInt>(cols[c]), v);
                   }
               }
             }
@@ -485,10 +461,10 @@ namespace Rodin::Assembly
 
         PetscErrorCode ierr2 = MatAssemblyBegin(res, MAT_FINAL_ASSEMBLY);
         assert(ierr2 == PETSC_SUCCESS);
-        (void) ierr2;
+        (void)ierr2;
         ierr2 = MatAssemblyEnd(res, MAT_FINAL_ASSEMBLY);
         assert(ierr2 == PETSC_SUCCESS);
-        (void) ierr2;
+        (void)ierr2;
       }
 
       /// @brief Creates a heap-allocated copy of this assembly backend.
@@ -597,10 +573,8 @@ namespace Rodin::Assembly
        * @param[in] input Single-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -621,10 +595,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         static_assert(std::is_same_v<TrialMeshContextType, Rodin::Context::Local>,
           "PETSc OpenMP assembly (sequential objects) supports only Local mesh context.");
@@ -654,16 +625,11 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            MATSEQAIJ,
-            false
-          });
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), MATSEQAIJ, false});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -672,30 +638,20 @@ namespace Rodin::Assembly
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(nrows),
-            VECSEQ,
-            true,
-            true
-          });
+          ierr = PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(nrows), VECSEQ, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(ncols),
-          VECSEQ,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(ncols),
+          static_cast<PetscInt>(ncols), VECSEQ, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ConstraintMap<PetscScalar> constraints(
             static_cast<size_t>(std::max(nrows, ncols)));
@@ -757,11 +713,9 @@ namespace Rodin::Assembly
         using MatrixEntry = std::tuple<PetscInt, PetscInt, PetscScalar>;
         using VectorEntry = std::pair<PetscInt, PetscScalar>;
 
-        auto add_matrix_entries =
-          [&](std::vector<MatrixEntry>& local,
-              std::vector<VectorEntry>& localRhs,
-              Index row, Index col, PetscScalar val)
-        {
+        auto add_matrix_entries = [&](std::vector<MatrixEntry>& local,
+                                    std::vector<VectorEntry>& localRhs, Index row,
+                                    Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -770,33 +724,25 @@ namespace Rodin::Assembly
           {
             if (colValue != PetscScalar(0))
               localRhs.emplace_back(
-                  static_cast<PetscInt>(r.index),
-                  -r.coefficient * val * colValue);
+                static_cast<PetscInt>(r.index), -r.coefficient * val * colValue);
             if (doMatrix)
             {
               for (const auto& c : constraints.expand(col))
-                local.emplace_back(
-                    static_cast<PetscInt>(r.index),
-                    static_cast<PetscInt>(c.index),
-                    r.coefficient * val * c.coefficient);
+                local.emplace_back(static_cast<PetscInt>(r.index),
+                  static_cast<PetscInt>(c.index), r.coefficient * val * c.coefficient);
             }
           }
         };
 
-        auto add_vector_entries =
-          [&](std::vector<VectorEntry>& local, Index row, PetscScalar val)
-        {
+        auto add_vector_entries = [&](std::vector<VectorEntry>& local, Index row,
+                                    PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
-            local.emplace_back(
-                static_cast<PetscInt>(r.index),
-                r.coefficient * val);
+            local.emplace_back(static_cast<PetscInt>(r.index), r.coefficient * val);
         };
 
-        auto flush_matrix_entries =
-          [&](std::vector<std::vector<MatrixEntry>>& chunks)
-        {
+        auto flush_matrix_entries = [&](std::vector<std::vector<MatrixEntry>>& chunks) {
           std::vector<MatrixEntry> entries;
           size_t total = 0;
           for (const auto& chunk : chunks)
@@ -804,20 +750,17 @@ namespace Rodin::Assembly
           entries.reserve(total);
           for (auto& chunk : chunks)
           {
-            entries.insert(
-                entries.end(),
-                std::make_move_iterator(chunk.begin()),
-                std::make_move_iterator(chunk.end()));
+            entries.insert(entries.end(), std::make_move_iterator(chunk.begin()),
+              std::make_move_iterator(chunk.end()));
             chunk.clear();
           }
 
           std::sort(entries.begin(), entries.end(),
-              [](const MatrixEntry& a, const MatrixEntry& b)
-              {
-                if (std::get<0>(a) != std::get<0>(b))
-                  return std::get<0>(a) < std::get<0>(b);
-                return std::get<1>(a) < std::get<1>(b);
-              });
+            [](const MatrixEntry& a, const MatrixEntry& b) {
+              if (std::get<0>(a) != std::get<0>(b))
+                return std::get<0>(a) < std::get<0>(b);
+              return std::get<1>(a) < std::get<1>(b);
+            });
 
           std::vector<PetscInt> cols;
           std::vector<PetscScalar> vals;
@@ -832,22 +775,14 @@ namespace Rodin::Assembly
               vals.push_back(std::get<2>(entries[pos]));
               ++pos;
             }
-            PetscErrorCode e = MatSetValues(
-                A,
-                1,
-                &row,
-                static_cast<PetscInt>(cols.size()),
-                cols.data(),
-                vals.data(),
-                ADD_VALUES);
+            PetscErrorCode e = MatSetValues(A, 1, &row,
+              static_cast<PetscInt>(cols.size()), cols.data(), vals.data(), ADD_VALUES);
             assert(e == PETSC_SUCCESS);
-            (void) e;
+            (void)e;
           }
         };
 
-        auto flush_vector_entries =
-          [&](std::vector<std::vector<VectorEntry>>& chunks)
-        {
+        auto flush_vector_entries = [&](std::vector<std::vector<VectorEntry>>& chunks) {
           for (auto& chunk : chunks)
           {
             if (chunk.empty())
@@ -861,14 +796,10 @@ namespace Rodin::Assembly
               rows.push_back(row);
               vals.push_back(val);
             }
-            PetscErrorCode e = VecSetValues(
-                b,
-                static_cast<PetscInt>(rows.size()),
-                rows.data(),
-                vals.data(),
-                ADD_VALUES);
+            PetscErrorCode e = VecSetValues(b, static_cast<PetscInt>(rows.size()),
+              rows.data(), vals.data(), ADD_VALUES);
             assert(e == PETSC_SUCCESS);
-            (void) e;
+            (void)e;
             chunk.clear();
           }
         };
@@ -895,8 +826,8 @@ namespace Rodin::Assembly
             {
               const int tid = omp_get_thread_num();
 
-              auto integrator =
-                std::unique_ptr<LocalBilinearIntegratorBase>(static_cast<LocalBilinearIntegratorBase*>(bfi.copy()));
+              auto integrator = std::unique_ptr<LocalBilinearIntegratorBase>(
+                static_cast<LocalBilinearIntegratorBase*>(bfi.copy()));
 
               std::vector<MatrixEntry> local;
               local.reserve(static_cast<size_t>(cnt));
@@ -905,15 +836,17 @@ namespace Rodin::Assembly
 #pragma omp for
               for (PetscInt k = 0; k < cnt; ++k)
               {
-                if (!seq.filter(k)) continue;
+                if (!seq.filter(k))
+                  continue;
                 if (!attrs.empty())
                 {
                   const auto a = mesh.getAttribute(dim, k);
-                  if (!a || !attrs.count(*a)) continue;
+                  if (!a || !attrs.count(*a))
+                    continue;
                 }
 
-                auto it = seq.getIterator(k);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(k);
+                integrator->setPolytope(polytope);
 
                 const auto& rowsDOF = testFES.getDOFs(dim, k);
                 const auto& colsDOF = trialFES.getDOFs(dim, k);
@@ -922,7 +855,8 @@ namespace Rodin::Assembly
                 {
                   for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
                   {
-                    const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(j, i));
+                    const PetscScalar val =
+                      static_cast<PetscScalar>(integrator->integrate(j, i));
                     add_matrix_entries(local, localRhs, rowsDOF[i], colsDOF[j], val);
                   }
                 }
@@ -947,10 +881,10 @@ namespace Rodin::Assembly
           for (auto& bfi : pb.getGlobalBFIs())
           {
             const auto& trialAttrs = bfi.getTrialAttributes();
-            const auto& testAttrs  = bfi.getTestAttributes();
+            const auto& testAttrs = bfi.getTestAttributes();
 
             OpenMPIteration trialseq(mesh, bfi.getTrialRegion());
-            OpenMPIteration testseq(mesh,  bfi.getTestRegion());
+            OpenMPIteration testseq(mesh, bfi.getTestRegion());
 
             const PetscInt tdim = static_cast<PetscInt>(testseq.getDimension());
             const PetscInt tcnt = static_cast<PetscInt>(testseq.getCount());
@@ -965,8 +899,8 @@ namespace Rodin::Assembly
             {
               const int tid = omp_get_thread_num();
 
-              auto integrator =
-                std::unique_ptr<GlobalBilinearIntegratorBase>(static_cast<GlobalBilinearIntegratorBase*>(bfi.copy()));
+              auto integrator = std::unique_ptr<GlobalBilinearIntegratorBase>(
+                static_cast<GlobalBilinearIntegratorBase*>(bfi.copy()));
 
               std::vector<MatrixEntry> local;
               local.reserve(static_cast<size_t>(tcnt));
@@ -975,35 +909,40 @@ namespace Rodin::Assembly
 #pragma omp for
               for (PetscInt te = 0; te < tcnt; ++te)
               {
-                if (!testseq.filter(te)) continue;
+                if (!testseq.filter(te))
+                  continue;
                 if (!testAttrs.empty())
                 {
                   const auto a = mesh.getAttribute(tdim, te);
-                  if (!a || !testAttrs.count(*a)) continue;
+                  if (!a || !testAttrs.count(*a))
+                    continue;
                 }
 
-                auto teIt = testseq.getIterator(te);
+                const auto testPolytope = testseq.getPolytope(te);
                 const auto& rowsDOF = testFES.getDOFs(tdim, te);
 
                 for (PetscInt tr = 0; tr < rcnt; ++tr)
                 {
-                  if (!trialseq.filter(tr)) continue;
+                  if (!trialseq.filter(tr))
+                    continue;
                   if (!trialAttrs.empty())
                   {
                     const auto a = mesh.getAttribute(rdim, tr);
-                    if (!a || !trialAttrs.count(*a)) continue;
+                    if (!a || !trialAttrs.count(*a))
+                      continue;
                   }
 
-                  auto trIt = trialseq.getIterator(tr);
+                  const auto trialPolytope = trialseq.getPolytope(tr);
                   const auto& colsDOF = trialFES.getDOFs(rdim, tr);
 
-                  integrator->setPolytope(*trIt, *teIt);
+                  integrator->setPolytope(trialPolytope, testPolytope);
 
                   for (PetscInt i = 0; i < static_cast<PetscInt>(rowsDOF.size()); ++i)
                   {
                     for (PetscInt j = 0; j < static_cast<PetscInt>(colsDOF.size()); ++j)
                     {
-                      const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(j, i));
+                      const PetscScalar val =
+                        static_cast<PetscScalar>(integrator->integrate(j, i));
                       add_matrix_entries(local, localRhs, rowsDOF[i], colsDOF[j], val);
                     }
                   }
@@ -1030,7 +969,7 @@ namespace Rodin::Assembly
             PetscInt rStart, rEnd;
             ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = rStart; i < rEnd; ++i)
             {
               PetscInt nc;
@@ -1038,17 +977,13 @@ namespace Rodin::Assembly
               const PetscScalar* vals;
               ierr = MatGetRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (PetscInt j = 0; j < nc; ++j)
               {
                 std::vector<MatrixEntry> local;
                 std::vector<VectorEntry> localRhs;
-                add_matrix_entries(
-                    local,
-                    localRhs,
-                    static_cast<Index>(i),
-                    static_cast<Index>(cols[j]),
-                    vals[j]);
+                add_matrix_entries(local, localRhs, static_cast<Index>(i),
+                  static_cast<Index>(cols[j]), vals[j]);
                 std::vector<std::vector<MatrixEntry>> matrixChunks(1);
                 matrixChunks[0] = std::move(local);
                 flush_matrix_entries(matrixChunks);
@@ -1061,7 +996,7 @@ namespace Rodin::Assembly
               }
               ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
@@ -1071,10 +1006,10 @@ namespace Rodin::Assembly
         {
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -1097,28 +1032,31 @@ namespace Rodin::Assembly
             {
               const int tid = omp_get_thread_num();
 
-              auto integrator =
-                std::unique_ptr<LinearIntegratorBase>(static_cast<LinearIntegratorBase*>(lfi.copy()));
+              auto integrator = std::unique_ptr<LinearIntegratorBase>(
+                static_cast<LinearIntegratorBase*>(lfi.copy()));
 
               std::vector<VectorEntry> local;
 
 #pragma omp for
               for (PetscInt k = 0; k < cnt; ++k)
               {
-                if (!seq.filter(k)) continue;
+                if (!seq.filter(k))
+                  continue;
                 if (!attrs.empty())
                 {
                   const auto a = mesh.getAttribute(dim, k);
-                  if (!a || !attrs.count(*a)) continue;
+                  if (!a || !attrs.count(*a))
+                    continue;
                 }
 
-                auto it = seq.getIterator(k);
-                integrator->setPolytope(*it);
+                const auto polytope = seq.getPolytope(k);
+                integrator->setPolytope(polytope);
 
                 const auto& dofs = testFES.getDOFs(dim, k);
                 for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
                 {
-                  const PetscScalar val = static_cast<PetscScalar>(integrator->integrate(l));
+                  const PetscScalar val =
+                    static_cast<PetscScalar>(integrator->integrate(l));
                   add_vector_entries(local, dofs[l], -val);
                 }
               }
@@ -1140,11 +1078,11 @@ namespace Rodin::Assembly
             PetscInt vecSize;
             ierr = VecGetSize(vec, &vecSize);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             const PetscScalar* arr;
             ierr = VecGetArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             std::vector<std::vector<VectorEntry>> chunks(1);
             for (PetscInt i = 0; i < vecSize; ++i)
             {
@@ -1153,7 +1091,7 @@ namespace Rodin::Assembly
             flush_vector_entries(chunks);
             ierr = VecRestoreArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -1162,10 +1100,10 @@ namespace Rodin::Assembly
         {
           ierr = VecAssemblyBegin(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         if (!constraints.getIdentifiedRows().empty())
@@ -1186,7 +1124,7 @@ namespace Rodin::Assembly
                 nullptr,
                 nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             for (const Index gs : constraints.getIdentifiedRows())
             {
@@ -1196,38 +1134,38 @@ namespace Rodin::Assembly
               const PetscScalar one = 1.0;
               ierr = MatSetValue(A, I, I, one, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (const auto& e : constraints.expand(gs))
               {
                 const PetscInt J = static_cast<PetscInt>(e.index);
                 const PetscScalar v = -e.coefficient;
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
               const PetscScalar rhs = constraints.getIdentificationValue(gs);
               if (doVector)
               {
                 ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
 
             ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             if (doVector)
             {
               ierr = VecAssemblyBegin(b);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               ierr = VecAssemblyEnd(b);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
@@ -1250,70 +1188,52 @@ namespace Rodin::Assembly
             Vec bcVec;
             ierr = VecDuplicate(b, &bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecZeroEntries(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
-            ierr = VecSetValues(
-                bcVec,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecAssemblyBegin(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = MatZeroRowsColumns(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                bcVec,
-                b);
+              A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0, bcVec, b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecDestroy(&bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else if (mode == AssemblyMode::LHS)
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0,
+              nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else
           {
-            ierr = VecSetValues(
-                b,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
       }
@@ -1421,10 +1341,8 @@ namespace Rodin::Assembly
        * @param[in] input Multi-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -1445,10 +1363,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         const bool doMatrix = mode != AssemblyMode::RHS;
         const bool doVector = mode != AssemblyMode::LHS;
@@ -1484,16 +1399,11 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            MATSEQAIJ,
-            false
-          });
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), MATSEQAIJ, false});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -1502,30 +1412,20 @@ namespace Rodin::Assembly
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(nrows),
-            VECSEQ,
-            true,
-            true
-          });
+          ierr = PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(nrows), VECSEQ, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(ncols),
-          VECSEQ,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(ncols),
+          static_cast<PetscInt>(ncols), VECSEQ, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         // ------------------------
         // Helpers (same as your sequential)
@@ -1653,11 +1553,9 @@ namespace Rodin::Assembly
         using MatrixEntry = std::tuple<PetscInt, PetscInt, PetscScalar>;
         using VectorEntry = std::pair<PetscInt, PetscScalar>;
 
-        auto add_matrix_entries =
-          [&](std::vector<MatrixEntry>& local,
-              std::vector<VectorEntry>& localRhs,
-              Index row, Index col, PetscScalar val)
-        {
+        auto add_matrix_entries = [&](std::vector<MatrixEntry>& local,
+                                    std::vector<VectorEntry>& localRhs, Index row,
+                                    Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -1666,8 +1564,7 @@ namespace Rodin::Assembly
           {
             if (colValue != PetscScalar(0))
               localRhs.emplace_back(
-                  static_cast<PetscInt>(r.index),
-                  -r.coefficient * val * colValue);
+                static_cast<PetscInt>(r.index), -r.coefficient * val * colValue);
             for (const auto& c : constraints.expand(col))
               local.emplace_back(
                   static_cast<PetscInt>(r.index),
@@ -1676,20 +1573,15 @@ namespace Rodin::Assembly
           }
         };
 
-        auto add_vector_entries =
-          [&](std::vector<VectorEntry>& local, Index row, PetscScalar val)
-        {
+        auto add_vector_entries = [&](std::vector<VectorEntry>& local, Index row,
+                                    PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
-            local.emplace_back(
-                static_cast<PetscInt>(r.index),
-                r.coefficient * val);
+            local.emplace_back(static_cast<PetscInt>(r.index), r.coefficient * val);
         };
 
-        auto flush_matrix_entries =
-          [&](std::vector<std::vector<MatrixEntry>>& chunks)
-        {
+        auto flush_matrix_entries = [&](std::vector<std::vector<MatrixEntry>>& chunks) {
           std::vector<MatrixEntry> entries;
           size_t total = 0;
           for (const auto& chunk : chunks)
@@ -1697,20 +1589,17 @@ namespace Rodin::Assembly
           entries.reserve(total);
           for (auto& chunk : chunks)
           {
-            entries.insert(
-                entries.end(),
-                std::make_move_iterator(chunk.begin()),
-                std::make_move_iterator(chunk.end()));
+            entries.insert(entries.end(), std::make_move_iterator(chunk.begin()),
+              std::make_move_iterator(chunk.end()));
             chunk.clear();
           }
 
           std::sort(entries.begin(), entries.end(),
-              [](const MatrixEntry& a, const MatrixEntry& b)
-              {
-                if (std::get<0>(a) != std::get<0>(b))
-                  return std::get<0>(a) < std::get<0>(b);
-                return std::get<1>(a) < std::get<1>(b);
-              });
+            [](const MatrixEntry& a, const MatrixEntry& b) {
+              if (std::get<0>(a) != std::get<0>(b))
+                return std::get<0>(a) < std::get<0>(b);
+              return std::get<1>(a) < std::get<1>(b);
+            });
 
           std::vector<PetscInt> cols;
           std::vector<PetscScalar> vals;
@@ -1725,22 +1614,14 @@ namespace Rodin::Assembly
               vals.push_back(std::get<2>(entries[pos]));
               ++pos;
             }
-            PetscErrorCode e = MatSetValues(
-                A,
-                1,
-                &row,
-                static_cast<PetscInt>(cols.size()),
-                cols.data(),
-                vals.data(),
-                ADD_VALUES);
+            PetscErrorCode e = MatSetValues(A, 1, &row,
+              static_cast<PetscInt>(cols.size()), cols.data(), vals.data(), ADD_VALUES);
             assert(e == PETSC_SUCCESS);
-            (void) e;
+            (void)e;
           }
         };
 
-        auto flush_vector_entries =
-          [&](std::vector<std::vector<VectorEntry>>& chunks)
-        {
+        auto flush_vector_entries = [&](std::vector<std::vector<VectorEntry>>& chunks) {
           for (auto& chunk : chunks)
           {
             if (chunk.empty())
@@ -1754,14 +1635,10 @@ namespace Rodin::Assembly
               rows.push_back(row);
               vals.push_back(val);
             }
-            PetscErrorCode e = VecSetValues(
-                b,
-                static_cast<PetscInt>(rows.size()),
-                rows.data(),
-                vals.data(),
-                ADD_VALUES);
+            PetscErrorCode e = VecSetValues(b, static_cast<PetscInt>(rows.size()),
+              rows.data(), vals.data(), ADD_VALUES);
             assert(e == PETSC_SUCCESS);
-            (void) e;
+            (void)e;
             chunk.clear();
           }
         };
@@ -1790,8 +1667,8 @@ namespace Rodin::Assembly
             const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
             const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
 
-          std::vector<std::vector<MatrixEntry>> chunks(static_cast<size_t>(tc));
-          std::vector<std::vector<VectorEntry>> rhsChunks(static_cast<size_t>(tc));
+            std::vector<std::vector<MatrixEntry>> chunks(static_cast<size_t>(tc));
+            std::vector<std::vector<VectorEntry>> rhsChunks(static_cast<size_t>(tc));
 
 #pragma omp parallel num_threads(tc)
           {
@@ -1814,12 +1691,10 @@ namespace Rodin::Assembly
                 if (!a || !attrs.count(*a)) continue;
               }
 
-              auto it = seq.getIterator(k);
-              withTrialFES(uUUID, [&](const auto& uFES)
-              {
-                withTestFES(vUUID, [&](const auto& vFES)
-                {
-                  integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(k);
+              withTrialFES(uUUID, [&](const auto& uFES) {
+                withTestFES(vUUID, [&](const auto& vFES) {
+                  integrator->setPolytope(polytope);
                   const auto& rows = vFES.getDOFs(dim, k);
                   const auto& cols = uFES.getDOFs(dim, k);
                   for (PetscInt i = 0; i < static_cast<PetscInt>(rows.size()); ++i)
@@ -1895,7 +1770,7 @@ namespace Rodin::Assembly
                 if (!a || !testAttrs.count(*a)) continue;
               }
 
-              auto teIt = testseq.getIterator(te);
+              const auto testPolytope = testseq.getPolytope(te);
               withTrialFES(uUUID, [&](const auto& uFES)
               {
                 withTestFES(vUUID, [&](const auto& vFES)
@@ -1911,10 +1786,10 @@ namespace Rodin::Assembly
                       if (!a || !trialAttrs.count(*a)) continue;
                     }
 
-                    auto trIt = trialseq.getIterator(tr);
+                    const auto trialPolytope = trialseq.getPolytope(tr);
                     const auto& cols = uFES.getDOFs(rdim, tr);
 
-                    integrator->setPolytope(*trIt, *teIt);
+                    integrator->setPolytope(trialPolytope, testPolytope);
 
                     for (PetscInt i = 0; i < static_cast<PetscInt>(rows.size()); ++i)
                     {
@@ -1959,7 +1834,7 @@ namespace Rodin::Assembly
           PetscInt opRows, opCols;
           ierr = MatGetSize(op, &opRows, &opCols);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           for (PetscInt i = 0; i < opRows; ++i)
           {
@@ -1968,7 +1843,7 @@ namespace Rodin::Assembly
             const PetscScalar* vals;
             ierr = MatGetRow(op, i, &nc, &cols, &vals);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt j = 0; j < nc; ++j)
             {
               std::vector<MatrixEntry> local;
@@ -1988,17 +1863,17 @@ namespace Rodin::Assembly
             }
             ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
         // Assemble A
         ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
         ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
         } // doMatrix
 
         // ------------------------
@@ -2007,19 +1882,19 @@ namespace Rodin::Assembly
         // ------------------------
         if (doVector)
         {
-        for (auto& lfi : pb.getLFIs())
-        {
-          const auto vUUID = lfi.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
+          for (auto& lfi : pb.getLFIs())
+          {
+            const auto vUUID = lfi.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff = testOffsets[vBlock];
 
-          const auto& attrs = lfi.getAttributes();
-          OpenMPIteration seq(mesh, lfi.getRegion());
+            const auto& attrs = lfi.getAttributes();
+            OpenMPIteration seq(mesh, lfi.getRegion());
 
-          const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
-          const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
+            const PetscInt dim = static_cast<PetscInt>(seq.getDimension());
+            const PetscInt cnt = static_cast<PetscInt>(seq.getCount());
 
-          std::vector<std::vector<VectorEntry>> chunks(static_cast<size_t>(tc));
+            std::vector<std::vector<VectorEntry>> chunks(static_cast<size_t>(tc));
 
 #pragma omp parallel num_threads(tc)
           {
@@ -2040,10 +1915,9 @@ namespace Rodin::Assembly
                 if (!a || !attrs.count(*a)) continue;
               }
 
-              auto it = seq.getIterator(k);
-              withTestFES(vUUID, [&](const auto& vFES)
-              {
-                integrator->setPolytope(*it);
+              const auto polytope = seq.getPolytope(k);
+              withTestFES(vUUID, [&](const auto& vFES) {
+                integrator->setPolytope(polytope);
                 const auto& dofs = vFES.getDOFs(dim, k);
                 for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
                 {
@@ -2062,7 +1936,7 @@ namespace Rodin::Assembly
               flush_vector_entries(chunks);
             }
           } // omp parallel
-        }
+          }
 
         // Preassembled linear forms (serial, with block offsets)
         for (auto& lf : pb.getLFs())
@@ -2075,36 +1949,34 @@ namespace Rodin::Assembly
           PetscInt vecSize;
           ierr = VecGetSize(vec, &vecSize);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           const PetscScalar* arr;
           ierr = VecGetArrayRead(vec, &arr);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           std::vector<std::vector<VectorEntry>> chunks(1);
           for (PetscInt i = 0; i < vecSize; ++i)
           {
             if (arr[i] != PetscScalar(0))
             {
               add_vector_entries(
-                  chunks[0],
-                  static_cast<Index>(vOff) + static_cast<Index>(i),
-                  arr[i]);
+                chunks[0], static_cast<Index>(vOff) + static_cast<Index>(i), arr[i]);
             }
           }
           flush_vector_entries(chunks);
           ierr = VecRestoreArrayRead(vec, &arr);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // Assemble b
         ierr = VecAssemblyBegin(b);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
         ierr = VecAssemblyEnd(b);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
         } // doVector
 
         if (!constraints.getIdentifiedRows().empty())
@@ -2124,7 +1996,7 @@ namespace Rodin::Assembly
                 0.0,
                 nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             for (const Index gs : constraints.getIdentifiedRows())
             {
@@ -2134,33 +2006,33 @@ namespace Rodin::Assembly
               const PetscScalar one = 1.0;
               ierr = MatSetValue(A, I, I, one, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (const auto& e : constraints.expand(gs))
               {
                 const PetscInt J = static_cast<PetscInt>(e.index);
                 const PetscScalar v = -e.coefficient;
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
               const PetscScalar rhs = constraints.getIdentificationValue(gs);
               ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
 
             ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -2182,70 +2054,52 @@ namespace Rodin::Assembly
             Vec bcVec;
             ierr = VecDuplicate(b, &bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecZeroEntries(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
-            ierr = VecSetValues(
-                bcVec,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecAssemblyBegin(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = MatZeroRowsColumns(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                bcVec,
-                b);
+              A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0, bcVec, b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecDestroy(&bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else if (mode == AssemblyMode::LHS)
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0,
+              nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else
           {
-            ierr = VecSetValues(
-                b,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
       }

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -79,14 +79,10 @@ namespace Rodin::Assembly
         // type. Without it (and with no explicit type) the vector stays
         // typeless and VecZeroEntries fails on PETSc 3.19 ("No method set for
         // Vec of type (null)"); 3.22 is merely more lenient.
-        ierr = PETSc::Assembly::VectorSetup(res).prepare({
-          static_cast<PetscInt>(n),
-          static_cast<PetscInt>(n),
-          nullptr,
-          true
-        });
+        ierr = PETSc::Assembly::VectorSetup(res).prepare(
+          {static_cast<PetscInt>(n), static_cast<PetscInt>(n), nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         const auto& mesh = input.getFES().getMesh();
         for (auto& lfi : input.getLFIs())
@@ -108,18 +104,18 @@ namespace Rodin::Assembly
               const PetscScalar v = PetscScalar(lfi.integrate(l));
               ierr = VecSetValue(res, dofs[l], v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
 
         ierr = VecAssemblyBegin(res);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ierr = VecAssemblyEnd(res);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
       }
 
       /// @brief Creates a heap-allocated copy of this assembly backend.
@@ -178,16 +174,11 @@ namespace Rodin::Assembly
         const size_t n = input.getTrialFES().getSize();
 
         PetscErrorCode ierr;
-        ierr = PETSc::Assembly::MatrixSetup(res).prepare({
-          static_cast<PetscInt>(m),
-          static_cast<PetscInt>(n),
-          static_cast<PetscInt>(m),
-          static_cast<PetscInt>(n),
-          nullptr,
-          true
-        });
+        ierr = PETSc::Assembly::MatrixSetup(res).prepare(
+          {static_cast<PetscInt>(m), static_cast<PetscInt>(n), static_cast<PetscInt>(m),
+            static_cast<PetscInt>(n), nullptr, true});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         const auto& mesh = input.getTrialFES().getMesh();
         // Local contributions
@@ -216,7 +207,7 @@ namespace Rodin::Assembly
                 const PetscScalar v = PetscScalar(bfi.integrate(j, i));
                 ierr = MatSetValue(res, rows[i], cols[j], v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
           }
@@ -254,7 +245,7 @@ namespace Rodin::Assembly
                   const PetscScalar v = PetscScalar(bfi.integrate(j, i));
                   ierr = MatSetValue(res, rows[i], cols[j], v, ADD_VALUES);
                   assert(ierr == PETSC_SUCCESS);
-                  (void) ierr;
+                  (void)ierr;
                 }
             }
           }
@@ -262,11 +253,11 @@ namespace Rodin::Assembly
 
         ierr = MatAssemblyBegin(res, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ierr = MatAssemblyEnd(res, MAT_FINAL_ASSEMBLY);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
       }
 
       /// @brief Creates a heap-allocated copy of this assembly backend.
@@ -335,10 +326,8 @@ namespace Rodin::Assembly
        * @param[in] input Single-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -359,10 +348,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         static_assert(std::is_same_v<TrialMeshContextType, Rodin::Context::Local>,
           "PETSc sequential assembly should only be used with Local mesh context.");
@@ -389,46 +375,31 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(rows),
-            static_cast<PetscInt>(cols),
-            static_cast<PetscInt>(rows),
-            static_cast<PetscInt>(cols),
-            MATSEQAIJ,
-            false
-          });
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({static_cast<PetscInt>(rows),
+            static_cast<PetscInt>(cols), static_cast<PetscInt>(rows),
+            static_cast<PetscInt>(cols), MATSEQAIJ, false});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // Vector setup
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(rows),
-            static_cast<PetscInt>(rows),
-            VECSEQ,
-            true,
-            true
-          });
+          ierr = PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(rows),
+            static_cast<PetscInt>(rows), VECSEQ, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(cols),
-          static_cast<PetscInt>(cols),
-          VECSEQ,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(cols),
+          static_cast<PetscInt>(cols), VECSEQ, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         ConstraintMap<PetscScalar> constraints(std::max(rows, cols));
         using DBCBaseType = Variational::DirichletBCBase<PetscScalar>;
@@ -483,8 +454,7 @@ namespace Rodin::Assembly
             << Alert::Raise;
         }
 
-        auto matrix_entry = [&](Index row, Index col, PetscScalar val)
-        {
+        auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -499,7 +469,7 @@ namespace Rodin::Assembly
               {
                 ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
             if (doMatrix)
@@ -507,14 +477,13 @@ namespace Rodin::Assembly
               for (const auto& c : constraints.expand(col))
               {
                 const PetscInt J = static_cast<PetscInt>(c.index);
-                const PetscScalar v =
-                  r.coefficient * val * c.coefficient;
+                const PetscScalar v = r.coefficient * val * c.coefficient;
                 // Insert unconditionally. PETSc decides whether zero-valued
                 // insertions affect the pattern according to its current
                 // matrix options.
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
             }
           }
@@ -530,7 +499,7 @@ namespace Rodin::Assembly
             const PetscScalar v = r.coefficient * val;
             ierr = VecSetValue(b, I, v, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         };
 
@@ -554,7 +523,7 @@ namespace Rodin::Assembly
               }
 
               const size_t d = it->getDimension();
-              const Index  p = it->getIndex();
+              const Index p = it->getIndex();
 
               bfi.setPolytope(*it);
 
@@ -576,7 +545,7 @@ namespace Rodin::Assembly
           for (auto& bfi : pb.getGlobalBFIs())
           {
             const auto& trialAttrs = bfi.getTrialAttributes();
-            const auto& testAttrs  = bfi.getTestAttributes();
+            const auto& testAttrs = bfi.getTestAttributes();
             SequentialIteration<MeshType> trialseq(mesh, bfi.getTrialRegion());
             SequentialIteration<MeshType> testseq(mesh, bfi.getTestRegion());
 
@@ -589,7 +558,8 @@ namespace Rodin::Assembly
                   continue;
               }
 
-              const auto& rowsDOF = testFES.getDOFs(teIt->getDimension(), teIt->getIndex());
+              const auto& rowsDOF =
+                testFES.getDOFs(teIt->getDimension(), teIt->getIndex());
 
               for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
               {
@@ -600,7 +570,8 @@ namespace Rodin::Assembly
                     continue;
                 }
 
-                const auto& colsDOF = trialFES.getDOFs(trIt->getDimension(), trIt->getIndex());
+                const auto& colsDOF =
+                  trialFES.getDOFs(trIt->getDimension(), trIt->getIndex());
 
                 bfi.setPolytope(*trIt, *teIt);
 
@@ -623,7 +594,7 @@ namespace Rodin::Assembly
             PetscInt rStart, rEnd;
             ierr = MatGetOwnershipRange(op, &rStart, &rEnd);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = rStart; i < rEnd; ++i)
             {
               PetscInt nc;
@@ -631,12 +602,12 @@ namespace Rodin::Assembly
               const PetscScalar* vals;
               ierr = MatGetRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (PetscInt j = 0; j < nc; ++j)
                 matrix_entry(static_cast<Index>(i), static_cast<Index>(cols[j]), vals[j]);
               ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         }
@@ -674,17 +645,17 @@ namespace Rodin::Assembly
             PetscInt vecSize;
             ierr = VecGetSize(vec, &vecSize);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             const PetscScalar* arr;
             ierr = VecGetArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             for (PetscInt i = 0; i < vecSize; ++i)
               if (arr[i] != PetscScalar(0))
                 vector_entry(static_cast<Index>(i), arr[i]);
             ierr = VecRestoreArrayRead(vec, &arr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -693,20 +664,20 @@ namespace Rodin::Assembly
         {
           ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         if (doVector)
         {
           ierr = VecAssemblyBegin(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
           ierr = VecAssemblyEnd(b);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // Identification reconstruction rows
@@ -728,7 +699,7 @@ namespace Rodin::Assembly
                 nullptr,
                 nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             for (const Index gs : constraints.getIdentifiedRows())
             {
@@ -738,33 +709,33 @@ namespace Rodin::Assembly
               const PetscScalar one = 1.0;
               ierr = MatSetValue(A, I, I, one, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (const auto& e : constraints.expand(gs))
               {
                 const PetscInt J = static_cast<PetscInt>(e.index);
                 const PetscScalar v = -e.coefficient;
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
               const PetscScalar rhs = constraints.getIdentificationValue(gs);
               ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
 
             ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -787,67 +758,49 @@ namespace Rodin::Assembly
             Vec bcVec;
             ierr = VecDuplicate(b, &bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecZeroEntries(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
-            ierr = VecSetValues(
-                bcVec,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            (void)ierr;
+            ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = MatZeroRowsColumns(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                bcVec,
-                b);
+              A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0, bcVec, b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecDestroy(&bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else if (mode == AssemblyMode::LHS)
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0,
+              nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else
           {
-            ierr = VecSetValues(
-                b,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
       }
@@ -916,10 +869,8 @@ namespace Rodin::Assembly
        * @param[in] input Multi-field problem assembly input.
        * @param[in] target Assembly target to update.
        */
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          Rodin::Variational::AssemblyTarget target) const
+      void execute(LinearSystemType& axb, const InputType& input,
+        Rodin::Variational::AssemblyTarget target) const
       {
         switch (target)
         {
@@ -940,10 +891,7 @@ namespace Rodin::Assembly
         RHS
       };
 
-      void execute(
-          LinearSystemType& axb,
-          const InputType& input,
-          AssemblyMode mode) const
+      void execute(LinearSystemType& axb, const InputType& input, AssemblyMode mode) const
       {
         const bool doMatrix = mode != AssemblyMode::RHS;
         const bool doVector = mode != AssemblyMode::LHS;
@@ -979,16 +927,11 @@ namespace Rodin::Assembly
         assert(A);
         if (doMatrix)
         {
-          ierr = PETSc::Assembly::MatrixSetup(A).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(ncols),
-            MATSEQAIJ,
-            false
-          });
+          ierr = PETSc::Assembly::MatrixSetup(A).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(ncols), MATSEQAIJ, false});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         // ------------------------
@@ -997,30 +940,20 @@ namespace Rodin::Assembly
         assert(b);
         if (doVector)
         {
-          ierr = PETSc::Assembly::VectorSetup(b).prepare({
-            static_cast<PetscInt>(nrows),
-            static_cast<PetscInt>(nrows),
-            VECSEQ,
-            true,
-            true
-          });
+          ierr = PETSc::Assembly::VectorSetup(b).prepare({static_cast<PetscInt>(nrows),
+            static_cast<PetscInt>(nrows), VECSEQ, true, true});
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
         }
 
         auto& x = axb.getSolution();
         assert(x);
         // The solution vector carries the previous iterate as the solver's
         // initial guess, so it must not be zeroed on reuse.
-        ierr = PETSc::Assembly::VectorSetup(x).prepare({
-          static_cast<PetscInt>(ncols),
-          static_cast<PetscInt>(ncols),
-          VECSEQ,
-          true,
-          false
-        });
+        ierr = PETSc::Assembly::VectorSetup(x).prepare({static_cast<PetscInt>(ncols),
+          static_cast<PetscInt>(ncols), VECSEQ, true, false});
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         // ------------------------
         // Helpers
@@ -1145,8 +1078,7 @@ namespace Rodin::Assembly
             << Alert::Raise;
         }
 
-        auto matrix_entry = [&](Index row, Index col, PetscScalar val)
-        {
+        auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
           const PetscScalar colValue =
             constraints.isIdentified(col)
               ? constraints.getIdentificationValue(col)
@@ -1159,7 +1091,7 @@ namespace Rodin::Assembly
               const PetscScalar rhsShift = -r.coefficient * val * colValue;
               ierr = VecSetValue(b, I, rhsShift, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
             for (const auto& c : constraints.expand(col))
             {
@@ -1171,7 +1103,7 @@ namespace Rodin::Assembly
               // matrix options.
               ierr = MatSetValue(A, I, J, v, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
           }
         };
@@ -1186,7 +1118,7 @@ namespace Rodin::Assembly
             const PetscScalar v = r.coefficient * val;
             ierr = VecSetValue(b, I, v, ADD_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         };
 
@@ -1195,25 +1127,185 @@ namespace Rodin::Assembly
         // ------------------------
         if (doMatrix)
         {
-        // Local BFIs
-        for (auto& bfi : pb.getLocalBFIs())
-        {
-          const auto uUUID = bfi.getTrialFunction().getUUID();
-          const auto vUUID = bfi.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& attrs = bfi.getAttributes();
-          SequentialIteration seq(mesh, bfi.getRegion());
-
-          withTrialFES(uUUID, [&](const auto& uFES)
+          // Local BFIs
+          for (auto& bfi : pb.getLocalBFIs())
           {
-            withTestFES(vUUID, [&](const auto& vFES)
+            const auto uUUID = bfi.getTrialFunction().getUUID();
+            const auto vUUID = bfi.getTestFunction().getUUID();
+
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& attrs = bfi.getAttributes();
+            SequentialIteration seq(mesh, bfi.getRegion());
+
+            withTrialFES(uUUID, [&](const auto& uFES) {
+              withTestFES(vUUID, [&](const auto& vFES) {
+                for (auto it = seq.getIterator(); it; ++it)
+                {
+                  if (!attrs.empty())
+                  {
+                    const auto a = it->getAttribute();
+                    if (!a || !attrs.count(*a))
+                      continue;
+                  }
+
+                  const size_t d = it->getDimension();
+                  const Index p = it->getIndex();
+
+                  bfi.setPolytope(*it);
+
+                  const auto& rows = vFES.getDOFs(d, p);
+                  const auto& cols = uFES.getDOFs(d, p);
+
+                  const PetscInt nr = static_cast<PetscInt>(rows.size());
+                  const PetscInt nc = static_cast<PetscInt>(cols.size());
+
+                  for (PetscInt i = 0; i < nr; ++i)
+                  {
+                    const Index I = static_cast<Index>(
+                      vOff + static_cast<size_t>(rows[static_cast<size_t>(i)]));
+                    for (PetscInt j = 0; j < nc; ++j)
+                    {
+                      const Index J = static_cast<Index>(
+                        uOff + static_cast<size_t>(cols[static_cast<size_t>(j)]));
+                      const PetscScalar val = static_cast<PetscScalar>(
+                        bfi.integrate(static_cast<size_t>(j), static_cast<size_t>(i)));
+                      matrix_entry(I, J, val);
+                    }
+                  }
+                }
+              });
+            });
+          }
+
+          // Global BFIs
+          for (auto& bfi : pb.getGlobalBFIs())
+          {
+            const auto uUUID = bfi.getTrialFunction().getUUID();
+            const auto vUUID = bfi.getTestFunction().getUUID();
+
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& trialAttrs = bfi.getTrialAttributes();
+            const auto& testAttrs = bfi.getTestAttributes();
+
+            SequentialIteration trialseq(mesh, bfi.getTrialRegion());
+            SequentialIteration testseq(mesh, bfi.getTestRegion());
+
+            withTrialFES(uUUID, [&](const auto& uFES) {
+              withTestFES(vUUID, [&](const auto& vFES) {
+                for (auto teIt = testseq.getIterator(); teIt; ++teIt)
+                {
+                  if (!testAttrs.empty())
+                  {
+                    const auto a = teIt->getAttribute();
+                    if (!a || !testAttrs.count(*a))
+                      continue;
+                  }
+
+                  const auto& rows = vFES.getDOFs(teIt.getDimension(), teIt->getIndex());
+
+                  for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
+                  {
+                    if (!trialAttrs.empty())
+                    {
+                      const auto a = trIt->getAttribute();
+                      if (!a || !trialAttrs.count(*a))
+                        continue;
+                    }
+
+                    const auto& cols =
+                      uFES.getDOFs(trIt.getDimension(), trIt->getIndex());
+
+                    bfi.setPolytope(*trIt, *teIt);
+
+                    for (PetscInt i = 0; i < static_cast<PetscInt>(rows.size()); ++i)
+                    {
+                      const Index I =
+                        static_cast<Index>(vOff + static_cast<size_t>(rows[i]));
+                      for (PetscInt j = 0; j < static_cast<PetscInt>(cols.size()); ++j)
+                      {
+                        const Index J =
+                          static_cast<Index>(uOff + static_cast<size_t>(cols[j]));
+                        const PetscScalar val =
+                          static_cast<PetscScalar>(bfi.integrate(j, i));
+                        matrix_entry(I, J, val);
+                      }
+                    }
+                  }
+                }
+              });
+            });
+          }
+
+          // Preassembled bilinear forms (with block offsets)
+          for (auto& bf : pb.getBFs())
+          {
+            const auto uUUID = bf.getTrialFunction().getUUID();
+            const auto vUUID = bf.getTestFunction().getUUID();
+
+            const size_t uBlock = findTrialBlock(uUUID);
+            const size_t vBlock = findTestBlock(vUUID);
+
+            const size_t uOff = trialOffsets[uBlock];
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& op = bf.getOperator();
+            PetscInt opRows, opCols;
+            ierr = MatGetSize(op, &opRows, &opCols);
+            assert(ierr == PETSC_SUCCESS);
+            (void)ierr;
+
+            for (PetscInt i = 0; i < opRows; ++i)
             {
+              PetscInt nc;
+              const PetscInt* cols;
+              const PetscScalar* vals;
+              ierr = MatGetRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              (void)ierr;
+              for (PetscInt j = 0; j < nc; ++j)
+              {
+                matrix_entry(static_cast<Index>(vOff) + static_cast<Index>(i),
+                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]), vals[j]);
+              }
+              ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
+              assert(ierr == PETSC_SUCCESS);
+              (void)ierr;
+            }
+          }
+
+          ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+          (void)ierr;
+          ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+          assert(ierr == PETSC_SUCCESS);
+          (void)ierr;
+        } // doMatrix
+
+        // ------------------------
+        // Assemble linear terms into b
+        // ------------------------
+        if (doVector)
+        {
+          for (auto& lfi : pb.getLFIs())
+          {
+            const auto vUUID = lfi.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& attrs = lfi.getAttributes();
+            SequentialIteration seq(mesh, lfi.getRegion());
+
+            withTestFES(vUUID, [&](const auto& vFES) {
               for (auto it = seq.getIterator(); it; ++it)
               {
                 if (!attrs.empty())
@@ -1223,218 +1315,54 @@ namespace Rodin::Assembly
                     continue;
                 }
 
-                const size_t d = it->getDimension();
-                const Index  p = it->getIndex();
+                lfi.setPolytope(*it);
 
-                bfi.setPolytope(*it);
-
-                const auto& rows = vFES.getDOFs(d, p);
-                const auto& cols = uFES.getDOFs(d, p);
-
-                const PetscInt nr = static_cast<PetscInt>(rows.size());
-                const PetscInt nc = static_cast<PetscInt>(cols.size());
-
-                for (PetscInt i = 0; i < nr; ++i)
+                const auto& dofs = vFES.getDOFs(it.getDimension(), it->getIndex());
+                for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
                 {
-                  const Index I =
-                    static_cast<Index>(vOff + static_cast<size_t>(rows[static_cast<size_t>(i)]));
-                  for (PetscInt j = 0; j < nc; ++j)
-                  {
-                    const Index J =
-                      static_cast<Index>(uOff + static_cast<size_t>(cols[static_cast<size_t>(j)]));
-                    const PetscScalar val =
-                      static_cast<PetscScalar>(bfi.integrate(
-                            static_cast<size_t>(j), static_cast<size_t>(i)));
-                    matrix_entry(I, J, val);
-                  }
+                  const Index I = static_cast<Index>(vOff + static_cast<size_t>(dofs[l]));
+                  const PetscScalar val = static_cast<PetscScalar>(lfi.integrate(l));
+                  vector_entry(I, -val);
                 }
               }
             });
-          });
-        }
-
-        // Global BFIs
-        for (auto& bfi : pb.getGlobalBFIs())
-        {
-          const auto uUUID = bfi.getTrialFunction().getUUID();
-          const auto vUUID = bfi.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& trialAttrs = bfi.getTrialAttributes();
-          const auto& testAttrs  = bfi.getTestAttributes();
-
-          SequentialIteration trialseq(mesh, bfi.getTrialRegion());
-          SequentialIteration testseq(mesh, bfi.getTestRegion());
-
-          withTrialFES(uUUID, [&](const auto& uFES)
-          {
-            withTestFES(vUUID, [&](const auto& vFES)
-            {
-              for (auto teIt = testseq.getIterator(); teIt; ++teIt)
-              {
-                if (!testAttrs.empty())
-                {
-                  const auto a = teIt->getAttribute();
-                  if (!a || !testAttrs.count(*a))
-                    continue;
-                }
-
-                const auto& rows = vFES.getDOFs(teIt.getDimension(), teIt->getIndex());
-
-                for (auto trIt = trialseq.getIterator(); trIt; ++trIt)
-                {
-                  if (!trialAttrs.empty())
-                  {
-                    const auto a = trIt->getAttribute();
-                    if (!a || !trialAttrs.count(*a))
-                      continue;
-                  }
-
-                  const auto& cols = uFES.getDOFs(trIt.getDimension(), trIt->getIndex());
-
-                  bfi.setPolytope(*trIt, *teIt);
-
-                  for (PetscInt i = 0; i < static_cast<PetscInt>(rows.size()); ++i)
-                  {
-                    const Index I = static_cast<Index>(vOff + static_cast<size_t>(rows[i]));
-                    for (PetscInt j = 0; j < static_cast<PetscInt>(cols.size()); ++j)
-                    {
-                      const Index J = static_cast<Index>(uOff + static_cast<size_t>(cols[j]));
-                      const PetscScalar val = static_cast<PetscScalar>(bfi.integrate(j, i));
-                      matrix_entry(I, J, val);
-                    }
-                  }
-                }
-              }
-            });
-          });
-        }
-
-        // Preassembled bilinear forms (with block offsets)
-        for (auto& bf : pb.getBFs())
-        {
-          const auto uUUID = bf.getTrialFunction().getUUID();
-          const auto vUUID = bf.getTestFunction().getUUID();
-
-          const size_t uBlock = findTrialBlock(uUUID);
-          const size_t vBlock = findTestBlock(vUUID);
-
-          const size_t uOff = trialOffsets[uBlock];
-          const size_t vOff = testOffsets[vBlock];
-
-          const auto& op = bf.getOperator();
-          PetscInt opRows, opCols;
-          ierr = MatGetSize(op, &opRows, &opCols);
-          assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
-
-          for (PetscInt i = 0; i < opRows; ++i)
-          {
-            PetscInt nc;
-            const PetscInt* cols;
-            const PetscScalar* vals;
-            ierr = MatGetRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
-            for (PetscInt j = 0; j < nc; ++j)
-            {
-              matrix_entry(
-                static_cast<Index>(vOff) + static_cast<Index>(i),
-                static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
-                vals[j]);
-            }
-            ierr = MatRestoreRow(op, i, &nc, &cols, &vals);
-            assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
           }
-        }
 
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
-        } // doMatrix
-
-        // ------------------------
-        // Assemble linear terms into b
-        // ------------------------
-        if (doVector)
-        {
-        for (auto& lfi : pb.getLFIs())
-        {
-          const auto vUUID = lfi.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
-
-          const auto& attrs = lfi.getAttributes();
-          SequentialIteration seq(mesh, lfi.getRegion());
-
-          withTestFES(vUUID, [&](const auto& vFES)
+          // Preassembled linear forms (with block offsets)
+          for (auto& lf : pb.getLFs())
           {
-            for (auto it = seq.getIterator(); it; ++it)
+            const auto vUUID = lf.getTestFunction().getUUID();
+            const size_t vBlock = findTestBlock(vUUID);
+            const size_t vOff = testOffsets[vBlock];
+
+            const auto& vec = lf.getVector();
+            PetscInt vecSize;
+            ierr = VecGetSize(vec, &vecSize);
+            assert(ierr == PETSC_SUCCESS);
+            (void)ierr;
+
+            const PetscScalar* arr;
+            ierr = VecGetArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            (void)ierr;
+            for (PetscInt i = 0; i < vecSize; ++i)
             {
-              if (!attrs.empty())
+              if (arr[i] != PetscScalar(0))
               {
-                const auto a = it->getAttribute();
-                if (!a || !attrs.count(*a))
-                  continue;
-              }
-
-              lfi.setPolytope(*it);
-
-              const auto& dofs = vFES.getDOFs(it.getDimension(), it->getIndex());
-              for (PetscInt l = 0; l < static_cast<PetscInt>(dofs.size()); ++l)
-              {
-                const Index I = static_cast<Index>(vOff + static_cast<size_t>(dofs[l]));
-                const PetscScalar val = static_cast<PetscScalar>(lfi.integrate(l));
-                vector_entry(I, -val);
+                vector_entry(static_cast<Index>(vOff) + static_cast<Index>(i), arr[i]);
               }
             }
-          });
-        }
-
-        // Preassembled linear forms (with block offsets)
-        for (auto& lf : pb.getLFs())
-        {
-          const auto vUUID = lf.getTestFunction().getUUID();
-          const size_t vBlock = findTestBlock(vUUID);
-          const size_t vOff   = testOffsets[vBlock];
-
-          const auto& vec = lf.getVector();
-          PetscInt vecSize;
-          ierr = VecGetSize(vec, &vecSize);
-          assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
-
-          const PetscScalar* arr;
-          ierr = VecGetArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
-          for (PetscInt i = 0; i < vecSize; ++i)
-          {
-            if (arr[i] != PetscScalar(0))
-            {
-              vector_entry(static_cast<Index>(vOff) + static_cast<Index>(i), arr[i]);
-            }
+            ierr = VecRestoreArrayRead(vec, &arr);
+            assert(ierr == PETSC_SUCCESS);
+            (void)ierr;
           }
-          ierr = VecRestoreArrayRead(vec, &arr);
-          assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
-        }
 
-        ierr = VecAssemblyBegin(b);
-        assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
-        ierr = VecAssemblyEnd(b);
-        assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+          ierr = VecAssemblyBegin(b);
+          assert(ierr == PETSC_SUCCESS);
+          (void)ierr;
+          ierr = VecAssemblyEnd(b);
+          assert(ierr == PETSC_SUCCESS);
+          (void)ierr;
         } // doVector
 
         if (!constraints.getIdentifiedRows().empty())
@@ -1454,7 +1382,7 @@ namespace Rodin::Assembly
                 0.0,
                 nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             for (const Index gs : constraints.getIdentifiedRows())
             {
@@ -1464,33 +1392,33 @@ namespace Rodin::Assembly
               const PetscScalar one = 1.0;
               ierr = MatSetValue(A, I, I, one, ADD_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
               for (const auto& e : constraints.expand(gs))
               {
                 const PetscInt J = static_cast<PetscInt>(e.index);
                 const PetscScalar v = -e.coefficient;
                 ierr = MatSetValue(A, I, J, v, ADD_VALUES);
                 assert(ierr == PETSC_SUCCESS);
-                (void) ierr;
+                (void)ierr;
               }
               const PetscScalar rhs = constraints.getIdentificationValue(gs);
               ierr = VecSetValue(b, I, rhs, INSERT_VALUES);
               assert(ierr == PETSC_SUCCESS);
-              (void) ierr;
+              (void)ierr;
             }
 
             ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -1512,70 +1440,52 @@ namespace Rodin::Assembly
             Vec bcVec;
             ierr = VecDuplicate(b, &bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecZeroEntries(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
-            ierr = VecSetValues(
-                bcVec,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecAssemblyBegin(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = MatZeroRowsColumns(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                bcVec,
-                b);
+              A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0, bcVec, b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
 
             ierr = VecDestroy(&bcVec);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else if (mode == AssemblyMode::LHS)
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                1.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(), 1.0,
+              nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
           else
           {
-            ierr = VecSetValues(
-                b,
-                static_cast<PetscInt>(bcIdx.size()),
-                bcIdx.data(),
-                bcVals.data(),
-                INSERT_VALUES);
+            ierr = VecSetValues(b, static_cast<PetscInt>(bcIdx.size()), bcIdx.data(),
+              bcVals.data(), INSERT_VALUES);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyBegin(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
             ierr = VecAssemblyEnd(b);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
       }

--- a/src/Rodin/PETSc/Assembly/VectorSetup.h
+++ b/src/Rodin/PETSc/Assembly/VectorSetup.h
@@ -83,26 +83,26 @@ namespace Rodin::PETSc::Assembly
         bool needsSetup = true;
         PetscErrorCode ierr = needsStructuralSetup(options, needsSetup);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         if (needsSetup)
         {
           ierr = VecSetSizes(m_vector, options.localSize, options.globalSize);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
           if (options.type)
           {
             ierr = VecSetType(m_vector, options.type);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
 
           if (options.setFromOptions)
           {
             ierr = VecSetFromOptions(m_vector);
             assert(ierr == PETSC_SUCCESS);
-            (void) ierr;
+            (void)ierr;
           }
         }
 
@@ -117,13 +117,12 @@ namespace Rodin::PETSc::Assembly
       // vector whose size matches is reused. A typed vector whose size differs
       // violates the constant-space contract and cannot be resized in place, so
       // it fails the debug assertion.
-      PetscErrorCode needsStructuralSetup(
-          const Options& options, bool& needsSetup) const
+      PetscErrorCode needsStructuralSetup(const Options& options, bool& needsSetup) const
       {
         VecType curType = nullptr;
         PetscErrorCode ierr = VecGetType(m_vector, &curType);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
 
         const bool hasType = (curType != nullptr);
         if (hasType)
@@ -131,11 +130,10 @@ namespace Rodin::PETSc::Assembly
           PetscInt curSize = 0;
           ierr = VecGetSize(m_vector, &curSize);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
-          assert(
-              curSize == options.globalSize &&
-              "VectorSetup cannot resize an assembled vector; use a fresh "
-              "LinearSystem for a different space or mesh.");
+          (void)ierr;
+          assert(curSize == options.globalSize &&
+            "VectorSetup cannot resize an assembled vector; use a fresh "
+            "LinearSystem for a different space or mesh.");
         }
 
         needsSetup = !hasType;

--- a/src/Rodin/PETSc/Math/LinearSystem.cpp
+++ b/src/Rodin/PETSc/Math/LinearSystem.cpp
@@ -20,7 +20,7 @@ namespace Rodin::Math
       {
         PetscErrorCode ierr = PetscObjectReference(obj);
         assert(ierr == PETSC_SUCCESS);
-        (void) ierr;
+        (void)ierr;
       }
     }
 
@@ -37,7 +37,7 @@ namespace Rodin::Math
       ierr = VecDestroy(&b);
       assert(ierr == PETSC_SUCCESS);
 
-      (void) ierr;
+      (void)ierr;
     }
   }
 

--- a/src/Rodin/PETSc/Solver/SNES.cpp
+++ b/src/Rodin/PETSc/Solver/SNES.cpp
@@ -151,10 +151,7 @@ namespace Rodin::Solver
     return PETSC_SUCCESS;
   }
 
-  PetscErrorCode SNES::Assemble(
-      ::Vec x,
-      void* ctx,
-      Variational::AssemblyTarget target)
+  PetscErrorCode SNES::Assemble(::Vec x, void* ctx, Variational::AssemblyTarget target)
   {
     auto* self = static_cast<SNES*>(ctx);
     assert(self);
@@ -167,10 +164,8 @@ namespace Rodin::Solver
     if (ierr)
       return ierr;
 
-    auto& assembled =
-      target == Variational::AssemblyTarget::LHS
-        ? self->m_lhsAssembled
-        : self->m_rhsAssembled;
+    auto& assembled = target == Variational::AssemblyTarget::LHS ? self->m_lhsAssembled
+                                                                 : self->m_rhsAssembled;
     if (assembled && *assembled == state)
       return PETSC_SUCCESS;
 #endif
@@ -270,8 +265,7 @@ namespace Rodin::Solver
         {
           const auto& s = splits[k];
           assert(s.is);
-          const std::string name =
-            !s.name.empty() ? s.name : std::to_string(k);
+          const std::string name = !s.name.empty() ? s.name : std::to_string(k);
           ierr = PCFieldSplitSetIS(pc, name.c_str(), s.is);
           assert(ierr == PETSC_SUCCESS);
         }

--- a/src/Rodin/PETSc/Solver/SNES.h
+++ b/src/Rodin/PETSc/Solver/SNES.h
@@ -181,9 +181,12 @@ namespace Rodin::Solver
        *
        * The solution vector is obtained directly from
        * @c ksp.getProblem().getLinearSystem().getSolution(), so no manual
-       * initial-guess packing is needed.  After the first solve the solution
-       * vector retains its value, providing a natural warm-start for subsequent
-       * time steps.
+       * initial-guess packing is needed. A full @c Problem::assemble() seeds
+       * this vector from the trial function data, so the initial iterate is
+       * the trial functions' state — consistent with
+       * @c NewtonSolverBase::solve(GridFunction&). After the first solve the
+       * solution vector retains its value, providing a natural warm start for
+       * subsequent time steps.
        */
       void solve();
 
@@ -228,18 +231,18 @@ namespace Rodin::Solver
     private:
       static PetscErrorCode Update(::Vec x, void* ctx);
       static PetscErrorCode Assemble(
-          ::Vec x, void* ctx, Variational::AssemblyTarget target);
+        ::Vec x, void* ctx, Variational::AssemblyTarget target);
       static PetscErrorCode Residual(::SNES snes, ::Vec x, ::Vec f, void* ctx);
       static PetscErrorCode Jacobian(::SNES snes, ::Vec x, ::Mat J, ::Mat P, void* ctx);
 
     private:
       HandleType m_snes;   ///< Underlying PETSc SNES context.
       ::SNESType m_type;   ///< Requested SNES algorithm type.
-      ::PetscReal m_abstol,  ///< Absolute convergence tolerance.
-                  m_rtol,    ///< Relative convergence tolerance.
-                  m_stol;    ///< Step norm convergence tolerance.
-      ::PetscInt m_maxIt,    ///< Maximum nonlinear iterations.
-                 m_maxF;     ///< Maximum function evaluations.
+      ::PetscReal m_abstol, ///< Absolute convergence tolerance.
+        m_rtol, ///< Relative convergence tolerance.
+        m_stol; ///< Step norm convergence tolerance.
+      ::PetscInt m_maxIt, ///< Maximum nonlinear iterations.
+        m_maxF; ///< Maximum function evaluations.
       StateUpdate m_update; ///< Optional state synchronization callback.
       Optional<::PetscObjectState> m_lhsAssembled;
       Optional<::PetscObjectState> m_rhsAssembled;

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -229,10 +229,25 @@ namespace Rodin::Variational
         return *this;
       }
 
-      /// @brief Assembles the variational formulation into the linear system.
+      /**
+       * @brief Assembles the variational formulation and establishes the
+       *        initial guess.
+       *
+       * After assembly, the linear system's solution vector holds the trial
+       * function data as the initial guess: on entry to a linear solver the
+       * solution vector is the guess, on exit it is the solution. Trial
+       * functions are zero-initialized, so the guess is zero unless set.
+       */
       Problem& assemble() override
       {
         m_assembly.execute(m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() });
+
+        const auto& u = this->getTrialFunction().getSolution();
+        u.flush();
+        PetscErrorCode ierr = VecCopy(u.getData(), m_axb.getSolution());
+        assert(ierr == PETSC_SUCCESS);
+        (void)ierr;
+
         m_assembled = true;
         return *this;
       }
@@ -242,7 +257,8 @@ namespace Rodin::Variational
       /// @returns Reference to this problem.
       Problem& assemble(AssemblyTarget target) override
       {
-        m_assembly.execute(m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() }, target);
+        m_assembly.execute(
+          m_axb, {m_pb, this->getTrialFunction(), this->getTestFunction()}, target);
         m_assembled = true;
         return *this;
       }
@@ -593,7 +609,15 @@ namespace Rodin::Variational
       // --------------------------
       // Assembly / solve
       // --------------------------
-      /// @brief Assembles the block-structured variational formulation.
+      /**
+       * @brief Assembles the block-structured variational formulation and
+       *        establishes the initial guess.
+       *
+       * After assembly, the linear system's solution vector holds the trial
+       * function data, gathered at the trial offsets, as the initial guess:
+       * on entry to a linear solver the solution vector is the guess, on
+       * exit it is the solution.
+       */
       Problem& assemble() override
       {
         computeOffsets();
@@ -607,6 +631,29 @@ namespace Rodin::Variational
 
         m_assembly.execute(m_axb, in);
 
+        // Gather the trial function data into the solution vector.
+        PetscErrorCode ierr;
+        m_us.iapply([&](size_t i, const auto& uref) {
+          const auto& u = uref.get().getSolution();
+          u.flush();
+
+          PetscInt n = 0;
+          ierr = VecGetSize(u.getData(), &n);
+          assert(ierr == PETSC_SUCCESS);
+
+          ::IS is = PETSC_NULLPTR;
+          ierr = ISCreateStride(
+            m_axb.getCommunicator(), n, static_cast<PetscInt>(m_trialOffsets[i]), 1, &is);
+          assert(ierr == PETSC_SUCCESS);
+
+          ierr = VecISCopy(m_axb.getSolution(), is, SCATTER_FORWARD, u.getData());
+          assert(ierr == PETSC_SUCCESS);
+
+          ierr = ISDestroy(&is);
+          assert(ierr == PETSC_SUCCESS);
+        });
+        (void)ierr;
+
         m_assembled = true;
         return *this;
       }
@@ -618,12 +665,8 @@ namespace Rodin::Variational
       {
         computeOffsets();
 
-        AssemblyInput in{
-          m_pb, m_us, m_vs,
-          m_trialOffsets, m_testOffsets,
-          m_trialUUIDMap, m_testUUIDMap,
-          m_totalTrial, m_totalTest
-        };
+        AssemblyInput in{m_pb, m_us, m_vs, m_trialOffsets, m_testOffsets, m_trialUUIDMap,
+          m_testUUIDMap, m_totalTrial, m_totalTest};
 
         m_assembly.execute(m_axb, in, target);
 

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -631,22 +631,41 @@ namespace Rodin::Variational
 
         m_assembly.execute(m_axb, in);
 
-        // Gather the trial function data into the solution vector.
+        // Gather each trial field's data into the block solution vector, so
+        // it holds the initial guess. This is the reverse of the scatter-back
+        // in solve() and mirrors GridFunction::setData: the IS local size must
+        // match the field vector's owned range, not the global field size, or
+        // the copy is invalid in the distributed case.
         PetscErrorCode ierr;
         m_us.iapply([&](size_t i, const auto& uref) {
           const auto& u = uref.get().getSolution();
           u.flush();
 
-          PetscInt n = 0;
-          ierr = VecGetSize(u.getData(), &n);
+          const PetscInt off = static_cast<PetscInt>(m_trialOffsets[i]);
+
+          PetscInt rb = 0, re = 0;
+          ierr = VecGetOwnershipRange(u.getData(), &rb, &re);
+          assert(ierr == PETSC_SUCCESS);
+          const PetscInt nLocal = re - rb;
+
+          MPI_Comm comm;
+          ierr = PetscObjectGetComm((PetscObject)m_axb.getSolution(), &comm);
           assert(ierr == PETSC_SUCCESS);
 
           ::IS is = PETSC_NULLPTR;
-          ierr = ISCreateStride(
-            m_axb.getCommunicator(), n, static_cast<PetscInt>(m_trialOffsets[i]), 1, &is);
+          ierr = ISCreateStride(comm, nLocal, off + rb, 1, &is);
           assert(ierr == PETSC_SUCCESS);
 
-          ierr = VecISCopy(m_axb.getSolution(), is, SCATTER_FORWARD, u.getData());
+          ::Vec sub = PETSC_NULLPTR;
+          ierr = VecGetSubVector(m_axb.getSolution(), is, &sub);
+          assert(ierr == PETSC_SUCCESS);
+
+          // sub and u.getData() now share a local layout, so copy the owned
+          // field values into the block sub-vector.
+          ierr = VecCopy(u.getData(), sub);
+          assert(ierr == PETSC_SUCCESS);
+
+          ierr = VecRestoreSubVector(m_axb.getSolution(), is, &sub);
           assert(ierr == PETSC_SUCCESS);
 
           ierr = ISDestroy(&is);

--- a/src/Rodin/Serialization/Optional.h
+++ b/src/Rodin/Serialization/Optional.h
@@ -29,10 +29,10 @@ namespace boost::serialization
   void save(Archive& ar, const std::optional<T>& opt, const unsigned int version)
   {
     (void)version;
-    bool has_value = opt.has_value();
-    ar & has_value;
+    bool hasValue = opt.has_value();
+    ar & hasValue;
 
-    if (has_value)
+    if (hasValue)
       ar&* opt;
   }
 
@@ -48,10 +48,10 @@ namespace boost::serialization
   void load(Archive& ar, std::optional<T>& opt, const unsigned int version)
   {
     (void)version;
-    bool has_value;
-    ar & has_value;
+    bool hasValue;
+    ar & hasValue;
 
-    if (has_value)
+    if (hasValue)
     {
       T value;
       ar & value;

--- a/src/Rodin/Solid/ForwardDecls.h
+++ b/src/Rodin/Solid/ForwardDecls.h
@@ -53,8 +53,8 @@ namespace Rodin::Solid
   template <class LawDerived, class TestFunctionType, class DisplacementType>
   class InternalVirtualWorkResidual;
 
-  template <class LawDerived, class TrialFunctionType,
-            class TestFunctionType, class DisplacementType>
+  template <class LawDerived, class TrialFunctionType, class TestFunctionType,
+    class DisplacementType>
   class InternalVirtualWorkTangent;
 
   template <class Law, class State>

--- a/src/Rodin/Solid/Integrators/InternalVirtualWork.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWork.h
@@ -91,7 +91,7 @@ namespace Rodin::Solid
   {
     public:
       /// @brief Constitutive law type.
-      using LawType   = Law;
+      using LawType = Law;
       /// @brief Current displacement state type.
       using StateType = State;
 
@@ -137,7 +137,10 @@ namespace Rodin::Solid
       }
 
       /// @brief Gets the constitutive law.
-      const Law& getLaw() const { return m_law; }
+      const Law& getLaw() const
+      {
+        return m_law;
+      }
 
       /**
        * @brief Returns the residual integrator (linear form contribution).
@@ -193,8 +196,8 @@ namespace Rodin::Solid
 
   /// CTAD deduction guide for InternalVirtualWork
   template <class Law, class State>
-  InternalVirtualWork(const Law&, const State&)
-    -> InternalVirtualWork<std::decay_t<Law>, std::decay_t<State>>;
+  InternalVirtualWork(const Law&,
+    const State&) -> InternalVirtualWork<std::decay_t<Law>, std::decay_t<State>>;
 }
 
 #endif

--- a/src/Rodin/Solid/Integrators/InternalVirtualWorkResidual.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWorkResidual.h
@@ -104,9 +104,7 @@ namespace Rodin::Solid
        * @param displacement Current displacement grid function
        */
       InternalVirtualWorkResidual(
-          const LawDerived& law,
-          const TestType& v,
-          const StateType& displacement)
+        const LawDerived& law, const TestType& v, const StateType& displacement)
         : Parent(v),
           m_law(law),
           m_test(v),
@@ -127,7 +125,8 @@ namespace Rodin::Solid
           m_testfes(other.m_testfes),
           m_statefes(other.m_statefes),
           m_quadOrder(other.m_quadOrder),
-          m_input(other.m_input)      {}
+          m_input(other.m_input)
+      {}
 
       /**
        * @brief Rebinds the current displacement state.
@@ -176,7 +175,8 @@ namespace Rodin::Solid
       }
 
       /// @brief Sets the current polytope and assembles the element residual.
-      InternalVirtualWorkResidual& setPolytope(const Geometry::Polytope& polytope) final override
+      InternalVirtualWorkResidual& setPolytope(
+        const Geometry::Polytope& polytope) final override
       {
         m_polytope = polytope;
 
@@ -194,7 +194,8 @@ namespace Rodin::Solid
         const size_t effectiveOrder = (m_quadOrder > 0)
           ? m_quadOrder
           : 2 * std::max(testFE.getOrder(), stateFE.getOrder());
-        const auto& qf = QF::PolytopeQuadratureFormula::get(effectiveOrder, polytope.getGeometry());
+        const auto& qf =
+          QF::PolytopeQuadratureFormula::get(effectiveOrder, polytope.getGeometry());
         const auto& quadrature = polytope.getQuadrature(qf);
         const size_t nqp = quadrature.getSize();
 
@@ -276,7 +277,10 @@ namespace Rodin::Solid
       }
 
       /// @brief Gets the constitutive law.
-      const LawType& getLaw() const { return m_law; }
+      const LawType& getLaw() const
+      {
+        return m_law;
+      }
 
     private:
       void checkCompatibility(const StateType& displacement) const
@@ -286,8 +290,8 @@ namespace Rodin::Solid
 
         assert(&stateFES.getMesh() == &testFES.getMesh());
         assert(stateFES.getVectorDimension() == testFES.getVectorDimension());
-        (void) testFES;
-        (void) stateFES;
+        (void)testFES;
+        (void)stateFES;
       }
 
       LawType m_law;
@@ -304,13 +308,10 @@ namespace Rodin::Solid
 
   /// CTAD deduction guide for InternalVirtualWorkResidual
   template <class LawDerived, class TestFunctionType, class DisplacementType>
-  InternalVirtualWorkResidual(const LawDerived&,
-                               const TestFunctionType&,
-                               const DisplacementType&)
-    -> InternalVirtualWorkResidual<
-         LawDerived,
-         std::decay_t<TestFunctionType>,
-         std::decay_t<DisplacementType>>;
+  InternalVirtualWorkResidual(
+    const LawDerived&, const TestFunctionType&, const DisplacementType&)
+    -> InternalVirtualWorkResidual<LawDerived, std::decay_t<TestFunctionType>,
+      std::decay_t<DisplacementType>>;
 }
 
 #endif

--- a/src/Rodin/Solid/Integrators/InternalVirtualWorkTangent.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWorkTangent.h
@@ -74,8 +74,8 @@ namespace Rodin::Solid
    * @tparam TestFunctionType The test function type (backend-generic)
    * @tparam DisplacementType The current displacement grid-function type
    */
-  template <class LawDerived, class TrialFunctionType,
-            class TestFunctionType, class DisplacementType>
+  template <class LawDerived, class TrialFunctionType, class TestFunctionType,
+    class DisplacementType>
   class InternalVirtualWorkTangent final
     : public Variational::LocalBilinearFormIntegratorBase<Real>
   {
@@ -112,11 +112,8 @@ namespace Rodin::Solid
        * @param v The test function
        * @param displacement Current displacement grid function
        */
-      InternalVirtualWorkTangent(
-          const LawDerived& law,
-          const TrialType& u,
-          const TestType& v,
-          const StateType& displacement)
+      InternalVirtualWorkTangent(const LawDerived& law, const TrialType& u,
+        const TestType& v, const StateType& displacement)
         : Parent(u, v),
           m_law(law),
           m_trial(u),
@@ -191,7 +188,8 @@ namespace Rodin::Solid
       }
 
       /// @brief Sets the current polytope and assembles the element tangent matrix.
-      InternalVirtualWorkTangent& setPolytope(const Geometry::Polytope& polytope) final override
+      InternalVirtualWorkTangent& setPolytope(
+        const Geometry::Polytope& polytope) final override
       {
         m_polytope = polytope;
 
@@ -211,10 +209,9 @@ namespace Rodin::Solid
         // Determine effective quadrature order
         const size_t effectiveOrder = (m_quadOrder > 0)
           ? m_quadOrder
-          : 2 * std::max({ trialFE.getOrder(),
-                           testFE.getOrder(),
-                           stateFE.getOrder() });
-        const auto& qf = QF::PolytopeQuadratureFormula::get(effectiveOrder, polytope.getGeometry());
+          : 2 * std::max({trialFE.getOrder(), testFE.getOrder(), stateFE.getOrder()});
+        const auto& qf =
+          QF::PolytopeQuadratureFormula::get(effectiveOrder, polytope.getGeometry());
         const auto& quadrature = polytope.getQuadrature(qf);
         const size_t nqp = quadrature.getSize();
 
@@ -307,7 +304,10 @@ namespace Rodin::Solid
       }
 
       /// @brief Gets the constitutive law.
-      const LawType& getLaw() const { return m_law; }
+      const LawType& getLaw() const
+      {
+        return m_law;
+      }
 
     private:
       void checkCompatibility(const StateType& displacement) const
@@ -320,9 +320,9 @@ namespace Rodin::Solid
         assert(&stateFES.getMesh() == &testFES.getMesh());
         assert(trialFES.getVectorDimension() == testFES.getVectorDimension());
         assert(stateFES.getVectorDimension() == testFES.getVectorDimension());
-        (void) trialFES;
-        (void) testFES;
-        (void) stateFES;
+        (void)trialFES;
+        (void)testFES;
+        (void)stateFES;
       }
 
       LawType m_law;
@@ -340,17 +340,12 @@ namespace Rodin::Solid
   };
 
   /// CTAD deduction guide for InternalVirtualWorkTangent
-  template <class LawDerived, class TrialFunctionType,
-            class TestFunctionType, class DisplacementType>
-  InternalVirtualWorkTangent(const LawDerived&,
-                              const TrialFunctionType&,
-                              const TestFunctionType&,
-                              const DisplacementType&)
-    -> InternalVirtualWorkTangent<
-         LawDerived,
-         std::decay_t<TrialFunctionType>,
-         std::decay_t<TestFunctionType>,
-         std::decay_t<DisplacementType>>;
+  template <class LawDerived, class TrialFunctionType, class TestFunctionType,
+    class DisplacementType>
+  InternalVirtualWorkTangent(const LawDerived&, const TrialFunctionType&,
+    const TestFunctionType&, const DisplacementType&)
+    -> InternalVirtualWorkTangent<LawDerived, std::decay_t<TrialFunctionType>,
+      std::decay_t<TestFunctionType>, std::decay_t<DisplacementType>>;
 }
 
 #endif

--- a/src/Rodin/Solver/BiCGSTAB.h
+++ b/src/Rodin/Solver/BiCGSTAB.h
@@ -195,7 +195,10 @@ namespace Rodin::Solver
       void solve(LinearSystemType& axb) override
       {
         m_solver.compute(axb.getOperator());
-        axb.getSolution() = m_solver.solve(axb.getVector());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /**

--- a/src/Rodin/Solver/CG.h
+++ b/src/Rodin/Solver/CG.h
@@ -187,7 +187,11 @@ namespace Rodin::Solver
        */
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /**
@@ -297,7 +301,11 @@ namespace Rodin::Solver
        */
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solveWithGuess(axb.getVector(), axb.getSolution());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /**

--- a/src/Rodin/Solver/CHOLMOD.h
+++ b/src/Rodin/Solver/CHOLMOD.h
@@ -96,8 +96,10 @@ namespace Rodin::Solver::CHOLMOD
    * @tparam Scalar The scalar type (e.g., Real, Complex)
    */
   template <class Scalar>
-  class SupernodalLLT<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
-    : public LinearSolverBase<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
+  class SupernodalLLT<
+    Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
+    : public LinearSolverBase<
+        Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
   {
     public:
       /// Type of scalar values in the system
@@ -186,5 +188,3 @@ namespace Rodin::Solver::CHOLMOD
 
 #endif // #ifdef RODIN_USE_CHOLMOD
 #endif
-
-

--- a/src/Rodin/Solver/CHOLMOD.h
+++ b/src/Rodin/Solver/CHOLMOD.h
@@ -97,7 +97,7 @@ namespace Rodin::Solver::CHOLMOD
    */
   template <class Scalar>
   class SupernodalLLT<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
-    : public LinearSolverBase<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>, Scalar>>
+    : public LinearSolverBase<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
   {
     public:
       /// Type of scalar values in the system
@@ -186,6 +186,5 @@ namespace Rodin::Solver::CHOLMOD
 
 #endif // #ifdef RODIN_USE_CHOLMOD
 #endif
-
 
 

--- a/src/Rodin/Solver/DGMRES.h
+++ b/src/Rodin/Solver/DGMRES.h
@@ -150,7 +150,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.
@@ -246,7 +250,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.

--- a/src/Rodin/Solver/GMRES.h
+++ b/src/Rodin/Solver/GMRES.h
@@ -155,7 +155,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.
@@ -243,7 +247,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.

--- a/src/Rodin/Solver/IDRS.h
+++ b/src/Rodin/Solver/IDRS.h
@@ -144,7 +144,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.
@@ -233,7 +237,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.

--- a/src/Rodin/Solver/IDRSTABL.h
+++ b/src/Rodin/Solver/IDRSTABL.h
@@ -142,7 +142,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.
@@ -231,7 +235,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.

--- a/src/Rodin/Solver/LeastSquaresCG.h
+++ b/src/Rodin/Solver/LeastSquaresCG.h
@@ -187,7 +187,11 @@ namespace Rodin::Solver
        */
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /**
@@ -300,7 +304,10 @@ namespace Rodin::Solver
       void solve(LinearSystemType& axb) override
       {
         m_solver.compute(axb.getOperator());
-        axb.getSolution() = m_solver.solve(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /**

--- a/src/Rodin/Solver/LinearSolver.h
+++ b/src/Rodin/Solver/LinearSolver.h
@@ -131,11 +131,19 @@ namespace Rodin::Solver
        * @brief Solves the linear system.
        *
        * Solves the linear system @f$ Ax = b @f$ where @f$ A @f$ is the matrix
-       * operator, @f$ x @f$ is the solution vector, and @f$ b @f$ is the 
+       * operator, @f$ x @f$ is the solution vector, and @f$ b @f$ is the
        * right-hand side vector.
        *
-       * @param[in,out] system The linear system to solve. The solution is 
-       *                       stored in the system's solution vector.
+       * @par Initial guess contract
+       * On entry, the system's solution vector holds the initial guess; on
+       * exit it holds the solution. Iterative solvers use the guess whenever
+       * it is correctly sized; direct solvers ignore it. Assembly seeds the
+       * guess from the trial function data, which is zero by construction
+       * unless set.
+       *
+       * @param[in,out] system The linear system to solve. On entry the
+       *                       solution vector is the initial guess; on exit
+       *                       it stores the solution.
        */
       virtual void solve(LinearSystem& system) = 0;
 

--- a/src/Rodin/Solver/MINRES.h
+++ b/src/Rodin/Solver/MINRES.h
@@ -146,7 +146,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.
@@ -228,7 +232,11 @@ namespace Rodin::Solver
       /// @brief Solves the assembled linear system.
       void solve(LinearSystemType& axb) override
       {
-        axb.getSolution() = m_solver.compute(axb.getOperator()).solve(axb.getVector());
+        m_solver.compute(axb.getOperator());
+        if (axb.getSolution().size() == axb.getVector().size())
+          axb.getSolution() = m_solver.solveWithGuess(axb.getVector(), axb.getSolution());
+        else
+          axb.getSolution() = m_solver.solve(axb.getVector());
       }
 
       /// @brief Returns whether the most recent solve converged successfully.

--- a/src/Rodin/Solver/NewtonSolver.h
+++ b/src/Rodin/Solver/NewtonSolver.h
@@ -737,12 +737,19 @@ namespace Rodin::Solver
             return;
           }
 
+          // The tangential solve always starts from a zero initial guess:
+          // the increment vanishes as Newton converges, so zero is its
+          // natural limit. This overrides the assembly-seeded guess, which
+          // holds the previous increment.
+          auto& increment = linearSystem.getSolution();
+          increment.resize(linearSystem.getVector().size());
+          increment.setZero();
+
           this->getLinearSolver().solve();
 
           if (m_stepPolicy)
           {
-            const StepResult step =
-              (*m_stepPolicy)(x, linearSystem, m_report);
+            const StepResult step = (*m_stepPolicy)(x, linearSystem, m_report);
             if (!std::isfinite(step.stepNorm))
             {
               m_report.reason = ConvergedReason::StepNormIsNotFinite;

--- a/src/Rodin/Test/CMakeLists.txt
+++ b/src/Rodin/Test/CMakeLists.txt
@@ -6,6 +6,7 @@ Distributed under the Boost Software License, Version 1.0.
 ]]
 
 set(RodinTest_HEADERS
+  FDProbe.h
   Random.h
   Utility.h
   Random/RandomInteger.h

--- a/src/Rodin/Test/FDProbe.h
+++ b/src/Rodin/Test/FDProbe.h
@@ -26,11 +26,16 @@ namespace Rodin::Test
    */
   struct FDProbeReport
   {
-    Real epsilon = 0.0;
-    Real absoluteError = 0.0;
-    Real relativeError = 0.0;
-    Real tangentNorm = 0.0;
-    Real finiteDifferenceNorm = 0.0;
+    /// @brief Central-difference step used by the probe.
+      Real epsilon = 0.0;
+    /// @brief Norm of the tangent-minus-finite-difference error.
+      Real absoluteError = 0.0;
+    /// @brief Absolute error scaled by the larger of the compared norms.
+      Real relativeError = 0.0;
+    /// @brief Norm of the tangent action @f$ A(u)w @f$.
+      Real tangentNorm = 0.0;
+    /// @brief Norm of the central finite difference.
+      Real finiteDifferenceNorm = 0.0;
   };
 
   /**
@@ -54,12 +59,19 @@ namespace Rodin::Test
   class FDProbe
   {
     public:
+      /// @brief Probed problem type.
       using Problem = ProblemType;
+      /// @brief Linear system type of the probed problem.
       using LinearSystemType =
         typename Problem::LinearSystemType;
+      /// @brief Vector type of the linear system.
       using VectorType =
         typename LinearSystemType::VectorType;
 
+      /**
+       * @brief Constructs the probe over a problem.
+       * @param problem Problem whose tangent is probed.
+       */
       explicit FDProbe(Problem& problem)
         : m_problem(problem)
       {}
@@ -153,18 +165,35 @@ namespace Rodin::Test
   class FDProbe<Math::LinearSystem<Operator, Vector>>
   {
     public:
+      /// @brief Probed linear system type.
       using LinearSystemType = Math::LinearSystem<Operator, Vector>;
+      /// @brief Vector type of the linear system.
       using VectorType = Vector;
 
+      /**
+       * @brief Constructs the probe over an assembled linear system.
+       * @param system Linear system whose operator is probed.
+       */
       explicit FDProbe(LinearSystemType& system)
         : m_system(system)
       {}
 
+      /**
+       * @brief Tests the system with a deterministic unit perturbation.
+       * @param epsilon Central-difference step.
+       * @return Error report.
+       */
       FDProbeReport test(Real epsilon = 1e-6)
       {
         return test(makeDeterministicDirection(), epsilon);
       }
 
+      /**
+       * @brief Tests the system in a caller-supplied perturbation direction.
+       * @param direction Direction @f$w@f$ used in the finite difference.
+       * @param epsilon Central-difference step.
+       * @return Error report.
+       */
       FDProbeReport test(const VectorType& direction, Real epsilon = 1e-6)
       {
         auto& solution = m_system.getSolution();

--- a/src/Rodin/Test/FDProbe.h
+++ b/src/Rodin/Test/FDProbe.h
@@ -62,11 +62,9 @@ namespace Rodin::Test
       /// @brief Probed problem type.
       using Problem = ProblemType;
       /// @brief Linear system type of the probed problem.
-      using LinearSystemType =
-        typename Problem::LinearSystemType;
+      using LinearSystemType = typename Problem::LinearSystemType;
       /// @brief Vector type of the linear system.
-      using VectorType =
-        typename LinearSystemType::VectorType;
+      using VectorType = typename LinearSystemType::VectorType;
 
       /**
        * @brief Constructs the probe over a problem.
@@ -109,8 +107,7 @@ namespace Rodin::Test
         m_problem.assemble();
         const auto tangent = m_problem.getLinearSystem().getOperator();
 
-        const auto finiteDifference =
-          -(1.0 / (2.0 * epsilon)) * (rhsPlus - rhsMinus);
+        const auto finiteDifference = -(1.0 / (2.0 * epsilon)) * (rhsPlus - rhsMinus);
         const auto tangentAction = tangent * direction;
         const auto error = tangentAction - finiteDifference;
 
@@ -119,11 +116,8 @@ namespace Rodin::Test
         report.absoluteError = error.norm();
         report.tangentNorm = tangentAction.norm();
         report.finiteDifferenceNorm = finiteDifference.norm();
-        report.relativeError =
-          report.absoluteError
-          / std::max<Real>(
-              1.0,
-              std::max(report.tangentNorm, report.finiteDifferenceNorm));
+        report.relativeError = report.absoluteError /
+          std::max<Real>(1.0, std::max(report.tangentNorm, report.finiteDifferenceNorm));
         return report;
       }
 
@@ -135,9 +129,7 @@ namespace Rodin::Test
         for (decltype(direction.size()) i = 0; i < direction.size(); ++i)
         {
           const Real x = static_cast<Real>(i + 1);
-          direction[i] =
-            0.5 * std::sin(0.37 * x)
-            + 0.25 * std::cos(0.19 * x);
+          direction[i] = 0.5 * std::sin(0.37 * x) + 0.25 * std::cos(0.19 * x);
         }
 
         const Real norm = direction.norm();
@@ -225,11 +217,8 @@ namespace Rodin::Test
         report.absoluteError = error.norm();
         report.tangentNorm = tangentAction.norm();
         report.finiteDifferenceNorm = finiteDifference.norm();
-        report.relativeError =
-          report.absoluteError
-          / std::max<Real>(
-              1.0,
-              std::max(report.tangentNorm, report.finiteDifferenceNorm));
+        report.relativeError = report.absoluteError /
+          std::max<Real>(1.0, std::max(report.tangentNorm, report.finiteDifferenceNorm));
         return report;
       }
 
@@ -240,9 +229,7 @@ namespace Rodin::Test
         for (decltype(direction.size()) i = 0; i < direction.size(); ++i)
         {
           const Real x = static_cast<Real>(i + 1);
-          direction[i] =
-            0.5 * std::sin(0.37 * x)
-            + 0.25 * std::cos(0.19 * x);
+          direction[i] = 0.5 * std::sin(0.37 * x) + 0.25 * std::cos(0.19 * x);
         }
 
         const Real norm = direction.norm();

--- a/src/Rodin/Test/FDProbe.h
+++ b/src/Rodin/Test/FDProbe.h
@@ -1,0 +1,229 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+/**
+ * @file FDProbe.h
+ * @brief Finite-difference probes for assembled Newton systems.
+ */
+#ifndef RODIN_TEST_FDPROBE_H
+#define RODIN_TEST_FDPROBE_H
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+#include "Rodin/Math/LinearSystem.h"
+#include "Rodin/Types.h"
+#include "Rodin/Variational/Problem.h"
+
+namespace Rodin::Test
+{
+  /**
+   * @brief Report produced by a finite-difference tangent probe.
+   */
+  struct FDProbeReport
+  {
+    Real epsilon = 0.0;
+    Real absoluteError = 0.0;
+    Real relativeError = 0.0;
+    Real tangentNorm = 0.0;
+    Real finiteDifferenceNorm = 0.0;
+  };
+
+  /**
+   * @brief Finite-difference probe for a nonlinear assembled problem.
+   *
+   * The probe checks the Newton consistency identity
+   * @f[
+   *   A(u)w \approx
+   *   -\frac{b(u + \epsilon w) - b(u - \epsilon w)}{2\epsilon},
+   * @f]
+   * where Rodin's @c Problem stores the Newton system as
+   * @f$ A(u)\Delta u = b(u) = -R(u) @f$.
+   *
+   * For problems with essential Dirichlet conditions, use the overload taking
+   * an explicit direction and pass an admissible direction, i.e. one whose
+   * constrained DOFs are zero.
+   *
+   * @tparam ProblemType Rodin variational problem type.
+   */
+  template <class ProblemType>
+  class FDProbe
+  {
+    public:
+      using Problem = ProblemType;
+      using LinearSystemType =
+        typename Problem::LinearSystemType;
+      using VectorType =
+        typename LinearSystemType::VectorType;
+
+      explicit FDProbe(Problem& problem)
+        : m_problem(problem)
+      {}
+
+      /**
+       * @brief Tests the problem with a deterministic unit perturbation.
+       * @param epsilon Central-difference step.
+       * @return Error report.
+       */
+      FDProbeReport test(Real epsilon = 1e-6)
+      {
+        return test(makeDeterministicDirection(), epsilon);
+      }
+
+      /**
+       * @brief Tests the problem in a caller-supplied perturbation direction.
+       * @param direction Direction @f$w@f$ used in the finite difference.
+       * @param epsilon Central-difference step.
+       * @return Error report.
+       */
+      FDProbeReport test(const VectorType& direction, Real epsilon = 1e-6)
+      {
+        auto& state = m_problem.getTrialFunction().getSolution();
+        const auto stateData = state.getData();
+
+        state.getData() = stateData + epsilon * direction;
+        m_problem.assemble();
+        const auto rhsPlus = m_problem.getLinearSystem().getVector();
+
+        state.getData() = stateData - epsilon * direction;
+        m_problem.assemble();
+        const auto rhsMinus = m_problem.getLinearSystem().getVector();
+
+        state.getData() = stateData;
+        m_problem.assemble();
+        const auto tangent = m_problem.getLinearSystem().getOperator();
+
+        const auto finiteDifference =
+          -(1.0 / (2.0 * epsilon)) * (rhsPlus - rhsMinus);
+        const auto tangentAction = tangent * direction;
+        const auto error = tangentAction - finiteDifference;
+
+        FDProbeReport report;
+        report.epsilon = epsilon;
+        report.absoluteError = error.norm();
+        report.tangentNorm = tangentAction.norm();
+        report.finiteDifferenceNorm = finiteDifference.norm();
+        report.relativeError =
+          report.absoluteError
+          / std::max<Real>(
+              1.0,
+              std::max(report.tangentNorm, report.finiteDifferenceNorm));
+        return report;
+      }
+
+    private:
+      VectorType makeDeterministicDirection()
+      {
+        const auto& state = m_problem.getTrialFunction().getSolution();
+        auto direction = state.getData();
+        for (decltype(direction.size()) i = 0; i < direction.size(); ++i)
+        {
+          const Real x = static_cast<Real>(i + 1);
+          direction[i] =
+            0.5 * std::sin(0.37 * x)
+            + 0.25 * std::cos(0.19 * x);
+        }
+
+        const Real norm = direction.norm();
+        if (norm > 0.0)
+          direction *= 1.0 / norm;
+        return direction;
+      }
+
+      Problem& m_problem;
+  };
+
+  /**
+   * @brief Finite-difference probe for an assembled linear system.
+   *
+   * This specialization probes the affine residual
+   * @f[
+   *   F(x) = Ax - b
+   * @f]
+   * and checks
+   * @f[
+   *   Aw \approx \frac{F(x + \epsilon w) - F(x - \epsilon w)}{2\epsilon}.
+   * @f]
+   */
+  template <class Operator, class Vector>
+  class FDProbe<Math::LinearSystem<Operator, Vector>>
+  {
+    public:
+      using LinearSystemType = Math::LinearSystem<Operator, Vector>;
+      using VectorType = Vector;
+
+      explicit FDProbe(LinearSystemType& system)
+        : m_system(system)
+      {}
+
+      FDProbeReport test(Real epsilon = 1e-6)
+      {
+        return test(makeDeterministicDirection(), epsilon);
+      }
+
+      FDProbeReport test(const VectorType& direction, Real epsilon = 1e-6)
+      {
+        auto& solution = m_system.getSolution();
+        if (solution.size() != direction.size())
+        {
+          solution.resize(direction.size());
+          solution.setZero();
+        }
+
+        const auto solutionData = solution;
+
+        solution = solutionData + epsilon * direction;
+        VectorType residualPlus =
+          m_system.getOperator() * solution - m_system.getVector();
+
+        solution = solutionData - epsilon * direction;
+        VectorType residualMinus =
+          m_system.getOperator() * solution - m_system.getVector();
+
+        solution = solutionData;
+
+        const auto finiteDifference =
+          (1.0 / (2.0 * epsilon)) * (residualPlus - residualMinus);
+        const auto tangentAction = m_system.getOperator() * direction;
+        const auto error = tangentAction - finiteDifference;
+
+        FDProbeReport report;
+        report.epsilon = epsilon;
+        report.absoluteError = error.norm();
+        report.tangentNorm = tangentAction.norm();
+        report.finiteDifferenceNorm = finiteDifference.norm();
+        report.relativeError =
+          report.absoluteError
+          / std::max<Real>(
+              1.0,
+              std::max(report.tangentNorm, report.finiteDifferenceNorm));
+        return report;
+      }
+
+    private:
+      VectorType makeDeterministicDirection()
+      {
+        VectorType direction(m_system.getOperator().cols());
+        for (decltype(direction.size()) i = 0; i < direction.size(); ++i)
+        {
+          const Real x = static_cast<Real>(i + 1);
+          direction[i] =
+            0.5 * std::sin(0.37 * x)
+            + 0.25 * std::cos(0.19 * x);
+        }
+
+        const Real norm = direction.norm();
+        if (norm > 0.0)
+          direction *= 1.0 / norm;
+        return direction;
+      }
+
+      LinearSystemType& m_system;
+  };
+}
+
+#endif

--- a/src/Rodin/Variational/Component.h
+++ b/src/Rodin/Variational/Component.h
@@ -499,7 +499,7 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        const auto basis = this->getOperand().getBasis(local);
+        decltype(auto) basis = this->getOperand().getBasis(local);
         return basis(m_idx);
       }
 

--- a/src/Rodin/Variational/Conjugate.h
+++ b/src/Rodin/Variational/Conjugate.h
@@ -248,7 +248,7 @@ namespace Rodin::Variational
       constexpr
       decltype(auto) getBasis(size_t local) const
       {
-        const auto v = this->getOperand().getBasis(local);
+        decltype(auto) v = this->getOperand().getBasis(local);
         return Math::conj(v);
       }
 

--- a/src/Rodin/Variational/Division.h
+++ b/src/Rodin/Variational/Division.h
@@ -313,7 +313,7 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& ip = getIntegrationPoint();
-        const auto lhs = getLHS().getBasis(local);
+        decltype(auto) lhs = getLHS().getBasis(local);
         const auto rhs = getRHS().getValue(ip);
         return lhs / rhs;
       }

--- a/src/Rodin/Variational/Dot.h
+++ b/src/Rodin/Variational/Dot.h
@@ -438,7 +438,7 @@ namespace Rodin::Variational
       {
         const auto& ip = this->getRHS().getIntegrationPoint();
         const auto lhs = getLHS().getValue(ip);
-        const auto rhs = getRHS().getBasis(local);
+        decltype(auto) rhs = getRHS().getBasis(local);
         return Math::dot(lhs, rhs);
       }
 
@@ -585,7 +585,7 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& p = getLHS().getIntegrationPoint();
-        const auto lhs = getLHS().getBasis(local);
+        decltype(auto) lhs = getLHS().getBasis(local);
         const auto rhs = getRHS().getValue(p);
         return Math::dot(lhs, rhs);
       }
@@ -714,8 +714,8 @@ namespace Rodin::Variational
       constexpr
       auto operator()(size_t tr, size_t te)
       {
-        const auto lhs = getLHS().getBasis(tr);
-        const auto rhs = getRHS().getBasis(te);
+        decltype(auto) lhs = getLHS().getBasis(tr);
+        decltype(auto) rhs = getRHS().getBasis(te);
         return Math::dot(lhs, rhs);
       }
 

--- a/src/Rodin/Variational/FiniteElement.h
+++ b/src/Rodin/Variational/FiniteElement.h
@@ -241,6 +241,36 @@ namespace Rodin::Variational
       }
 
       /**
+       * @brief Evaluates a local finite element expansion on the reference element.
+       *
+       * Given local coefficients @f$ c_i @f$ and basis functions
+       * @f$ \varphi_i @f$, this method evaluates
+       * @f[
+       *   u_h(\widehat{x}) = \sum_i c_i \varphi_i(\widehat{x}).
+       * @f]
+       *
+       * Derived finite elements may hide this method with an equivalent
+       * structured contraction when their basis has a known component layout.
+       *
+       * @tparam Range Range type of the finite element expansion.
+       * @tparam Coefficient Callable returning the local coefficient of a basis.
+       * @param[out] out Value of the expansion.
+       * @param[in] coefficient Local coefficient accessor.
+       * @param[in] rc Reference coordinates.
+       */
+      template <class Range, class Coefficient>
+      constexpr void evaluate(
+        Range& out, Coefficient&& coefficient, const Math::SpatialPoint& rc) const
+      {
+        const auto& derived = static_cast<const Derived&>(*this);
+        const size_t count = derived.getCount();
+        assert(count > 0);
+        out = coefficient(size_t(0)) * derived.getBasis(0)(rc);
+        for (size_t local = 1; local < count; ++local)
+          out += coefficient(local) * derived.getBasis(local)(rc);
+      }
+
+      /**
        * @brief Gets the i-th linear functional (degree of freedom) on the element.
        *
        * A linear form represents one element of the DOF set @f$ \Sigma @f$, such

--- a/src/Rodin/Variational/FiniteElementSpace.h
+++ b/src/Rodin/Variational/FiniteElementSpace.h
@@ -253,6 +253,45 @@ namespace Rodin::Variational
       {
         return static_cast<const Derived&>(*this).getPushforward(idx, v);
       }
+
+      /**
+       * @brief Evaluates a finite element expansion on a physical element.
+       *
+       * The reference expansion is evaluated first and the finite element
+       * space pushforward is then applied to the complete function:
+       * @f[
+       *   u_h(x)
+       *   =
+       *   \psi_K^{-1}
+       *   \left(
+       *     \sum_i c_i \widehat{\varphi}_i
+       *   \right)(x).
+       * @f]
+       * This formulation applies equally to composition-based Lagrange maps
+       * and to range-transforming maps such as the Piola transformations used
+       * by @f$ H(\mathrm{div}) @f$ and @f$ H(\mathrm{curl}) @f$ spaces.
+       *
+       * @tparam Range Range type of the finite element expansion.
+       * @tparam Coefficient Callable returning the local coefficient of a basis.
+       * @param[out] out Value of the expansion.
+       * @param[in] idx Dimension and index of the physical element.
+       * @param[in] coefficient Local coefficient accessor.
+       * @param[in] p Point on the physical element.
+       */
+      template <class Range, class Coefficient>
+      constexpr void evaluate(Range& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& derived = static_cast<const Derived&>(*this);
+        const auto& fe = derived.getFiniteElement(idx.first, idx.second);
+        const auto expansion = [&](const Math::SpatialPoint& rc) {
+          Range value;
+          fe.evaluate(value, coefficient, rc);
+          return value;
+        };
+        const auto mapping = derived.getPushforward(idx, expansion);
+        out = mapping(p);
+      }
   };
 
   /**

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -718,18 +718,11 @@ namespace Rodin::Variational
         const size_t d = polytope.getDimension();
         const Index  i = polytope.getIndex();
 
-        const auto& fe = fes.getFiniteElement(d, i);
-        const size_t count = fe.getCount();
         const auto& dofs = getCachedDOFs(d, i);
-        for (Index local = 0; local < count; ++local)
-        {
-          const auto mapping = fes.getPushforward({ d, i }, fe.getBasis(local));
-          const auto k = this->operator[](dofs[local]) * mapping(p);
-          if (local == 0)
-            res = k;
-          else
-            res += k;
-        }
+        const auto coefficient = [&](size_t local) -> decltype(auto) {
+          return this->operator[](dofs[local]);
+        };
+        fes.evaluate(res, {d, i}, coefficient, p);
       }
 
       /**

--- a/src/Rodin/Variational/H1/Dubiner.h
+++ b/src/Rodin/Variational/H1/Dubiner.h
@@ -162,7 +162,7 @@ namespace Rodin::Variational
    * The nodal basis functions @f$ \phi_i @f$ are recovered from the modal
    * basis via @f$ \phi_i(x) = \sum_j V^{-1}_{ij} \psi_j(x) @f$.
    *
-   * Both @f$ V @f$ and @f$ V^{-1} @f$ are cached in thread-local storage.
+   * Both @f$ V @f$ and @f$ V^{-1} @f$ are computed once and shared.
    *
    * @tparam K Polynomial degree.
    *
@@ -176,22 +176,17 @@ namespace Rodin::Variational
       /**
        * @brief Returns the Vandermonde matrix @f$ V @f$.
        *
-       * The matrix is computed once and cached in thread-local storage.
+       * The matrix is computed once and cached in immutable storage.
        *
        * @return Reference to the N×N Vandermonde matrix where N = (K+1)(K+2)/2.
        */
       static const Math::Matrix<Real>& getMatrix()
       {
-        static thread_local Math::Matrix<Real> s_vandermonde;
-
-        constexpr size_t N = FeketeTriangle<K>::Count;
-
-        if (s_vandermonde.size() == 0)
-        {
+        static const Math::Matrix<Real> s_vandermonde = [] {
+          constexpr size_t N = FeketeTriangle<K>::Count;
           const auto& nodes = FeketeTriangle<K>::getNodes();
-          s_vandermonde.resize(N, N);
+          Math::Matrix<Real> vandermonde(N, N);
 
-          // Fill Vandermonde matrix
           size_t modeIdx = 0;
           Rodin::Utility::ForIndex<K + 1>([&](auto pIdx) {
             constexpr size_t P = pIdx.value;
@@ -204,26 +199,24 @@ namespace Rodin::Variational
                   r, s, nodes[nodeIdx].x(), nodes[nodeIdx].y());
 
                 DubinerTriangle<K>::template getBasis<P, Q>(
-                  s_vandermonde(nodeIdx, modeIdx), r, s);
+                  vandermonde(nodeIdx, modeIdx), r, s);
               }
               ++modeIdx;
             });
           });
-        }
+          return vandermonde;
+        }();
         return s_vandermonde;
       }
 
       static const Math::Matrix<Real>& getInverse()
       {
-        static thread_local Math::Matrix<Real> s_inv;
-
-        if (s_inv.size() == 0)
-        {
+        static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTriangle<K>::getMatrix();
           Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
-          s_inv = svd.solve(I); // computes the (pseudo-)inverse applied to I
-        }
+          return svd.solve(I).eval();
+        }();
 
         return s_inv;
       }
@@ -373,14 +366,10 @@ namespace Rodin::Variational
     public:
       static const Math::Matrix<Real>& getMatrix()
       {
-        static thread_local Math::Matrix<Real> s_vandermonde;
-
-        constexpr size_t N = FeketeTetrahedron<K>::Count;
-
-        if (s_vandermonde.size() == 0)
-        {
+        static const Math::Matrix<Real> s_vandermonde = [] {
+          constexpr size_t N = FeketeTetrahedron<K>::Count;
           const auto& nodes = FeketeTetrahedron<K>::getNodes();
-          s_vandermonde.resize(N, N);
+          Math::Matrix<Real> vandermonde(N, N);
 
           size_t modeIdx = 0;
           Rodin::Utility::ForIndex<K + 1>([&](auto pIdx) {
@@ -396,28 +385,26 @@ namespace Rodin::Variational
                     a, b, c, nodes[nodeIdx].x(), nodes[nodeIdx].y(), nodes[nodeIdx].z());
 
                   DubinerTetrahedron<K>::template getBasis<P, Q, R>(
-                    s_vandermonde(nodeIdx, modeIdx), a, b, c);
+                    vandermonde(nodeIdx, modeIdx), a, b, c);
                 }
                 ++modeIdx;
               });
             });
           });
-        }
+          return vandermonde;
+        }();
 
         return s_vandermonde;
       }
 
       static const Math::Matrix<Real>& getInverse()
       {
-        static thread_local Math::Matrix<Real> s_inv;
-
-        if (s_inv.size() == 0)
-        {
+        static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTetrahedron<K>::getMatrix();
           Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
-          s_inv = svd.solve(I); // computes the (pseudo-)inverse applied to I
-        }
+          return svd.solve(I).eval();
+        }();
 
         return s_inv;
       }

--- a/src/Rodin/Variational/H1/H1.h
+++ b/src/Rodin/Variational/H1/H1.h
@@ -390,47 +390,47 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Point);
+            static const ElementType s_element(Geometry::Polytope::Type::Point);
             return s_element;
           }
           case Geometry::Polytope::Type::Segment:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Segment);
+            static const ElementType s_element(Geometry::Polytope::Type::Segment);
             return s_element;
           }
           case Geometry::Polytope::Type::Triangle:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Triangle);
+            static const ElementType s_element(Geometry::Polytope::Type::Triangle);
             return s_element;
           }
           case Geometry::Polytope::Type::Quadrilateral:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Quadrilateral);
+            static const ElementType s_element(Geometry::Polytope::Type::Quadrilateral);
             return s_element;
           }
           case Geometry::Polytope::Type::Tetrahedron:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Tetrahedron);
+            static const ElementType s_element(Geometry::Polytope::Type::Tetrahedron);
             return s_element;
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Pyramid);
+            static const ElementType s_element(Geometry::Polytope::Type::Pyramid);
             return s_element;
           }
           case Geometry::Polytope::Type::Wedge:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Wedge);
+            static const ElementType s_element(Geometry::Polytope::Type::Wedge);
             return s_element;
           }
           case Geometry::Polytope::Type::Hexahedron:
           {
-            static thread_local const ElementType s_element(Geometry::Polytope::Type::Hexahedron);
+            static const ElementType s_element(Geometry::Polytope::Type::Hexahedron);
             return s_element;
           }
         }
         assert(false);
-        static thread_local const ElementType s_null;
+        static const ElementType s_null;
         return s_null;
       }
 
@@ -513,6 +513,22 @@ namespace Rodin::Variational
       auto getPushforward(const std::pair<size_t, Index>& idx, Callable&& v) const
       {
         return Pushforward<Callable>(std::forward<Callable>(v));
+      }
+
+      /**
+       * @brief Evaluates the scalar expansion directly at reference coordinates.
+       *
+       * The scalar Lagrange pushforward is composition with the element map;
+       * therefore a point already carrying reference coordinates requires no
+       * range transformation.
+       */
+      template <class Coefficient>
+      constexpr void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:
@@ -687,95 +703,79 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Point, 0),
-              ElementType(Geometry::Polytope::Type::Point, 1),
-              ElementType(Geometry::Polytope::Type::Point, 2),
-              ElementType(Geometry::Polytope::Type::Point, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Point, 0),
+                ElementType(Geometry::Polytope::Type::Point, 1),
+                ElementType(Geometry::Polytope::Type::Point, 2),
+                ElementType(Geometry::Polytope::Type::Point, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Segment:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Segment, 0),
-              ElementType(Geometry::Polytope::Type::Segment, 1),
-              ElementType(Geometry::Polytope::Type::Segment, 2),
-              ElementType(Geometry::Polytope::Type::Segment, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Segment, 0),
+                ElementType(Geometry::Polytope::Type::Segment, 1),
+                ElementType(Geometry::Polytope::Type::Segment, 2),
+                ElementType(Geometry::Polytope::Type::Segment, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Triangle:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Triangle, 0),
-              ElementType(Geometry::Polytope::Type::Triangle, 1),
-              ElementType(Geometry::Polytope::Type::Triangle, 2),
-              ElementType(Geometry::Polytope::Type::Triangle, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Triangle, 0),
+                ElementType(Geometry::Polytope::Type::Triangle, 1),
+                ElementType(Geometry::Polytope::Type::Triangle, 2),
+                ElementType(Geometry::Polytope::Type::Triangle, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Quadrilateral:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 0),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 1),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 2),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Quadrilateral, 0),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 1),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 2),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Tetrahedron:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 0),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 1),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 2),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Tetrahedron, 0),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 1),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 2),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Pyramid, 0),
-              ElementType(Geometry::Polytope::Type::Pyramid, 1),
-              ElementType(Geometry::Polytope::Type::Pyramid, 2),
-              ElementType(Geometry::Polytope::Type::Pyramid, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Pyramid, 0),
+                ElementType(Geometry::Polytope::Type::Pyramid, 1),
+                ElementType(Geometry::Polytope::Type::Pyramid, 2),
+                ElementType(Geometry::Polytope::Type::Pyramid, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Wedge:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Wedge, 0),
-              ElementType(Geometry::Polytope::Type::Wedge, 1),
-              ElementType(Geometry::Polytope::Type::Wedge, 2),
-              ElementType(Geometry::Polytope::Type::Wedge, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Wedge, 0),
+                ElementType(Geometry::Polytope::Type::Wedge, 1),
+                ElementType(Geometry::Polytope::Type::Wedge, 2),
+                ElementType(Geometry::Polytope::Type::Wedge, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Hexahedron:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Hexahedron, 0),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 1),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 2),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Hexahedron, 0),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 1),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 2),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 3)};
             return s_elements[m_vdim];
           }
         }
         assert(false);
-        static thread_local ElementType s_null(Geometry::Polytope::Type::Point, 0);
+        static const ElementType s_null(Geometry::Polytope::Type::Point, 0);
         return s_null;
       }
 
@@ -818,6 +818,21 @@ namespace Rodin::Variational
       {
         (void) idx;
         return Pushforward<Callable>(std::forward<Callable>(v));
+      }
+
+      /**
+       * @brief Evaluates the vector expansion directly at reference coordinates.
+       *
+       * Vector H1 uses a componentwise Lagrange map and therefore requires no
+       * range transformation after the structured local contraction.
+       */
+      template <class Coefficient>
+      constexpr void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:

--- a/src/Rodin/Variational/H1/H1Element.h
+++ b/src/Rodin/Variational/H1/H1Element.h
@@ -1127,6 +1127,27 @@ namespace Rodin::Variational
         return H1Element<K, ScalarType>::getNodes(this->getGeometry())[local / m_vdim];
       }
 
+      template <class Coefficient>
+      constexpr void evaluate(
+        RangeType& out, Coefficient&& coefficient, const Math::SpatialPoint& rc) const
+      {
+        assert(m_vdim > 0);
+        out.resize(m_vdim);
+        out.setZero();
+
+        const H1Element<K, ScalarType> scalarfe(this->getGeometry());
+        const size_t count = scalarfe.getCount();
+        for (size_t node = 0; node < count; ++node)
+        {
+          const ScalarType phi = scalarfe.getBasis(node)(rc);
+          for (size_t component = 0; component < m_vdim; ++component)
+          {
+            const size_t local = node * m_vdim + component;
+            out(component) += coefficient(local) * phi;
+          }
+        }
+      }
+
       constexpr
       size_t getOrder() const
       {

--- a/src/Rodin/Variational/H1/H1Element.hpp
+++ b/src/Rodin/Variational/H1/H1Element.hpp
@@ -236,36 +236,31 @@ namespace Rodin::Variational
     public:
       static const Math::Matrix<Real>& getMatrix()
       {
-        static thread_local Math::Matrix<Real> s_vandermonde;
-        constexpr size_t N = PyramidIndex<K>::Count;
-
-        if (s_vandermonde.size() == 0)
-        {
+        static const Math::Matrix<Real> s_vandermonde = [] {
+          constexpr size_t N = PyramidIndex<K>::Count;
           const auto& nodes =
             H1Element<K, Real>::getNodes(Geometry::Polytope::Type::Pyramid);
-          s_vandermonde.resize(N, N);
+          Math::Matrix<Real> vandermonde(N, N);
 
           for (size_t node = 0; node < N; ++node)
           {
             for (size_t mode = 0; mode < N; ++mode)
-              s_vandermonde(node, mode) = PyramidModal<K>::getBasis(mode, nodes[node]);
+              vandermonde(node, mode) = PyramidModal<K>::getBasis(mode, nodes[node]);
           }
-        }
+          return vandermonde;
+        }();
 
         return s_vandermonde;
       }
 
       static const Math::Matrix<Real>& getInverse()
       {
-        static thread_local Math::Matrix<Real> s_inv;
-
-        if (s_inv.size() == 0)
-        {
+        static const Math::Matrix<Real> s_inv = [] {
           const auto& V = getMatrix();
           Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
-          s_inv = svd.solve(I);
-        }
+          return svd.solve(I).eval();
+        }();
 
         return s_inv;
       }
@@ -371,109 +366,63 @@ namespace Rodin::Variational
   {
     const Geometry::Polytope::Type g = this->getGeometry();
 
-    // Use switch to create geometry-specific thread_local storage
+    // These objects depend only on the compile-time order and reference
+    // geometry. Sharing their immutable storage avoids per-thread replicas.
+    const auto makeLinearForms = [this, g] {
+      std::vector<LinearForm> forms;
+      const size_t count = getCount();
+      forms.reserve(count);
+      for (size_t j = 0; j < count; ++j)
+        forms.emplace_back(j, g);
+      return forms;
+    };
+
     switch (g)
     {
       case Geometry::Polytope::Type::Point:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Segment:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Triangle:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Quadrilateral:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Tetrahedron:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Pyramid:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Wedge:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
       case Geometry::Polytope::Type::Hexahedron:
       {
-        static thread_local std::vector<LinearForm> s_lfs;
-        if (s_lfs.empty())
-        {
-          const size_t count = getCount();
-          s_lfs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_lfs.emplace_back(j, g);
-        }
+        static const std::vector<LinearForm> s_lfs = makeLinearForms();
         return s_lfs[i];
       }
     }
 
     // Fallback (should never happen)
-    static thread_local LinearForm s_null(0, g);
+    static const LinearForm s_null(0, Geometry::Polytope::Type::Point);
     assert(false);
     return s_null;
   }
@@ -483,109 +432,63 @@ namespace Rodin::Variational
   {
     const Geometry::Polytope::Type g = this->getGeometry();
 
-    // Use switch to create geometry-specific thread_local storage
+    // Basis descriptors are immutable after construction and are safe to share
+    // across concurrent element evaluations.
+    const auto makeBasis = [this, g] {
+      std::vector<BasisFunction> basis;
+      const size_t count = getCount();
+      basis.reserve(count);
+      for (size_t j = 0; j < count; ++j)
+        basis.emplace_back(j, g);
+      return basis;
+    };
+
     switch (g)
     {
       case Geometry::Polytope::Type::Point:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Segment:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Triangle:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Quadrilateral:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Tetrahedron:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Pyramid:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Wedge:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
       case Geometry::Polytope::Type::Hexahedron:
       {
-        static thread_local std::vector<BasisFunction> s_bs;
-        if (s_bs.empty())
-        {
-          const size_t count = getCount();
-          s_bs.reserve(count);
-          for (size_t j = 0; j < count; ++j)
-            s_bs.emplace_back(j, g);
-        }
+        static const std::vector<BasisFunction> s_bs = makeBasis();
         return s_bs[i];
       }
     }
 
     // Fallback (should never happen)
-    static thread_local BasisFunction s_null(0, g);
+    static const BasisFunction s_null(0, Geometry::Polytope::Type::Point);
     assert(false);
     return s_null;
   }

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -447,7 +447,7 @@ namespace Rodin::Variational
       {
         const auto& p = this->getIntegrationPoint();
         const auto lhs = getLHS().getValue(p);
-        const auto rhs = getRHS().getBasis(local);
+        decltype(auto) rhs = getRHS().getBasis(local);
         const auto product = lhs * rhs;
         return Internal::materializeProduct(product);
       }
@@ -608,7 +608,7 @@ namespace Rodin::Variational
       auto getBasis(size_t local) const
       {
         const auto& p = this->getIntegrationPoint();
-        const auto lhs = this->getLHS().getBasis(local);
+        decltype(auto) lhs = this->getLHS().getBasis(local);
         const auto rhs = this->getRHS().getValue(p);
         const auto product = lhs * rhs;
         return Internal::materializeProduct(product);

--- a/src/Rodin/Variational/P0/P0.h
+++ b/src/Rodin/Variational/P0/P0.h
@@ -241,55 +241,48 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Point);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Point);
             return sElement;
           }
           case Geometry::Polytope::Type::Segment:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Segment);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Segment);
             return sElement;
           }
           case Geometry::Polytope::Type::Triangle:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Triangle);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Triangle);
             return sElement;
           }
           case Geometry::Polytope::Type::Quadrilateral:
           {
-            static thread_local constexpr ElementType sElement(
+            static constexpr ElementType sElement(
               Geometry::Polytope::Type::Quadrilateral);
             return sElement;
           }
           case Geometry::Polytope::Type::Tetrahedron:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Tetrahedron);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Tetrahedron);
             return sElement;
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Pyramid);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Pyramid);
             return sElement;
           }
           case Geometry::Polytope::Type::Wedge:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Wedge);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Wedge);
             return sElement;
           }
           case Geometry::Polytope::Type::Hexahedron:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Hexahedron);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Hexahedron);
             return sElement;
           }
         }
         assert(false);
-        static thread_local constexpr ElementType sNull(Geometry::Polytope::Type::Point);
+        static constexpr ElementType sNull(Geometry::Polytope::Type::Point);
         return sNull;
       }
 

--- a/src/Rodin/Variational/P0/P0Element.h
+++ b/src/Rodin/Variational/P0/P0Element.h
@@ -542,6 +542,15 @@ namespace Rodin::Variational
         return Geometry::Polytope::Traits(this->getGeometry()).getCentroid();
       }
 
+      template <class Coefficient>
+      constexpr void evaluate(
+        RangeType& out, Coefficient&& coefficient, const Math::SpatialPoint&) const
+      {
+        out.resize(m_vdim);
+        for (size_t component = 0; component < m_vdim; ++component)
+          out(component) = coefficient(component);
+      }
+
       constexpr
       size_t getOrder() const
       {

--- a/src/Rodin/Variational/P0g/P0g.h
+++ b/src/Rodin/Variational/P0g/P0g.h
@@ -197,8 +197,9 @@ namespace Rodin::Variational
           case Geometry::Polytope::Type::Wedge:
           case Geometry::Polytope::Type::Hexahedron:
           {
-            // One thread-local element per call site; geometry is set in ctor.
-            // Returning a reference is required by the FES API.
+            // Unlike the fixed P0/P1/H1 elements, this cached element is
+            // reassigned when the requested geometry changes. It must remain
+            // thread-local while the FES API returns it by reference.
             static thread_local ElementType e(Geometry::Polytope::Type::Point);
             if (e.getGeometry() != g)
               e = ElementType(g);
@@ -378,6 +379,8 @@ namespace Rodin::Variational
           case Geometry::Polytope::Type::Wedge:
           case Geometry::Polytope::Type::Hexahedron:
           {
+            // Geometry and vector dimension both select the returned element;
+            // sharing this mutable cache would race between evaluations.
             static thread_local ElementType e(Geometry::Polytope::Type::Point, 1);
             if (e.getGeometry() != g || e.getCount() != m_vdim)
               e = ElementType(g, m_vdim);

--- a/src/Rodin/Variational/P0g/P0gElement.h
+++ b/src/Rodin/Variational/P0g/P0gElement.h
@@ -377,6 +377,15 @@ namespace Rodin::Variational
       return P0gElement<ScalarType>(this->getGeometry()).getNode(local / m_vdim);
     }
 
+    template <class Coefficient>
+    constexpr void evaluate(
+      RangeType& out, Coefficient&& coefficient, const Math::SpatialPoint&) const
+    {
+      out.resize(m_vdim);
+      for (size_t component = 0; component < m_vdim; ++component)
+        out(component) = coefficient(component);
+    }
+
     constexpr size_t getOrder() const { return 0; }
 
   private:

--- a/src/Rodin/Variational/P1/Grad.h
+++ b/src/Rodin/Variational/P1/Grad.h
@@ -419,8 +419,7 @@ namespace Rodin::Variational
         return *this;
       }
 
-      constexpr
-      auto getBasis(size_t local) const
+      constexpr const SpatialVectorType& getBasis(size_t local) const
       {
         assert(m_cache.cellKey);
         assert(local < m_cache.grad.size());

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -527,7 +527,7 @@ namespace Rodin::Variational
         return *this;
       }
 
-      auto getBasis(size_t local) const
+      const SpatialMatrixType& getBasis(size_t local) const
       {
         assert(m_cache.cellKey);
         assert(local < m_cache.jac.size());

--- a/src/Rodin/Variational/P1/P1.h
+++ b/src/Rodin/Variational/P1/P1.h
@@ -233,55 +233,48 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Point);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Point);
             return sElement;
           }
           case Geometry::Polytope::Type::Segment:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Segment);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Segment);
             return sElement;
           }
           case Geometry::Polytope::Type::Triangle:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Triangle);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Triangle);
             return sElement;
           }
           case Geometry::Polytope::Type::Quadrilateral:
           {
-            static thread_local constexpr ElementType sElement(
+            static constexpr ElementType sElement(
               Geometry::Polytope::Type::Quadrilateral);
             return sElement;
           }
           case Geometry::Polytope::Type::Tetrahedron:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Tetrahedron);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Tetrahedron);
             return sElement;
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Pyramid);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Pyramid);
             return sElement;
           }
           case Geometry::Polytope::Type::Wedge:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Wedge);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Wedge);
             return sElement;
           }
           case Geometry::Polytope::Type::Hexahedron:
           {
-            static thread_local constexpr ElementType sElement(
-              Geometry::Polytope::Type::Hexahedron);
+            static constexpr ElementType sElement(Geometry::Polytope::Type::Hexahedron);
             return sElement;
           }
         }
         assert(false);
-        static thread_local constexpr ElementType sNull;
+        static constexpr ElementType sNull;
         return sNull;
       }
 
@@ -386,6 +379,22 @@ namespace Rodin::Variational
       auto getPushforward(const std::pair<size_t, Index>& idx, Callable&& v) const
       {
         return Pushforward<Callable>(std::forward<Callable>(v));
+      }
+
+      /**
+       * @brief Evaluates the scalar expansion directly at reference coordinates.
+       *
+       * The scalar Lagrange pushforward is composition with the element map;
+       * therefore a point already carrying reference coordinates requires no
+       * range transformation.
+       */
+      template <class Coefficient>
+      constexpr void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:
@@ -596,95 +605,79 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Point, 0),
-              ElementType(Geometry::Polytope::Type::Point, 1),
-              ElementType(Geometry::Polytope::Type::Point, 2),
-              ElementType(Geometry::Polytope::Type::Point, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Point, 0),
+                ElementType(Geometry::Polytope::Type::Point, 1),
+                ElementType(Geometry::Polytope::Type::Point, 2),
+                ElementType(Geometry::Polytope::Type::Point, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Segment:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Segment, 0),
-              ElementType(Geometry::Polytope::Type::Segment, 1),
-              ElementType(Geometry::Polytope::Type::Segment, 2),
-              ElementType(Geometry::Polytope::Type::Segment, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Segment, 0),
+                ElementType(Geometry::Polytope::Type::Segment, 1),
+                ElementType(Geometry::Polytope::Type::Segment, 2),
+                ElementType(Geometry::Polytope::Type::Segment, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Triangle:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Triangle, 0),
-              ElementType(Geometry::Polytope::Type::Triangle, 1),
-              ElementType(Geometry::Polytope::Type::Triangle, 2),
-              ElementType(Geometry::Polytope::Type::Triangle, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Triangle, 0),
+                ElementType(Geometry::Polytope::Type::Triangle, 1),
+                ElementType(Geometry::Polytope::Type::Triangle, 2),
+                ElementType(Geometry::Polytope::Type::Triangle, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Quadrilateral:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 0),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 1),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 2),
-              ElementType(Geometry::Polytope::Type::Quadrilateral, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Quadrilateral, 0),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 1),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 2),
+                ElementType(Geometry::Polytope::Type::Quadrilateral, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Tetrahedron:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 0),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 1),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 2),
-              ElementType(Geometry::Polytope::Type::Tetrahedron, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Tetrahedron, 0),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 1),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 2),
+                ElementType(Geometry::Polytope::Type::Tetrahedron, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Pyramid, 0),
-              ElementType(Geometry::Polytope::Type::Pyramid, 1),
-              ElementType(Geometry::Polytope::Type::Pyramid, 2),
-              ElementType(Geometry::Polytope::Type::Pyramid, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Pyramid, 0),
+                ElementType(Geometry::Polytope::Type::Pyramid, 1),
+                ElementType(Geometry::Polytope::Type::Pyramid, 2),
+                ElementType(Geometry::Polytope::Type::Pyramid, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Wedge:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Wedge, 0),
-              ElementType(Geometry::Polytope::Type::Wedge, 1),
-              ElementType(Geometry::Polytope::Type::Wedge, 2),
-              ElementType(Geometry::Polytope::Type::Wedge, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Wedge, 0),
+                ElementType(Geometry::Polytope::Type::Wedge, 1),
+                ElementType(Geometry::Polytope::Type::Wedge, 2),
+                ElementType(Geometry::Polytope::Type::Wedge, 3)};
             return s_elements[m_vdim];
           }
           case Geometry::Polytope::Type::Hexahedron:
           {
-            static thread_local std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1> s_elements =
-            {
-              ElementType(Geometry::Polytope::Type::Hexahedron, 0),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 1),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 2),
-              ElementType(Geometry::Polytope::Type::Hexahedron, 3)
-            };
+            static const std::array<ElementType, RODIN_MAXIMAL_SPACE_DIMENSION + 1>
+              s_elements = {ElementType(Geometry::Polytope::Type::Hexahedron, 0),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 1),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 2),
+                ElementType(Geometry::Polytope::Type::Hexahedron, 3)};
             return s_elements[m_vdim];
           }
         }
         assert(false);
-        static thread_local ElementType s_null(Geometry::Polytope::Type::Point, 0);
+        static const ElementType s_null(Geometry::Polytope::Type::Point, 0);
         return s_null;
       }
 
@@ -730,6 +723,21 @@ namespace Rodin::Variational
       auto getPushforward(const std::pair<size_t, Index>&, Callable&& v) const
       {
         return Pushforward<Callable>(std::forward<Callable>(v));
+      }
+
+      /**
+       * @brief Evaluates the vector expansion directly at reference coordinates.
+       *
+       * Vector P1 uses a componentwise Lagrange map and therefore requires no
+       * range transformation after the structured local contraction.
+       */
+      template <class Coefficient>
+      constexpr void evaluate(RangeType& out, const std::pair<size_t, Index>& idx,
+        Coefficient&& coefficient, const Geometry::Point& p) const
+      {
+        const auto& fe = getFiniteElement(idx.first, idx.second);
+        fe.evaluate(
+          out, std::forward<Coefficient>(coefficient), p.getReferenceCoordinates());
       }
 
     private:

--- a/src/Rodin/Variational/P1/P1Element.h
+++ b/src/Rodin/Variational/P1/P1Element.h
@@ -211,14 +211,13 @@ namespace Rodin::Variational
                * @param r Reference point in the element (gradient is constant, so r doesn't affect result)
                * @return Constant gradient vector
                */
-              const ReturnType& operator()(const Math::SpatialPoint& r) const
+              ReturnType operator()(const Math::SpatialPoint& r) const
               {
-                static thread_local ReturnType s_out;
                 const size_t dim = Geometry::Polytope::Traits(m_g).getDimension();
-                s_out.resize(dim);
+                ReturnType out(static_cast<std::uint8_t>(dim));
                 for (size_t i = 0; i < dim; ++i)
-                  s_out(i) = DerivativeFunction<1>(i, m_local, m_g)(r);
-                return s_out;
+                  out(i) = DerivativeFunction<1>(i, m_local, m_g)(r);
+                return out;
               }
 
             private:
@@ -314,7 +313,7 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local LinearForm s_lf(0, g);
+            static const LinearForm s_lf(0, g);
             assert(i == 0);
             return s_lf;
           }
@@ -324,12 +323,12 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               default:
@@ -346,17 +345,17 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               default:
@@ -373,22 +372,22 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               case 3:
               {
-                static thread_local LinearForm s_lf(3, g);
+                static const LinearForm s_lf(3, g);
                 return s_lf;
               }
               default:
@@ -405,22 +404,22 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               case 3:
               {
-                static thread_local LinearForm s_lf(3, g);
+                static const LinearForm s_lf(3, g);
                 return s_lf;
               }
               default:
@@ -438,27 +437,27 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               case 3:
               {
-                static thread_local LinearForm s_lf(3, g);
+                static const LinearForm s_lf(3, g);
                 return s_lf;
               }
               case 4:
               {
-                static thread_local LinearForm s_lf(4, g);
+                static const LinearForm s_lf(4, g);
                 return s_lf;
               }
               default:
@@ -476,32 +475,32 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               case 3:
               {
-                static thread_local LinearForm s_lf(3, g);
+                static const LinearForm s_lf(3, g);
                 return s_lf;
               }
               case 4:
               {
-                static thread_local LinearForm s_lf(4, g);
+                static const LinearForm s_lf(4, g);
                 return s_lf;
               }
               case 5:
               {
-                static thread_local LinearForm s_lf(5, g);
+                static const LinearForm s_lf(5, g);
                 return s_lf;
               }
               default:
@@ -519,42 +518,42 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local LinearForm s_lf(0, g);
+                static const LinearForm s_lf(0, g);
                 return s_lf;
               }
               case 1:
               {
-                static thread_local LinearForm s_lf(1, g);
+                static const LinearForm s_lf(1, g);
                 return s_lf;
               }
               case 2:
               {
-                static thread_local LinearForm s_lf(2, g);
+                static const LinearForm s_lf(2, g);
                 return s_lf;
               }
               case 3:
               {
-                static thread_local LinearForm s_lf(3, g);
+                static const LinearForm s_lf(3, g);
                 return s_lf;
               }
               case 4:
               {
-                static thread_local LinearForm s_lf(4, g);
+                static const LinearForm s_lf(4, g);
                 return s_lf;
               }
               case 5:
               {
-                static thread_local LinearForm s_lf(5, g);
+                static const LinearForm s_lf(5, g);
                 return s_lf;
               }
               case 6:
               {
-                static thread_local LinearForm s_lf(6, g);
+                static const LinearForm s_lf(6, g);
                 return s_lf;
               }
               case 7:
               {
-                static thread_local LinearForm s_lf(7, g);
+                static const LinearForm s_lf(7, g);
                 return s_lf;
               }
               default:
@@ -566,7 +565,7 @@ namespace Rodin::Variational
             break;
           }
         }
-        static thread_local LinearForm s_null(0, g);
+        static const LinearForm s_null(0, g);
         assert(false);
         return s_null;
       }
@@ -578,7 +577,7 @@ namespace Rodin::Variational
         {
           case Geometry::Polytope::Type::Point:
           {
-            static thread_local BasisFunction s_basis(0, g);
+            static const BasisFunction s_basis(0, g);
             assert(i == 0);
             return s_basis;
           }
@@ -588,12 +587,12 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               default:
@@ -610,17 +609,17 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               default:
@@ -637,22 +636,22 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               case 3:
               {
-                static thread_local BasisFunction s_basis(3, g);
+                static const BasisFunction s_basis(3, g);
                 return s_basis;
               }
               default:
@@ -669,22 +668,22 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               case 3:
               {
-                static thread_local BasisFunction s_basis(3, g);
+                static const BasisFunction s_basis(3, g);
                 return s_basis;
               }
               default:
@@ -701,27 +700,27 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               case 3:
               {
-                static thread_local BasisFunction s_basis(3, g);
+                static const BasisFunction s_basis(3, g);
                 return s_basis;
               }
               case 4:
               {
-                static thread_local BasisFunction s_basis(4, g);
+                static const BasisFunction s_basis(4, g);
                 return s_basis;
               }
               default:
@@ -738,32 +737,32 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               case 3:
               {
-                static thread_local BasisFunction s_basis(3, g);
+                static const BasisFunction s_basis(3, g);
                 return s_basis;
               }
               case 4:
               {
-                static thread_local BasisFunction s_basis(4, g);
+                static const BasisFunction s_basis(4, g);
                 return s_basis;
               }
               case 5:
               {
-                static thread_local BasisFunction s_basis(5, g);
+                static const BasisFunction s_basis(5, g);
                 return s_basis;
               }
               default:
@@ -781,42 +780,42 @@ namespace Rodin::Variational
             {
               case 0:
               {
-                static thread_local BasisFunction s_basis(0, g);
+                static const BasisFunction s_basis(0, g);
                 return s_basis;
               }
               case 1:
               {
-                static thread_local BasisFunction s_basis(1, g);
+                static const BasisFunction s_basis(1, g);
                 return s_basis;
               }
               case 2:
               {
-                static thread_local BasisFunction s_basis(2, g);
+                static const BasisFunction s_basis(2, g);
                 return s_basis;
               }
               case 3:
               {
-                static thread_local BasisFunction s_basis(3, g);
+                static const BasisFunction s_basis(3, g);
                 return s_basis;
               }
               case 4:
               {
-                static thread_local BasisFunction s_basis(4, g);
+                static const BasisFunction s_basis(4, g);
                 return s_basis;
               }
               case 5:
               {
-                static thread_local BasisFunction s_basis(5, g);
+                static const BasisFunction s_basis(5, g);
                 return s_basis;
               }
               case 6:
               {
-                static thread_local BasisFunction s_basis(6, g);
+                static const BasisFunction s_basis(6, g);
                 return s_basis;
               }
               case 7:
               {
-                static thread_local BasisFunction s_basis(7, g);
+                static const BasisFunction s_basis(7, g);
                 return s_basis;
               }
               default:
@@ -828,7 +827,7 @@ namespace Rodin::Variational
             break;
           }
         }
-        static thread_local BasisFunction s_null(0, g);
+        static const BasisFunction s_null(0, g);
         assert(false);
         return s_null;
       }
@@ -1012,17 +1011,17 @@ namespace Rodin::Variational
               constexpr
               JacobianFunction(JacobianFunction&&) = default;
 
-              const ReturnType& operator()(const Math::SpatialPoint& r) const
+              ReturnType operator()(const Math::SpatialPoint& r) const
               {
-                static thread_local ReturnType s_out;
                 const size_t dim = Geometry::Polytope::Traits(m_g).getDimension();
-                s_out.resize(m_vdim, dim);
+                ReturnType out(
+                  static_cast<std::uint8_t>(m_vdim), static_cast<std::uint8_t>(dim));
                 for (size_t i = 0; i < m_vdim; ++i)
                 {
                   for (size_t j = 0; j < dim; ++j)
-                    s_out(i, j) = DerivativeFunction<1>(i, j, m_vdim, m_local, m_g)(r);
+                    out(i, j) = DerivativeFunction<1>(i, j, m_vdim, m_local, m_g)(r);
                 }
-                return s_out;
+                return out;
               }
 
             private:
@@ -1042,14 +1041,13 @@ namespace Rodin::Variational
           constexpr
           BasisFunction(BasisFunction&&) = default;
 
-          const ReturnType& operator()(const Math::SpatialPoint& rc) const
+          ReturnType operator()(const Math::SpatialPoint& rc) const
           {
-            static thread_local ReturnType s_out;
-            s_out = ReturnType(static_cast<std::uint8_t>(m_vdim));
-            s_out.setZero();
-            s_out[static_cast<std::uint8_t>(m_local % m_vdim)] =
+            ReturnType out(static_cast<std::uint8_t>(m_vdim));
+            out.setZero();
+            out[static_cast<std::uint8_t>(m_local % m_vdim)] =
               P1Element<ScalarType>(m_g).getBasis(m_local / m_vdim)(rc);
-            return s_out;
+            return out;
           }
 
           template <size_t Order>
@@ -1147,6 +1145,27 @@ namespace Rodin::Variational
       const Math::SpatialPoint& getNode(size_t local) const
       {
         return Geometry::Polytope::Traits(this->getGeometry()).getVertex(local / m_vdim);
+      }
+
+      template <class Coefficient>
+      constexpr void evaluate(
+        RangeType& out, Coefficient&& coefficient, const Math::SpatialPoint& rc) const
+      {
+        assert(m_vdim > 0);
+        out.resize(m_vdim);
+        out.setZero();
+
+        const P1Element<ScalarType> scalarfe(this->getGeometry());
+        const size_t nv = scalarfe.getCount();
+        for (size_t vertex = 0; vertex < nv; ++vertex)
+        {
+          const ScalarType phi = scalarfe.getBasis(vertex)(rc);
+          for (size_t component = 0; component < m_vdim; ++component)
+          {
+            const size_t local = vertex * m_vdim + component;
+            out(component) += coefficient(local) * phi;
+          }
+        }
       }
 
       constexpr

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -535,20 +535,20 @@ namespace Rodin::Variational
           m_integrand(integrand.copy())
       {}
 
-      constexpr
-      QuadratureRule(const QuadratureRule& other)
+      constexpr QuadratureRule(const QuadratureRule& other)
         : Parent(other),
-          m_integrand(other.m_integrand->copy())
+          m_integrand(other.m_integrand->copy()),
+          m_basis(other.m_basis)
       {}
 
-      constexpr
-      QuadratureRule(QuadratureRule&& other)
+      constexpr QuadratureRule(QuadratureRule&& other)
         : Parent(std::move(other)),
           m_integrand(std::move(other.m_integrand)),
           m_polytope(std::move(other.m_polytope)),
           m_qf(std::exchange(other.m_qf, nullptr)),
           m_quadrature(std::exchange(other.m_quadrature, nullptr)),
           m_matrix(std::move(other.m_matrix)),
+          m_basis(std::move(other.m_basis)),
           m_set(std::exchange(other.m_set, false)),
           m_order(std::exchange(other.m_order, 0)),
           m_geometry(std::move(other.m_geometry))
@@ -593,6 +593,19 @@ namespace Rodin::Variational
           m_geometry = geometry;
 
           m_qf = &QF::PolytopeQuadratureFormula::get(order, geometry);
+
+          // Reference P1 basis values depend on the geometry and quadrature
+          // formula, but not on the physical mesh cell.
+          const P1Element<ScalarType> scalarfe(geometry);
+          const size_t nv = scalarfe.getCount();
+          m_basis.resize(
+            static_cast<Eigen::Index>(m_qf->getSize()), static_cast<Eigen::Index>(nv));
+          for (size_t qp = 0; qp < m_qf->getSize(); ++qp)
+          {
+            const auto& rc = m_qf->getPoint(qp);
+            for (size_t a = 0; a < nv; ++a)
+              m_basis(qp, a) = scalarfe.getBasis(a)(rc);
+          }
         }
 
         assert(m_qf);
@@ -606,6 +619,23 @@ namespace Rodin::Variational
 
         const bool symmetric =
           (&trialfes.getMesh() == &testfes.getMesh()) && (ntr == nte);
+        const size_t vdim = [&]() {
+          if constexpr (FormLanguage::IsVectorRange<LHSRangeType>::Value)
+          {
+            const size_t trialVdim = trialfes.getVectorDimension();
+            assert(trialVdim == testfes.getVectorDimension());
+            return trialVdim;
+          }
+          else
+          {
+            return size_t(1);
+          }
+        }();
+        assert(vdim > 0);
+        assert(ntr % vdim == 0);
+        assert(nte % vdim == 0);
+        assert(static_cast<size_t>(m_basis.cols()) == ntr / vdim);
+        assert(static_cast<size_t>(m_basis.cols()) == nte / vdim);
 
         m_matrix.resize(static_cast<Eigen::Index>(nte), static_cast<Eigen::Index>(ntr));
         m_matrix.setZero();
@@ -618,24 +648,22 @@ namespace Rodin::Variational
           const ScalarType wdet =
             static_cast<ScalarType>(m_qf->getWeight(qp) * p.getDistortion());
 
-          const auto& rc = m_qf->getPoint(qp);
-
           if constexpr (std::is_same_v<LHSRangeType, ScalarType>)
           {
             if (symmetric)
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const ScalarType phi_te = testfe.getBasis(ib)(rc);
+                const ScalarType phi_te = m_basis(qp, ib);
 
                 {
-                  const ScalarType kii = wdet * phi_te * trialfe.getBasis(ib)(rc);
+                  const ScalarType kii = wdet * phi_te * m_basis(qp, ib);
                   m_matrix(ib, ib) += kii;
                 }
 
                 for (size_t ia = 0; ia < ib; ++ia)
                 {
-                  const ScalarType kij = wdet * phi_te * trialfe.getBasis(ia)(rc);
+                  const ScalarType kij = wdet * phi_te * m_basis(qp, ia);
                   m_matrix(ib, ia) += kij;
                 }
               }
@@ -644,10 +672,10 @@ namespace Rodin::Variational
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const ScalarType phi_te = testfe.getBasis(ib)(rc);
+                const ScalarType phi_te = m_basis(qp, ib);
                 for (size_t ia = 0; ia < ntr; ++ia)
                 {
-                  const ScalarType kij = wdet * phi_te * trialfe.getBasis(ia)(rc);
+                  const ScalarType kij = wdet * phi_te * m_basis(qp, ia);
                   m_matrix(ib, ia) += kij;
                 }
               }
@@ -659,19 +687,22 @@ namespace Rodin::Variational
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const auto phi_te = testfe.getBasis(ib)(rc);
+                const size_t vb = ib / vdim;
+                const size_t cb = ib % vdim;
+                const ScalarType phi_te = m_basis(qp, vb);
 
                 {
-                  const ScalarType kii =
-                    wdet * Math::dot(phi_te, trialfe.getBasis(ib)(rc));
+                  const ScalarType kii = wdet * phi_te * phi_te;
                   m_matrix(ib, ib) += kii;
                 }
 
                 for (size_t ia = 0; ia < ib; ++ia)
                 {
-                  const auto phi_tr = trialfe.getBasis(ia)(rc);
-                  const ScalarType kij = wdet * Math::dot(phi_te, phi_tr);
-                  m_matrix(ib, ia) += kij;
+                  if (ia % vdim == cb)
+                  {
+                    const ScalarType phi_tr = m_basis(qp, ia / vdim);
+                    m_matrix(ib, ia) += wdet * phi_te * phi_tr;
+                  }
                 }
               }
             }
@@ -679,12 +710,16 @@ namespace Rodin::Variational
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const auto phi_te = testfe.getBasis(ib)(rc);
+                const size_t vb = ib / vdim;
+                const size_t cb = ib % vdim;
+                const ScalarType phi_te = m_basis(qp, vb);
                 for (size_t ia = 0; ia < ntr; ++ia)
                 {
-                  const auto phi_tr = trialfe.getBasis(ia)(rc);
-                  const ScalarType kij = wdet * Math::dot(phi_te, phi_tr);
-                  m_matrix(ib, ia) += kij;
+                  if (ia % vdim == cb)
+                  {
+                    const ScalarType phi_tr = m_basis(qp, ia / vdim);
+                    m_matrix(ib, ia) += wdet * phi_te * phi_tr;
+                  }
                 }
               }
             }
@@ -717,6 +752,7 @@ namespace Rodin::Variational
       const Geometry::PolytopeQuadrature* m_quadrature;
 
       Math::Matrix<ScalarType> m_matrix;
+      Math::Matrix<ScalarType> m_basis;
 
       bool m_set = false;
       size_t m_order = 0;
@@ -861,7 +897,8 @@ namespace Rodin::Variational
           m_set(std::exchange(other.m_set, false)),
           m_order(std::exchange(other.m_order, 0)),
           m_geometry(std::exchange(other.m_geometry, Geometry::Polytope::Type::Point)),
-          m_matrix(std::move(other.m_matrix))
+          m_matrix(std::move(other.m_matrix)),
+          m_basis(std::move(other.m_basis))
       {}
 
       constexpr
@@ -906,6 +943,19 @@ namespace Rodin::Variational
           m_geometry = geometry;
 
           m_qf = &QF::PolytopeQuadratureFormula::get(order, geometry);
+
+          // Reference P1 basis values are shared by every physical cell with
+          // this geometry and quadrature formula.
+          const P1Element<ScalarType> scalarfe(geometry);
+          const size_t nv = scalarfe.getCount();
+          m_basis.resize(
+            static_cast<Eigen::Index>(m_qf->getSize()), static_cast<Eigen::Index>(nv));
+          for (size_t qp = 0; qp < m_qf->getSize(); ++qp)
+          {
+            const auto& rc = m_qf->getPoint(qp);
+            for (size_t a = 0; a < nv; ++a)
+              m_basis(qp, a) = scalarfe.getBasis(a)(rc);
+          }
         }
 
         assert(m_qf);
@@ -916,6 +966,24 @@ namespace Rodin::Variational
 
         assert(ntr == trialfe.getCount());
         assert(nte == testfe.getCount());
+
+        const size_t vdim = [&]() {
+          if constexpr (FormLanguage::IsVectorRange<MultiplicandRangeType>::Value)
+          {
+            const size_t trialVdim = trialfes.getVectorDimension();
+            assert(trialVdim == testfes.getVectorDimension());
+            return trialVdim;
+          }
+          else
+          {
+            return size_t(1);
+          }
+        }();
+        assert(vdim > 0);
+        assert(ntr % vdim == 0);
+        assert(nte % vdim == 0);
+        assert(static_cast<size_t>(m_basis.cols()) == ntr / vdim);
+        assert(static_cast<size_t>(m_basis.cols()) == nte / vdim);
 
         m_matrix.resize(static_cast<Eigen::Index>(nte), static_cast<Eigen::Index>(ntr));
         m_matrix.setZero();
@@ -929,8 +997,6 @@ namespace Rodin::Variational
           const ScalarType wdet =
             static_cast<ScalarType>(m_qf->getWeight(qp) * p.getDistortion());
 
-          const auto& rc = m_qf->getPoint(qp);
-
           if constexpr (std::is_same_v<CoefficientRangeType, ScalarType>)
           {
             const ScalarType csv = coeff.getValue(ip);
@@ -939,11 +1005,10 @@ namespace Rodin::Variational
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const ScalarType phi_te = testfe.getBasis(ib)(rc);
+                const ScalarType phi_te = m_basis(qp, ib);
                 for (size_t ia = 0; ia < ntr; ++ia)
                 {
-                  const ScalarType kij =
-                    wdet * csv * phi_te * trialfe.getBasis(ia)(rc);
+                  const ScalarType kij = wdet * csv * phi_te * m_basis(qp, ia);
                   m_matrix(ib, ia) += kij;
                 }
               }
@@ -952,12 +1017,16 @@ namespace Rodin::Variational
             {
               for (size_t ib = 0; ib < nte; ++ib)
               {
-                const auto phi_te = testfe.getBasis(ib)(rc);
+                const size_t vb = ib / vdim;
+                const size_t cb = ib % vdim;
+                const ScalarType phi_te = m_basis(qp, vb);
                 for (size_t ia = 0; ia < ntr; ++ia)
                 {
-                  const auto phi_tr = trialfe.getBasis(ia)(rc);
-                  const ScalarType kij = wdet * csv * Math::dot(phi_te, phi_tr);
-                  m_matrix(ib, ia) += kij;
+                  if (ia % vdim == cb)
+                  {
+                    const ScalarType phi_tr = m_basis(qp, ia / vdim);
+                    m_matrix(ib, ia) += wdet * csv * phi_te * phi_tr;
+                  }
                 }
               }
             }
@@ -972,11 +1041,14 @@ namespace Rodin::Variational
 
             for (size_t ib = 0; ib < nte; ++ib)
             {
-              const auto phi_te = testfe.getBasis(ib)(rc);
+              const size_t vb = ib / vdim;
+              const size_t cb = ib % vdim;
+              const ScalarType phi_te = m_basis(qp, vb);
               for (size_t ia = 0; ia < ntr; ++ia)
               {
-                const auto phi_tr = trialfe.getBasis(ia)(rc);
-                m_matrix(ib, ia) += wdet * Math::dot(phi_te, cmv * phi_tr);
+                const size_t ca = ia % vdim;
+                const ScalarType phi_tr = m_basis(qp, ia / vdim);
+                m_matrix(ib, ia) += wdet * phi_te * cmv(cb, ca) * phi_tr;
               }
             }
           }
@@ -1010,6 +1082,7 @@ namespace Rodin::Variational
       Geometry::Polytope::Type m_geometry;
 
       Math::Matrix<ScalarType> m_matrix;
+      Math::Matrix<ScalarType> m_basis;
   };
 
   template <class CoefficientDerived, class LHSDerived, class RHSDerived, class Number, class Mesh>

--- a/src/Rodin/Variational/Problem.h
+++ b/src/Rodin/Variational/Problem.h
@@ -186,8 +186,7 @@ namespace Rodin::Variational
       virtual ProblemBase& assemble(AssemblyTarget)
       {
         Alert::MemberFunctionException(*this, __func__)
-          << "Targeted assembly is not implemented for this problem."
-          << Alert::Raise;
+          << "Targeted assembly is not implemented for this problem." << Alert::Raise;
         return *this;
       }
 
@@ -477,9 +476,18 @@ namespace Rodin::Variational
       }
 
       /// @brief Assembles the whole linear system.
+      /**
+       * @brief Assembles the linear system and establishes the initial guess.
+       *
+       * After assembly, the linear system's solution vector holds the trial
+       * function data as the initial guess: on entry to a linear solver the
+       * solution vector is the guess, on exit it is the solution. Trial
+       * functions are zero-initialized, so the guess is zero unless set.
+       */
       Problem& assemble() override
       {
         m_assembly.execute(m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() });
+        m_axb.getSolution() = this->getTrialFunction().getSolution().getData();
         m_assembled = true;
         return *this;
       }
@@ -488,7 +496,7 @@ namespace Rodin::Variational
       Problem& assemble(AssemblyTarget target) override
       {
         m_assembly.execute(
-            m_axb, { m_pb, this->getTrialFunction(), this->getTestFunction() }, target);
+          m_axb, {m_pb, this->getTrialFunction(), this->getTestFunction()}, target);
         m_assembled = true;
         return *this;
       }
@@ -879,6 +887,15 @@ namespace Rodin::Variational
             m_trialUUIDMap, m_testUUIDMap, cols, rows);
         m_assembly.execute(axb, input);
 
+        // Establish the initial guess: gather the trial function data into
+        // the solution vector at the trial offsets.
+        auto& guess = axb.getSolution();
+        guess.resize(static_cast<Eigen::Index>(cols));
+        m_us.iapply([&](size_t i, auto& u) {
+          const auto& data = u.get().getSolution().getData();
+          guess.segment(static_cast<Eigen::Index>(m_trialOffsets[i]), data.size()) = data;
+        });
+
         m_assembled = true;
 
         return *this;
@@ -891,10 +908,9 @@ namespace Rodin::Variational
         // Compute trial offsets
         {
           std::array<size_t, TrialFunctionTuple::Size> sz;
-          m_us.map(
-                [](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
-              .iapply(
-                [&](const Index i, size_t s) { sz[i] = s; });
+          m_us
+            .map([](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
+            .iapply([&](const Index i, size_t s) { sz[i] = s; });
           m_trialOffsets[0] = 0;
           for (size_t i = 0; i < TrialFunctionTuple::Size - 1; i++)
             m_trialOffsets[i + 1] = sz[i] + m_trialOffsets[i];
@@ -903,10 +919,9 @@ namespace Rodin::Variational
         // Compute test offsets
         {
           std::array<size_t, TestFunctionTuple::Size> sz;
-          m_vs.map(
-                [](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
-              .iapply(
-                [&](const Index i, size_t s) { sz[i] = s; });
+          m_vs
+            .map([](const auto& u) { return u.get().getFiniteElementSpace().getSize(); })
+            .iapply([&](const Index i, size_t s) { sz[i] = s; });
           m_testOffsets[0] = 0;
           for (size_t i = 0; i < TestFunctionTuple::Size - 1; i++)
             m_testOffsets[i + 1] = sz[i] + m_testOffsets[i];
@@ -914,23 +929,20 @@ namespace Rodin::Variational
 
         size_t rows =
           m_vs
-            .map([](const auto& v)
-            {
+            .map([](const auto& v) {
               return static_cast<size_t>(v.get().getFiniteElementSpace().getSize());
             })
             .reduce([](size_t a, size_t b) { return a + b; });
 
         size_t cols =
           m_us
-            .map([](const auto& u)
-            {
+            .map([](const auto& u) {
               return static_cast<size_t>(u.get().getFiniteElementSpace().getSize());
             })
             .reduce([](size_t a, size_t b) { return a + b; });
 
-        AssemblyInput input(
-            m_pb, m_us, m_vs, m_trialOffsets, m_testOffsets,
-            m_trialUUIDMap, m_testUUIDMap, cols, rows);
+        AssemblyInput input(m_pb, m_us, m_vs, m_trialOffsets, m_testOffsets,
+          m_trialUUIDMap, m_testUUIDMap, cols, rows);
         m_assembly.execute(axb, input, target);
 
         m_assembled = true;

--- a/src/Rodin/Variational/Sum.h
+++ b/src/Rodin/Variational/Sum.h
@@ -397,8 +397,8 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        const auto lhs = getLHS().getBasis(local);
-        const auto rhs = getRHS().getBasis(local);
+        decltype(auto) lhs = getLHS().getBasis(local);
+        decltype(auto) rhs = getRHS().getBasis(local);
         return lhs + rhs;
       }
 

--- a/src/Rodin/Variational/Transpose.h
+++ b/src/Rodin/Variational/Transpose.h
@@ -93,7 +93,10 @@ namespace Rodin::Variational
       auto getValue(const Point& p) const
       {
         const auto v = getOperand().getValue(p);
-        return v.transpose();
+        if constexpr (requires { v.transpose().eval(); })
+          return v.transpose().eval();
+        else
+          return v.transpose();
       }
 
       Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
@@ -218,8 +221,11 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        const auto v = getOperand().getBasis(local);
-        return v.transpose();
+        decltype(auto) v = getOperand().getBasis(local);
+        if constexpr (requires { v.transpose().eval(); })
+          return v.transpose().eval();
+        else
+          return v.transpose();
       }
 
       /**

--- a/src/Rodin/Variational/UnaryMinus.h
+++ b/src/Rodin/Variational/UnaryMinus.h
@@ -106,7 +106,10 @@ namespace Rodin::Variational
       auto getValue(const Point& p) const
       {
         const auto v = getOperand().getValue(p);
-        return -v;
+        if constexpr (requires { (-v).eval(); })
+          return (-v).eval();
+        else
+          return -v;
       }
 
       constexpr
@@ -243,8 +246,11 @@ namespace Rodin::Variational
       constexpr
       auto getBasis(size_t local) const
       {
-        const auto v = getOperand().getBasis(local);
-        return -v;
+        decltype(auto) v = getOperand().getBasis(local);
+        if constexpr (requires { (-v).eval(); })
+          return (-v).eval();
+        else
+          return -v;
       }
 
       const FES& getFiniteElementSpace() const

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(RodinBenchmarks_SRCS
+  GridFunction.cpp
   P1.cpp
   Poisson.cpp
   MeshIO.cpp
@@ -13,4 +14,3 @@ target_link_libraries(RodinBenchmarks
   Rodin::Solver
   benchmark::benchmark
   benchmark::benchmark_main)
-

--- a/tests/benchmarks/GridFunction.cpp
+++ b/tests/benchmarks/GridFunction.cpp
@@ -1,0 +1,256 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+
+/**
+ * @file
+ * @brief Grid-function point-evaluation benchmarks.
+ *
+ * Compares finite-element expansion evaluation with the mapped-basis
+ * contraction previously used by GridFunction at arbitrary geometric points.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <Rodin/Geometry.h>
+#include <Rodin/Variational.h>
+#include <Rodin/Variational/H1.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace Rodin::Tests::Benchmarks
+{
+  /// @cond RODIN_TEST_INTERNAL
+
+  struct GridFunctionEvaluationBenchmark : public benchmark::Fixture
+  {
+      void SetUp(const benchmark::State&)
+      {
+        mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {4, 4});
+        mesh.getConnectivity().compute(2, 1);
+        mesh.getConnectivity().compute(1, 0);
+      }
+
+      LocalMesh mesh;
+  };
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1VectorExpansion)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh, 2);
+    GridFunction gf(fes);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + 2.0 * p.x() + p.y(); }};
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+
+    for (auto _ : state)
+    {
+      Math::SpatialVector<Real> value;
+      gf.interpolate(value, p);
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1ScalarExpansion)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+
+    for (auto _ : state)
+    {
+      Real value;
+      gf.interpolate(value, p);
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1ScalarReferenceExpansion)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& fe = fes.getFiniteElement(2, 0);
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Real value;
+      fe.evaluate(
+        value, [&](size_t local) -> decltype(auto) { return gf[dofs[local]]; },
+        p.getReferenceCoordinates());
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1ScalarSpaceExpansion)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Real value;
+      fes.evaluate(
+        value, {2, 0}, [&](size_t local) -> decltype(auto) { return gf[dofs[local]]; },
+        p);
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1ScalarMappedBasis)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& fe = fes.getFiniteElement(2, 0);
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Real value = 0;
+      for (size_t local = 0; local < fe.getCount(); ++local)
+      {
+        const auto mapping = fes.getPushforward({2, 0}, fe.getBasis(local));
+        value += gf[dofs[local]] * mapping(p);
+      }
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, P1VectorMappedBasis)
+  (benchmark::State& state)
+  {
+    P1 fes(mesh, 2);
+    GridFunction gf(fes);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + 2.0 * p.x() + p.y(); }};
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& fe = fes.getFiniteElement(2, 0);
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Math::SpatialVector<Real> value;
+      for (size_t local = 0; local < fe.getCount(); ++local)
+      {
+        const auto mapping = fes.getPushforward({2, 0}, fe.getBasis(local));
+        const auto term = gf[dofs[local]] * mapping(p);
+        if (local == 0)
+          value = term;
+        else
+          value += term;
+      }
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, H1P2VectorExpansion)
+  (benchmark::State& state)
+  {
+    H1 fes(std::integral_constant<size_t, 2>{}, mesh, size_t(2));
+    GridFunction gf(fes);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + 2.0 * p.x() + p.y(); }};
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+
+    for (auto _ : state)
+    {
+      Math::SpatialVector<Real> value;
+      gf.interpolate(value, p);
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, H1P2ScalarExpansion)
+  (benchmark::State& state)
+  {
+    H1 fes(std::integral_constant<size_t, 2>{}, mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+
+    for (auto _ : state)
+    {
+      Real value;
+      gf.interpolate(value, p);
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, H1P2ScalarMappedBasis)
+  (benchmark::State& state)
+  {
+    H1 fes(std::integral_constant<size_t, 2>{}, mesh);
+    GridFunction gf(fes);
+    gf = RealFunction([](const Point& p) { return 1.0 + p.x() - p.y(); });
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& fe = fes.getFiniteElement(2, 0);
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Real value = 0;
+      for (size_t local = 0; local < fe.getCount(); ++local)
+      {
+        const auto mapping = fes.getPushforward({2, 0}, fe.getBasis(local));
+        value += gf[dofs[local]] * mapping(p);
+      }
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  BENCHMARK_F(GridFunctionEvaluationBenchmark, H1P2VectorMappedBasis)
+  (benchmark::State& state)
+  {
+    H1 fes(std::integral_constant<size_t, 2>{}, mesh, size_t(2));
+    GridFunction gf(fes);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + 2.0 * p.x() + p.y(); }};
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto& fe = fes.getFiniteElement(2, 0);
+    const auto& dofs = fes.getDOFs(2, 0);
+
+    for (auto _ : state)
+    {
+      Math::SpatialVector<Real> value;
+      for (size_t local = 0; local < fe.getCount(); ++local)
+      {
+        const auto mapping = fes.getPushforward({2, 0}, fe.getBasis(local));
+        const auto term = gf[dofs[local]] * mapping(p);
+        if (local == 0)
+          value = term;
+        else
+          value += term;
+      }
+      benchmark::DoNotOptimize(value);
+    }
+  }
+
+  /// @endcond
+}

--- a/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/Assembly/TargetedAssemblyTest.cpp
@@ -48,18 +48,17 @@ namespace Rodin::Tests::Manufactured::Assembly
     Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>>;
 
   /// @brief Helper used by the manufactured tests to Expect Same Vector.
-  void expectSameVector(const Math::Vector<Real>& expected,
-                        const Math::Vector<Real>& actual)
+  void expectSameVector(
+    const Math::Vector<Real>& expected, const Math::Vector<Real>& actual)
   {
     ASSERT_EQ(expected.size(), actual.size());
     for (Eigen::Index i = 0; i < expected.size(); ++i)
-      EXPECT_LE(std::abs(expected.coeff(i) - actual.coeff(i)), 1e-12)
-        << "row " << i;
+      EXPECT_LE(std::abs(expected.coeff(i) - actual.coeff(i)), 1e-12) << "row " << i;
   }
 
   /// @brief Helper used by the manufactured tests to Expect Same Matrix.
-  void expectSameMatrix(const Math::SparseMatrix<Real>& expected,
-                        const Math::SparseMatrix<Real>& actual)
+  void expectSameMatrix(
+    const Math::SparseMatrix<Real>& expected, const Math::SparseMatrix<Real>& actual)
   {
     ASSERT_EQ(expected.rows(), actual.rows());
     ASSERT_EQ(expected.cols(), actual.cols());
@@ -78,22 +77,20 @@ namespace Rodin::Tests::Manufactured::Assembly
   /// @brief Helper used by the manufactured tests to Assemble Single Field.
   LinearSystemType assembleSingleField(Variational::AssemblyTarget target, bool targeted)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     TrialFunction u(fes);
-    TestFunction  v(fes);
+    TestFunction v(fes);
 
     using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
     typename ProblemType::ProblemBodyType body =
-      Integral(Grad(u), Grad(v)) + Integral(u, v)
-        - Integral(RealFunction(1.0), v);
+      Integral(Grad(u), Grad(v)) + Integral(u, v) - Integral(RealFunction(1.0), v);
 
-    ::Rodin::Assembly::ProblemAssemblyInput<
-      typename ProblemType::ProblemBodyType,
-      decltype(u), decltype(v)> input(body, u, v);
+    ::Rodin::Assembly::ProblemAssemblyInput<typename ProblemType::ProblemBodyType,
+      decltype(u), decltype(v)>
+      input(body, u, v);
 
     LinearSystemType ls;
     Assembler<LinearSystemType, ProblemType> assembler;
@@ -144,50 +141,46 @@ namespace Rodin::Tests::Manufactured::Assembly
   /// @brief Helper used by the manufactured tests to Assemble Block.
   LinearSystemType assembleBlock(Variational::AssemblyTarget target, bool targeted)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 vh(mesh);
     P0 ph(mesh);
     TrialFunction u(vh);
-    TestFunction  v(vh);
+    TestFunction v(vh);
     TrialFunction p(ph);
-    TestFunction  q(ph);
+    TestFunction q(ph);
 
     using ProblemType =
       Problem<LinearSystemType, decltype(u), decltype(v), decltype(p), decltype(q)>;
-    typename ProblemType::ProblemBodyType body =
-      Integral(Grad(u), Grad(v)) + Integral(u, v)
-        - Integral(p, v) - Integral(u, q) + Integral(p, q)
-        - Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
+    typename ProblemType::ProblemBodyType body = Integral(Grad(u), Grad(v)) +
+      Integral(u, v) - Integral(p, v) - Integral(u, q) + Integral(p, q) -
+      Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
 
     // Trial blocks: [u, p]; test blocks: [v, q].
-    auto us = Tuple{ std::ref(u), std::ref(p) };
-    auto vs = Tuple{ std::ref(v), std::ref(q) };
+    auto us = Tuple{std::ref(u), std::ref(p)};
+    auto vs = Tuple{std::ref(v), std::ref(q)};
 
     const size_t uSize = static_cast<size_t>(vh.getSize());
     const size_t pSize = static_cast<size_t>(ph.getSize());
 
-    std::array<size_t, 2> trialOffsets{ 0, uSize };
-    std::array<size_t, 2> testOffsets{ 0, uSize };
+    std::array<size_t, 2> trialOffsets{0, uSize};
+    std::array<size_t, 2> testOffsets{0, uSize};
 
     boost::bimap<Rodin::FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<Rodin::FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, p.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, q.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, p.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, q.getUUID()});
 
     const size_t totalTrial = uSize + pSize;
-    const size_t totalTest  = uSize + pSize;
+    const size_t totalTest = uSize + pSize;
 
-    ::Rodin::Assembly::ProblemAssemblyInput<
-      typename ProblemType::ProblemBodyType,
+    ::Rodin::Assembly::ProblemAssemblyInput<typename ProblemType::ProblemBodyType,
       decltype(u), decltype(v), decltype(p), decltype(q)>
-      input(
-        body, us, vs, trialOffsets, testOffsets,
-        trialUUIDMap, testUUIDMap, totalTrial, totalTest);
+      input(body, us, vs, trialOffsets, testOffsets, trialUUIDMap, testUUIDMap,
+        totalTrial, totalTest);
 
     LinearSystemType ls;
     Assembler<LinearSystemType, ProblemType> assembler;
@@ -202,12 +195,9 @@ namespace Rodin::Tests::Manufactured::Assembly
   /// @brief Helper used by the manufactured tests to Check Block Targeted.
   void checkBlockTargeted()
   {
-    const auto full =
-      assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, false);
-    const auto lhs =
-      assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, true);
-    const auto rhs =
-      assembleBlock<Assembler>(Variational::AssemblyTarget::RHS, true);
+    const auto full = assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, false);
+    const auto lhs = assembleBlock<Assembler>(Variational::AssemblyTarget::LHS, true);
+    const auto rhs = assembleBlock<Assembler>(Variational::AssemblyTarget::RHS, true);
 
     expectSameMatrix(full.getOperator(), lhs.getOperator());
     expectSameVector(full.getVector(), rhs.getVector());
@@ -232,31 +222,29 @@ namespace Rodin::Tests::Manufactured::Assembly
   /// @brief Verifies block problem APILHS and RHS for eigen targeted assembly by checking form assembly.
   TEST(Eigen_TargetedAssembly, BlockProblemAPILHSAndRHS)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 vh(mesh);
     P0 ph(mesh);
     TrialFunction u(vh);
     TrialFunction p(ph);
-    TestFunction  v(vh);
-    TestFunction  q(ph);
+    TestFunction v(vh);
+    TestFunction q(ph);
 
     Problem prob(u, v, p, q);
-    prob = Integral(Grad(u), Grad(v)) + Integral(u, v)
-         - Integral(p, v) - Integral(u, q) + Integral(p, q)
-         - Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
+    prob = Integral(Grad(u), Grad(v)) + Integral(u, v) - Integral(p, v) - Integral(u, q) +
+      Integral(p, q) - Integral(RealFunction(1.0), v) - Integral(RealFunction(2.0), q);
 
     prob.assemble();
     const Math::SparseMatrix<Real> Afull = prob.getLinearSystem().getOperator();
-    const Math::Vector<Real>       bfull = prob.getLinearSystem().getVector();
+    const Math::Vector<Real> bfull = prob.getLinearSystem().getVector();
 
     prob.assemble(Variational::AssemblyTarget::LHS);
     const Math::SparseMatrix<Real> Alhs = prob.getLinearSystem().getOperator();
 
     prob.assemble(Variational::AssemblyTarget::RHS);
-    const Math::Vector<Real>       brhs = prob.getLinearSystem().getVector();
+    const Math::Vector<Real> brhs = prob.getLinearSystem().getVector();
 
     expectSameMatrix(Afull, Alhs);
     expectSameVector(bfull, brhs);

--- a/tests/manufactured/Rodin/P1/CMakeLists.txt
+++ b/tests/manufactured/Rodin/P1/CMakeLists.txt
@@ -181,6 +181,7 @@ target_link_libraries(RodinManufacturedP1HyperElasticity
   Rodin::Variational
   Rodin::Solver
   Rodin::Solid
+  Rodin::Test
 )
 gtest_discover_tests(RodinManufacturedP1HyperElasticity
   PROPERTIES

--- a/tests/manufactured/Rodin/P1/HyperElasticity.cpp
+++ b/tests/manufactured/Rodin/P1/HyperElasticity.cpp
@@ -58,17 +58,15 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
     {
       constexpr Real meshElementSize = 1.0 / 4.0;
       Mesh mesh;
-      mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 5, 5, 5 });
+      mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {5, 5, 5});
       mesh.scale(meshElementSize);
       mesh.getConnectivity().compute(2, 3);
       return mesh;
     }
 
     template <class FES, class State>
-    Rodin::Test::FDProbeReport
-    checkNeoHookeanInternalVirtualWorkFD(
-        FES& Vh,
-        State& uCurrent)
+    Rodin::Test::FDProbeReport checkNeoHookeanInternalVirtualWorkFD(
+      FES& Vh, State& uCurrent)
     {
       const Real lambda = 2.0;
       const Real mu = 1.0;
@@ -87,26 +85,23 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
     }
 
     template <class FES, class State>
-    Rodin::Test::FDProbeReport
-    checkActiveContractionInternalVirtualWorkFD(
-        FES& Vh,
-        State& uCurrent)
+    Rodin::Test::FDProbeReport checkActiveContractionInternalVirtualWorkFD(
+      FES& Vh, State& uCurrent)
     {
       const size_t dim = Vh.getMesh().getSpaceDimension();
 
       Solid::NeoHookean passive(0.0, 0.0);
       Solid::ActiveFiberLaw::Parameters activeInput;
-      activeInput.stiffness            = 80.0;
-      activeInput.damping              = 0.4;
-      activeInput.destructionRate      = 0.5;
+      activeInput.stiffness = 80.0;
+      activeInput.damping = 0.4;
+      activeInput.destructionRate = 0.5;
       activeInput.crossBridgeStiffness = 60.0;
-      activeInput.contractility        = 40.0;
+      activeInput.contractility = 40.0;
       Solid::ActiveFiberLaw active(activeInput);
       Solid::ActiveContraction law(passive, active);
       law.setLocalTolerance(1e-13).setLocalMaxIterations(80);
 
-      auto setActiveInput = [dim](Solid::ConstitutivePoint& cp)
-      {
+      auto setActiveInput = [dim](Solid::ConstitutivePoint& cp) {
         Math::SpatialVector<Real> fiber(static_cast<std::uint8_t>(dim));
         fiber.setZero();
         fiber[0] = 0.8;
@@ -128,8 +123,7 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       du.getSolution() = uCurrent;
 
       auto ivw =
-        Solid::InternalVirtualWork(law, du.getSolution())
-          .setInput(setActiveInput);
+        Solid::InternalVirtualWork(law, du.getSolution()).setInput(setActiveInput);
       Problem problem(du, v);
       problem = ivw(du, v);
 
@@ -238,17 +232,16 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
   }
 
   /// @brief Verifies the NeoHookean internal virtual work tangent against a central finite difference of the residual in 2D.
-  TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency2D)
+  TEST(
+    Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency2D)
   {
     Mesh mesh = makeUnitSquareMesh();
     P1 Vh(mesh, mesh.getSpaceDimension());
 
     GridFunction uCurrent(Vh);
     const Real pi = Math::Constants::pi();
-    uCurrent = VectorFunction{
-      0.07 * F::x + 0.02 * sin(pi * F::x) * sin(pi * F::y),
-      -0.05 * F::y + 0.01 * cos(pi * F::x) * sin(pi * F::y)
-    };
+    uCurrent = VectorFunction{0.07 * F::x + 0.02 * sin(pi * F::x) * sin(pi * F::y),
+      -0.05 * F::y + 0.01 * cos(pi * F::x) * sin(pi * F::y)};
 
     const auto result = checkNeoHookeanInternalVirtualWorkFD(Vh, uCurrent);
     EXPECT_LT(result.relativeError, 1e-6)
@@ -258,18 +251,17 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
   }
 
   /// @brief Verifies the NeoHookean internal virtual work tangent against a central finite difference of the residual in 3D.
-  TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency3D)
+  TEST(
+    Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency3D)
   {
     Mesh mesh = makeUnitCubeMesh();
     P1 Vh(mesh, mesh.getSpaceDimension());
 
     GridFunction uCurrent(Vh);
     const Real pi = Math::Constants::pi();
-    uCurrent = VectorFunction{
-      0.04 * F::x + 0.01 * sin(pi * F::x) * sin(pi * F::y),
+    uCurrent = VectorFunction{0.04 * F::x + 0.01 * sin(pi * F::x) * sin(pi * F::y),
       -0.03 * F::y + 0.01 * sin(pi * F::y) * sin(pi * F::z),
-      0.02 * F::z + 0.01 * sin(pi * F::x) * sin(pi * F::z)
-    };
+      0.02 * F::z + 0.01 * sin(pi * F::x) * sin(pi * F::z)};
 
     const auto result = checkNeoHookeanInternalVirtualWorkFD(Vh, uCurrent);
     EXPECT_LT(result.relativeError, 1e-6)
@@ -279,17 +271,16 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
   }
 
   /// @brief Verifies the ActiveContraction internal virtual work tangent against a central finite difference of the residual in 2D.
-  TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency2D)
+  TEST(Rodin_Manufactured_P1,
+    HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency2D)
   {
     Mesh mesh = makeUnitSquareMesh();
     P1 Vh(mesh, mesh.getSpaceDimension());
 
     GridFunction uCurrent(Vh);
     const Real pi = Math::Constants::pi();
-    uCurrent = VectorFunction{
-      0.05 * F::x + 0.015 * sin(pi * F::x) * sin(pi * F::y),
-      -0.04 * F::y + 0.012 * cos(pi * F::x) * sin(pi * F::y)
-    };
+    uCurrent = VectorFunction{0.05 * F::x + 0.015 * sin(pi * F::x) * sin(pi * F::y),
+      -0.04 * F::y + 0.012 * cos(pi * F::x) * sin(pi * F::y)};
 
     const auto result = checkActiveContractionInternalVirtualWorkFD(Vh, uCurrent);
     EXPECT_GT(result.finiteDifferenceNorm, 1e-10);
@@ -300,18 +291,17 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
   }
 
   /// @brief Verifies the ActiveContraction internal virtual work tangent against a central finite difference of the residual in 3D.
-  TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency3D)
+  TEST(Rodin_Manufactured_P1,
+    HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency3D)
   {
     Mesh mesh = makeUnitCubeMesh();
     P1 Vh(mesh, mesh.getSpaceDimension());
 
     GridFunction uCurrent(Vh);
     const Real pi = Math::Constants::pi();
-    uCurrent = VectorFunction{
-      0.035 * F::x + 0.008 * sin(pi * F::x) * sin(pi * F::y),
+    uCurrent = VectorFunction{0.035 * F::x + 0.008 * sin(pi * F::x) * sin(pi * F::y),
       -0.025 * F::y + 0.007 * sin(pi * F::y) * sin(pi * F::z),
-      0.020 * F::z + 0.006 * sin(pi * F::x) * sin(pi * F::z)
-    };
+      0.020 * F::z + 0.006 * sin(pi * F::x) * sin(pi * F::z)};
 
     const auto result = checkActiveContractionInternalVirtualWorkFD(Vh, uCurrent);
     EXPECT_GT(result.finiteDifferenceNorm, 1e-10);

--- a/tests/manufactured/Rodin/P1/HyperElasticity.cpp
+++ b/tests/manufactured/Rodin/P1/HyperElasticity.cpp
@@ -237,6 +237,7 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
     EXPECT_GT(result.l2ErrorSquared, 1e-6);
   }
 
+  /// @brief Verifies the NeoHookean internal virtual work tangent against a central finite difference of the residual in 2D.
   TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency2D)
   {
     Mesh mesh = makeUnitSquareMesh();
@@ -256,6 +257,7 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
   }
 
+  /// @brief Verifies the NeoHookean internal virtual work tangent against a central finite difference of the residual in 3D.
   TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency3D)
   {
     Mesh mesh = makeUnitCubeMesh();
@@ -276,6 +278,7 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
   }
 
+  /// @brief Verifies the ActiveContraction internal virtual work tangent against a central finite difference of the residual in 2D.
   TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency2D)
   {
     Mesh mesh = makeUnitSquareMesh();
@@ -296,6 +299,7 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
   }
 
+  /// @brief Verifies the ActiveContraction internal virtual work tangent against a central finite difference of the residual in 3D.
   TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency3D)
   {
     Mesh mesh = makeUnitCubeMesh();

--- a/tests/manufactured/Rodin/P1/HyperElasticity.cpp
+++ b/tests/manufactured/Rodin/P1/HyperElasticity.cpp
@@ -18,6 +18,7 @@
 #include "Rodin/Solid.h"
 #include "Rodin/Solver/NewtonSolver.h"
 #include "Rodin/Solver/SparseLU.h"
+#include "Rodin/Test/FDProbe.h"
 #include "Rodin/Variational.h"
 
 using namespace Rodin;
@@ -51,6 +52,89 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       mesh.scale(meshElementSize);
       mesh.getConnectivity().compute(1, 2);
       return mesh;
+    }
+
+    auto makeUnitCubeMesh()
+    {
+      constexpr Real meshElementSize = 1.0 / 4.0;
+      Mesh mesh;
+      mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 5, 5, 5 });
+      mesh.scale(meshElementSize);
+      mesh.getConnectivity().compute(2, 3);
+      return mesh;
+    }
+
+    template <class FES, class State>
+    Rodin::Test::FDProbeReport
+    checkNeoHookeanInternalVirtualWorkFD(
+        FES& Vh,
+        State& uCurrent)
+    {
+      const Real lambda = 2.0;
+      const Real mu = 1.0;
+      Solid::NeoHookean law(lambda, mu);
+
+      TrialFunction du(Vh);
+      TestFunction v(Vh);
+      du.getSolution() = uCurrent;
+
+      auto ivw = Solid::InternalVirtualWork(law, du.getSolution());
+      Problem problem(du, v);
+      problem = ivw(du, v);
+
+      Rodin::Test::FDProbe probe(problem);
+      return probe.test(1e-6);
+    }
+
+    template <class FES, class State>
+    Rodin::Test::FDProbeReport
+    checkActiveContractionInternalVirtualWorkFD(
+        FES& Vh,
+        State& uCurrent)
+    {
+      const size_t dim = Vh.getMesh().getSpaceDimension();
+
+      Solid::NeoHookean passive(0.0, 0.0);
+      Solid::ActiveFiberLaw::Parameters activeInput;
+      activeInput.stiffness            = 80.0;
+      activeInput.damping              = 0.4;
+      activeInput.destructionRate      = 0.5;
+      activeInput.crossBridgeStiffness = 60.0;
+      activeInput.contractility        = 40.0;
+      Solid::ActiveFiberLaw active(activeInput);
+      Solid::ActiveContraction law(passive, active);
+      law.setLocalTolerance(1e-13).setLocalMaxIterations(80);
+
+      auto setActiveInput = [dim](Solid::ConstitutivePoint& cp)
+      {
+        Math::SpatialVector<Real> fiber(static_cast<std::uint8_t>(dim));
+        fiber.setZero();
+        fiber[0] = 0.8;
+        fiber[1] = 0.6;
+        if (dim == 3)
+          fiber[2] = 0.3;
+        fiber *= 1.0 / fiber.norm();
+
+        cp.set<Solid::Tags::FiberDirection>(fiber);
+        cp.set<Solid::Tags::TimeStep>(0.01);
+        cp.set<Solid::Tags::PreviousActiveExtension>(-0.035);
+        cp.set<Solid::Tags::PreviousActiveGamma>(1.7);
+        cp.set<Solid::Tags::PreviousActiveBeta>(0.9);
+        cp.set<Solid::Tags::ElectricalActivation>(1.1);
+      };
+
+      TrialFunction du(Vh);
+      TestFunction v(Vh);
+      du.getSolution() = uCurrent;
+
+      auto ivw =
+        Solid::InternalVirtualWork(law, du.getSolution())
+          .setInput(setActiveInput);
+      Problem problem(du, v);
+      problem = ivw(du, v);
+
+      Rodin::Test::FDProbe probe(problem);
+      return probe.test(1e-7);
     }
 
     SolveResult solveAffineHyperElasticity(ResidualSign residualSign)
@@ -151,5 +235,85 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
     // The wrong sign makes the residual grow rather than decay.
     EXPECT_GT(result.finalResidual, result.initialResidual);
     EXPECT_GT(result.l2ErrorSquared, 1e-6);
+  }
+
+  TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency2D)
+  {
+    Mesh mesh = makeUnitSquareMesh();
+    P1 Vh(mesh, mesh.getSpaceDimension());
+
+    GridFunction uCurrent(Vh);
+    const Real pi = Math::Constants::pi();
+    uCurrent = VectorFunction{
+      0.07 * F::x + 0.02 * sin(pi * F::x) * sin(pi * F::y),
+      -0.05 * F::y + 0.01 * cos(pi * F::x) * sin(pi * F::y)
+    };
+
+    const auto result = checkNeoHookeanInternalVirtualWorkFD(Vh, uCurrent);
+    EXPECT_LT(result.relativeError, 1e-6)
+      << "absoluteError = " << result.absoluteError
+      << ", tangentNorm = " << result.tangentNorm
+      << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
+  }
+
+  TEST(Rodin_Manufactured_P1, HyperElasticity_NeoHookean_InternalVirtualWork_FDConsistency3D)
+  {
+    Mesh mesh = makeUnitCubeMesh();
+    P1 Vh(mesh, mesh.getSpaceDimension());
+
+    GridFunction uCurrent(Vh);
+    const Real pi = Math::Constants::pi();
+    uCurrent = VectorFunction{
+      0.04 * F::x + 0.01 * sin(pi * F::x) * sin(pi * F::y),
+      -0.03 * F::y + 0.01 * sin(pi * F::y) * sin(pi * F::z),
+      0.02 * F::z + 0.01 * sin(pi * F::x) * sin(pi * F::z)
+    };
+
+    const auto result = checkNeoHookeanInternalVirtualWorkFD(Vh, uCurrent);
+    EXPECT_LT(result.relativeError, 1e-6)
+      << "absoluteError = " << result.absoluteError
+      << ", tangentNorm = " << result.tangentNorm
+      << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
+  }
+
+  TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency2D)
+  {
+    Mesh mesh = makeUnitSquareMesh();
+    P1 Vh(mesh, mesh.getSpaceDimension());
+
+    GridFunction uCurrent(Vh);
+    const Real pi = Math::Constants::pi();
+    uCurrent = VectorFunction{
+      0.05 * F::x + 0.015 * sin(pi * F::x) * sin(pi * F::y),
+      -0.04 * F::y + 0.012 * cos(pi * F::x) * sin(pi * F::y)
+    };
+
+    const auto result = checkActiveContractionInternalVirtualWorkFD(Vh, uCurrent);
+    EXPECT_GT(result.finiteDifferenceNorm, 1e-10);
+    EXPECT_LT(result.relativeError, 2e-5)
+      << "absoluteError = " << result.absoluteError
+      << ", tangentNorm = " << result.tangentNorm
+      << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
+  }
+
+  TEST(Rodin_Manufactured_P1, HyperElasticity_ActiveContraction_InternalVirtualWork_FDConsistency3D)
+  {
+    Mesh mesh = makeUnitCubeMesh();
+    P1 Vh(mesh, mesh.getSpaceDimension());
+
+    GridFunction uCurrent(Vh);
+    const Real pi = Math::Constants::pi();
+    uCurrent = VectorFunction{
+      0.035 * F::x + 0.008 * sin(pi * F::x) * sin(pi * F::y),
+      -0.025 * F::y + 0.007 * sin(pi * F::y) * sin(pi * F::z),
+      0.020 * F::z + 0.006 * sin(pi * F::x) * sin(pi * F::z)
+    };
+
+    const auto result = checkActiveContractionInternalVirtualWorkFD(Vh, uCurrent);
+    EXPECT_GT(result.finiteDifferenceNorm, 1e-10);
+    EXPECT_LT(result.relativeError, 2e-5)
+      << "absoluteError = " << result.absoluteError
+      << ", tangentNorm = " << result.tangentNorm
+      << ", finiteDifferenceNorm = " << result.finiteDifferenceNorm;
   }
 }

--- a/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
@@ -313,8 +313,11 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
     p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(1.0), v);
     p.assemble();
 
-    Vec x = p.getLinearSystem().getSolution();
-    ASSERT_EQ(VecSet(x, 3.0), PETSC_SUCCESS);
+    // The solution vector is the initial guess, seeded from the trial
+    // function on assembly. Set the guess through the trial function (its
+    // carrier under the initial-guess contract) and confirm reassembly reuses
+    // the solution vector to reflect it rather than reallocating or zeroing.
+    u.getSolution() = 3.0;
 
     p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(2.0), v);
     p.assemble();

--- a/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/MPI/TargetedAssemblyTest.cpp
@@ -33,15 +33,14 @@ using namespace Rodin;
 using namespace Rodin::Geometry;
 using namespace Rodin::Variational;
 
-static boost::mpi::environment*  g_env = nullptr;
+static boost::mpi::environment* g_env = nullptr;
 static boost::mpi::communicator* g_world = nullptr;
 
 namespace
 {
   Mesh<Context::Local> makeShardableMesh(size_t n = 5)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { n, n });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {n, n});
     const size_t D = mesh.getDimension();
     mesh.getConnectivity().compute(D, D);
     mesh.getConnectivity().compute(D, 0);
@@ -174,8 +173,7 @@ namespace
         ASSERT_EQ(ierr, PETSC_SUCCESS);
         ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
-          << "entry (" << i << ", " << j << ")";
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "entry (" << i << ", " << j << ")";
       }
     }
   }
@@ -195,31 +193,29 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
 
     P1<Real, Mesh<Context::MPI>> fullFES(mesh);
     PETSc::Variational::TrialFunction uFull(fullFES);
-    PETSc::Variational::TestFunction  vFull(fullFES);
+    PETSc::Variational::TestFunction vFull(fullFES);
     Problem full(uFull, vFull);
     full = Integral(uFull, vFull) - Integral(RealFunction(1.0), vFull);
     full.assemble();
 
     P1<Real, Mesh<Context::MPI>> lhsFES(mesh);
     PETSc::Variational::TrialFunction uLHS(lhsFES);
-    PETSc::Variational::TestFunction  vLHS(lhsFES);
+    PETSc::Variational::TestFunction vLHS(lhsFES);
     Problem lhs(uLHS, vLHS);
     lhs = Integral(uLHS, vLHS) - Integral(RealFunction(1.0), vLHS);
     lhs.assemble(Variational::AssemblyTarget::LHS);
 
     P1<Real, Mesh<Context::MPI>> rhsFES(mesh);
     PETSc::Variational::TrialFunction uRHS(rhsFES);
-    PETSc::Variational::TestFunction  vRHS(rhsFES);
+    PETSc::Variational::TestFunction vRHS(rhsFES);
     Problem rhs(uRHS, vRHS);
     rhs = Integral(uRHS, vRHS) - Integral(RealFunction(1.0), vRHS);
     rhs.assemble(Variational::AssemblyTarget::RHS);
 
     expectSameOwnedMatrix(
-        full.getLinearSystem().getOperator(),
-        lhs.getLinearSystem().getOperator());
+      full.getLinearSystem().getOperator(), lhs.getLinearSystem().getOperator());
     expectSameOwnedVector(
-        full.getLinearSystem().getVector(),
-        rhs.getLinearSystem().getVector());
+      full.getLinearSystem().getVector(), rhs.getLinearSystem().getVector());
   }
 
   // Re-assembling the identical problem into the same distributed matrix must
@@ -235,7 +231,7 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
 
     P1<Real, Mesh<Context::MPI>> fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     RealFunction gamma(1.0);
     Problem p(u, v);
     p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(1.0), v);
@@ -275,7 +271,7 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
 
     P1<Real, Mesh<Context::MPI>> fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     RealFunction gamma(1.0);
 
     auto emptyLHS = Integral(gamma * Grad(u), Grad(v));
@@ -289,8 +285,7 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
     ASSERT_EQ(matrixGlobalNonzeros(A), 0);
 
     ASSERT_EQ(
-        MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE),
-        PETSC_SUCCESS);
+      MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE), PETSC_SUCCESS);
     p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(1.0), v);
     p.assemble();
 
@@ -311,33 +306,30 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
 
     P1<Real, Mesh<Context::MPI>> fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     RealFunction gamma(1.0);
 
     Problem p(u, v);
-    p = Integral(gamma * Grad(u), Grad(v))
-      - Integral(RealFunction(1.0), v);
+    p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(1.0), v);
     p.assemble();
 
     Vec x = p.getLinearSystem().getSolution();
     ASSERT_EQ(VecSet(x, 3.0), PETSC_SUCCESS);
 
-    p = Integral(gamma * Grad(u), Grad(v))
-      - Integral(RealFunction(2.0), v);
+    p = Integral(gamma * Grad(u), Grad(v)) - Integral(RealFunction(2.0), v);
     p.assemble();
     expectOwnedVectorConstant(p.getLinearSystem().getSolution(), 3.0);
 
     P1<Real, Mesh<Context::MPI>> expectedFES(mesh);
     PETSc::Variational::TrialFunction uExpected(expectedFES);
-    PETSc::Variational::TestFunction  vExpected(expectedFES);
+    PETSc::Variational::TestFunction vExpected(expectedFES);
     Problem expected(uExpected, vExpected);
-    expected = Integral(gamma * Grad(uExpected), Grad(vExpected))
-             - Integral(RealFunction(2.0), vExpected);
+    expected = Integral(gamma * Grad(uExpected), Grad(vExpected)) -
+      Integral(RealFunction(2.0), vExpected);
     expected.assemble();
 
     expectSameOwnedVector(
-        expected.getLinearSystem().getVector(),
-        p.getLinearSystem().getVector());
+      expected.getLinearSystem().getVector(), p.getLinearSystem().getVector());
   }
 
   // A problem with different global dimensions must produce a different nonzero
@@ -354,11 +346,10 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
     auto coarseMesh = distributeFromRoot(ctx, 4);
     P1<Real, Mesh<Context::MPI>> coarseFES(coarseMesh);
     PETSc::Variational::TrialFunction uC(coarseFES);
-    PETSc::Variational::TestFunction  vC(coarseFES);
+    PETSc::Variational::TestFunction vC(coarseFES);
     RealFunction gammaC(1.0);
     Problem coarse(uC, vC);
-    coarse = Integral(gammaC * Grad(uC), Grad(vC))
-           - Integral(RealFunction(1.0), vC);
+    coarse = Integral(gammaC * Grad(uC), Grad(vC)) - Integral(RealFunction(1.0), vC);
     coarse.assemble();
     Mat coarseA = coarse.getLinearSystem().getOperator();
     PetscInt rows1 = 0;
@@ -369,11 +360,10 @@ namespace Rodin::Tests::Manufactured::PETSc::MPI
     auto fineMesh = distributeFromRoot(ctx, 6);
     P1<Real, Mesh<Context::MPI>> fineFES(fineMesh);
     PETSc::Variational::TrialFunction uF(fineFES);
-    PETSc::Variational::TestFunction  vF(fineFES);
+    PETSc::Variational::TestFunction vF(fineFES);
     RealFunction gammaF(1.0);
     Problem fine(uF, vF);
-    fine = Integral(gammaF * Grad(uF), Grad(vF))
-         - Integral(RealFunction(1.0), vF);
+    fine = Integral(gammaF * Grad(uF), Grad(vF)) - Integral(RealFunction(1.0), vF);
     fine.assemble();
     Mat fineA = fine.getLinearSystem().getOperator();
     PetscInt rows2 = 0;
@@ -394,8 +384,7 @@ int main(int argc, char** argv)
   g_env = &env;
   g_world = &world;
 
-  [[maybe_unused]] PetscErrorCode ierr =
-    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  [[maybe_unused]] PetscErrorCode ierr = PetscInitialize(&argc, &argv, nullptr, nullptr);
   assert(ierr == PETSC_SUCCESS);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
+++ b/tests/manufactured/Rodin/PETSc/TargetedAssemblyTest.cpp
@@ -32,25 +32,23 @@ namespace
 {
   template <template <class, class> class Assembler>
   PETSc::Math::LinearSystem assembleLocal(
-      Variational::AssemblyTarget target,
-      bool targeted)
+    Variational::AssemblyTarget target, bool targeted)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 3, 3 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {3, 3});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
 
     using LinearSystemType = PETSc::Math::LinearSystem;
     using ProblemType = Problem<LinearSystemType, decltype(u), decltype(v)>;
     typename ProblemType::ProblemBodyType body =
       Integral(u, v) - Integral(RealFunction(1.0), v);
 
-    Assembly::ProblemAssemblyInput<
-      typename ProblemType::ProblemBodyType,
-      decltype(u), decltype(v)> input(body, u, v);
+    Assembly::ProblemAssemblyInput<typename ProblemType::ProblemBodyType, decltype(u),
+      decltype(v)>
+      input(body, u, v);
 
     LinearSystemType ls(PETSC_COMM_SELF);
     Assembler<LinearSystemType, ProblemType> assembler;
@@ -124,8 +122,7 @@ namespace
         ASSERT_EQ(ierr, PETSC_SUCCESS);
         ierr = MatGetValues(actual, 1, &i, 1, &j, &b);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_LE(PetscAbsScalar(a - b), 1e-14)
-          << "entry (" << i << ", " << j << ")";
+        EXPECT_LE(PetscAbsScalar(a - b), 1e-14) << "entry (" << i << ", " << j << ")";
       }
     }
   }
@@ -133,12 +130,9 @@ namespace
   template <template <class, class> class Assembler>
   void checkLocalBackendTargetedAssembly()
   {
-    auto full = assembleLocal<Assembler>(
-        Variational::AssemblyTarget::LHS, false);
-    auto lhs = assembleLocal<Assembler>(
-        Variational::AssemblyTarget::LHS, true);
-    auto rhs = assembleLocal<Assembler>(
-        Variational::AssemblyTarget::RHS, true);
+    auto full = assembleLocal<Assembler>(Variational::AssemblyTarget::LHS, false);
+    auto lhs = assembleLocal<Assembler>(Variational::AssemblyTarget::LHS, true);
+    auto rhs = assembleLocal<Assembler>(Variational::AssemblyTarget::RHS, true);
 
     expectSameMatrix(full.getOperator(), lhs.getOperator());
     expectSameVector(full.getVector(), rhs.getVector());
@@ -151,7 +145,7 @@ namespace
     MatInfo info;
     PetscErrorCode ierr = MatGetInfo(A, MAT_LOCAL, &info);
     assert(ierr == PETSC_SUCCESS);
-    (void) ierr;
+    (void)ierr;
     return static_cast<PetscInt>(info.nz_used);
   }
 
@@ -162,7 +156,7 @@ namespace
     MatInfo info;
     PetscErrorCode ierr = MatGetInfo(A, MAT_LOCAL, &info);
     assert(ierr == PETSC_SUCCESS);
-    (void) ierr;
+    (void)ierr;
     return info.mallocs;
   }
 
@@ -171,20 +165,15 @@ namespace
   // same n exercises the MatrixSetup reuse path; changing n forces a full
   // structural setup.
   template <template <class, class> class Assembler>
-  void assembleStiffness(
-      PETSc::Math::LinearSystem& ls,
-      size_t n,
-      double gammaValue,
-      bool emptyLHS,
-      double sourceValue)
+  void assembleStiffness(PETSc::Math::LinearSystem& ls, size_t n, double gammaValue,
+    bool emptyLHS, double sourceValue)
   {
-    auto mesh =
-      Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { n, n });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     RealFunction gamma(gammaValue);
 
     using LinearSystemType = PETSc::Math::LinearSystem;
@@ -196,9 +185,9 @@ namespace
     typename ProblemType::ProblemBodyType body =
       lhs - Integral(RealFunction(sourceValue), v);
 
-    Assembly::ProblemAssemblyInput<
-      typename ProblemType::ProblemBodyType,
-      decltype(u), decltype(v)> input(body, u, v);
+    Assembly::ProblemAssemblyInput<typename ProblemType::ProblemBodyType, decltype(u),
+      decltype(v)>
+      input(body, u, v);
 
     Assembler<LinearSystemType, ProblemType> assembler;
     assembler.execute(ls, input);
@@ -206,17 +195,13 @@ namespace
 
   template <template <class, class> class Assembler>
   void assembleStiffness(
-      PETSc::Math::LinearSystem& ls,
-      size_t n,
-      double gammaValue,
-      bool emptyLHS)
+    PETSc::Math::LinearSystem& ls, size_t n, double gammaValue, bool emptyLHS)
   {
     assembleStiffness<Assembler>(ls, n, gammaValue, emptyLHS, 1.0);
   }
 
   template <template <class, class> class Assembler>
-  void assembleStiffness(
-      PETSc::Math::LinearSystem& ls, size_t n, double gammaValue)
+  void assembleStiffness(PETSc::Math::LinearSystem& ls, size_t n, double gammaValue)
   {
     assembleStiffness<Assembler>(ls, n, gammaValue, false, 1.0);
   }
@@ -314,8 +299,8 @@ namespace
     assembleStiffness<Assembler>(ls, 4, 1.0, true);
     ASSERT_EQ(matrixNonzeros(ls.getOperator()), 0);
 
-    PetscErrorCode ierr = MatSetOption(
-        ls.getOperator(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+    PetscErrorCode ierr =
+      MatSetOption(ls.getOperator(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
     ASSERT_EQ(ierr, PETSC_SUCCESS);
     assembleStiffness<Assembler>(ls, 4, 1.0);
     EXPECT_GT(matrixNonzeros(ls.getOperator()), 0);
@@ -333,8 +318,8 @@ namespace
     assembleStiffness<Assembler>(ls, 4, 1.0, true);
     ASSERT_EQ(matrixNonzeros(ls.getOperator()), 0);
 
-    PetscErrorCode ierr = MatSetOption(
-        ls.getOperator(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+    PetscErrorCode ierr =
+      MatSetOption(ls.getOperator(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
     ASSERT_EQ(ierr, PETSC_SUCCESS);
     EXPECT_DEATH(assembleStiffness<Assembler>(ls, 4, 1.0), "");
   }
@@ -374,8 +359,7 @@ namespace
   /// @brief Verifies sequential forbids new nonzero before reassembly for PET sc targeted assembly by checking form assembly.
   TEST(PETSc_TargetedAssembly, SequentialForbidsNewNonzeroBeforeReassembly)
   {
-    checkNewNonzeroOptionForbidsPatternGrowthBeforeReassembly<
-      Assembly::Sequential>();
+    checkNewNonzeroOptionForbidsPatternGrowthBeforeReassembly<Assembly::Sequential>();
   }
 #endif
 
@@ -416,8 +400,7 @@ namespace
 /// @brief Initializes the test runtime and runs the GoogleTest suite.
 int main(int argc, char** argv)
 {
-  [[maybe_unused]] PetscErrorCode ierr =
-    PetscInitialize(&argc, &argv, nullptr, nullptr);
+  [[maybe_unused]] PetscErrorCode ierr = PetscInitialize(&argc, &argv, nullptr, nullptr);
   assert(ierr == PETSC_SUCCESS);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit/Rodin/Geometry/AttributeIndexTest.cpp
+++ b/tests/unit/Rodin/Geometry/AttributeIndexTest.cpp
@@ -4,6 +4,10 @@
  *       (See accompanying file LICENSE or copy at
  *          https://www.boost.org/LICENSE_1_0.txt)
  */
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include <Rodin/Geometry.h>
@@ -98,5 +102,43 @@ namespace Rodin::Tests::Unit
     auto attr = mesh.getPolytope(0, 0)->getAttribute();
     EXPECT_TRUE(attr.has_value());
     EXPECT_EQ(*attr, 99);
+  }
+
+  /// @brief Verifies coherent attribute snapshots during concurrent reads and writes.
+  TEST(Geometry_AttributeIndex, ConcurrentReadersAndWriter)
+  {
+    AttributeIndex attributes;
+    attributes.initialize(2);
+    attributes.resize(2, 1);
+    attributes.set({2, 0}, 1, 1);
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> valid{true};
+    std::vector<std::thread> readers;
+    for (size_t t = 0; t < 8; ++t)
+    {
+      readers.emplace_back([&] {
+        while (!start.load(std::memory_order_acquire))
+        {}
+        for (size_t i = 0; i < 10000; ++i)
+        {
+          const auto attribute = attributes.get({2, 0}, 1);
+          if (!attribute || (*attribute != 1 && *attribute != 2))
+            valid.store(false, std::memory_order_relaxed);
+        }
+      });
+    }
+
+    std::thread writer([&] {
+      start.store(true, std::memory_order_release);
+      for (size_t i = 0; i < 10000; ++i)
+        attributes.set({2, 0}, 1, i % 2 + 1);
+    });
+
+    writer.join();
+    for (auto& reader : readers)
+      reader.join();
+
+    EXPECT_TRUE(valid.load(std::memory_order_relaxed));
   }
 }

--- a/tests/unit/Rodin/Geometry/CMakeLists.txt
+++ b/tests/unit/Rodin/Geometry/CMakeLists.txt
@@ -119,6 +119,19 @@ gtest_discover_tests(RodinGeometryPolytopeQuadratureIndexTest
     LABELS unit
 )
 
+add_executable(RodinGeometryPolytopeTransformationIndexTest
+  PolytopeTransformationIndexTest.cpp)
+target_link_libraries(RodinGeometryPolytopeTransformationIndexTest
+  PUBLIC
+  GTest::gtest
+  GTest::gtest_main
+  Rodin::Geometry)
+gtest_discover_tests(RodinGeometryPolytopeTransformationIndexTest
+  DISCOVERY_MODE PRE_TEST
+  PROPERTIES
+    LABELS unit
+)
+
 add_executable(RodinGeometryShardTest ShardTest.cpp)
 target_link_libraries(RodinGeometryShardTest
   PUBLIC

--- a/tests/unit/Rodin/Geometry/MinSTCutTest.cpp
+++ b/tests/unit/Rodin/Geometry/MinSTCutTest.cpp
@@ -21,20 +21,18 @@ namespace Rodin::Tests::Unit
     // Build the edges of a (rows x cols) 4-connected grid of cells with
     // uniform capacity.
     std::vector<MinSTCut::Edge> gridEdges(
-        std::size_t rows, std::size_t cols, Real capacity)
+      std::size_t rows, std::size_t cols, Real capacity)
     {
       std::vector<MinSTCut::Edge> edges;
-      auto idx = [cols](std::size_t r, std::size_t c) -> Index {
-        return r * cols + c;
-      };
+      auto idx = [cols](std::size_t r, std::size_t c) -> Index { return r * cols + c; };
       for (std::size_t r = 0; r < rows; ++r)
       {
         for (std::size_t c = 0; c < cols; ++c)
         {
           if (c + 1 < cols)
-            edges.push_back({ idx(r, c), idx(r, c + 1), capacity });
+            edges.push_back({idx(r, c), idx(r, c + 1), capacity});
           if (r + 1 < rows)
-            edges.push_back({ idx(r, c), idx(r + 1, c), capacity });
+            edges.push_back({idx(r, c), idx(r + 1, c), capacity});
         }
       }
       return edges;
@@ -84,10 +82,9 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Geometry_MinSTCut, NegativeMomentIsInside)
   {
     // Single isolated cell with a negative moment is labelled Inside.
-    const std::vector<Real> volumes{ 1.0 };
-    const std::vector<Real> moments{ -0.7 };
-    const auto result =
-      MinSTCut().classify(volumes, moments, {});
+    const std::vector<Real> volumes{1.0};
+    const std::vector<Real> moments{-0.7};
+    const auto result = MinSTCut().classify(volumes, moments, {});
     ASSERT_EQ(result.labels.size(), 1u);
     EXPECT_EQ(result.labels[0], MinSTCut::Inside);
   }
@@ -96,10 +93,9 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Geometry_MinSTCut, PositiveMomentIsOutside)
   {
     // Single isolated cell with a positive moment is labelled Outside.
-    const std::vector<Real> volumes{ 1.0 };
-    const std::vector<Real> moments{ +0.7 };
-    const auto result =
-      MinSTCut().classify(volumes, moments, {});
+    const std::vector<Real> volumes{1.0};
+    const std::vector<Real> moments{+0.7};
+    const auto result = MinSTCut().classify(volumes, moments, {});
     ASSERT_EQ(result.labels.size(), 1u);
     EXPECT_EQ(result.labels[0], MinSTCut::Outside);
   }
@@ -111,11 +107,10 @@ namespace Rodin::Tests::Unit
     // connected by an edge whose capacity dominates the unary terms.
     // The optimal cut keeps both on the same side of the source/sink
     // partition, i.e. they share a label and no cut edge appears.
-    const std::vector<Real> volumes{ 1.0, 1.0 };
-    const std::vector<Real> moments{ -0.4, +0.4 };
-    const std::vector<MinSTCut::Edge> edges{ { 0, 1, 1e3 } };
-    const auto result =
-      MinSTCut().classify(volumes, moments, edges);
+    const std::vector<Real> volumes{1.0, 1.0};
+    const std::vector<Real> moments{-0.4, +0.4};
+    const std::vector<MinSTCut::Edge> edges{{0, 1, 1e3}};
+    const auto result = MinSTCut().classify(volumes, moments, edges);
     ASSERT_EQ(result.labels.size(), 2u);
     EXPECT_EQ(result.labels[0], result.labels[1]);
     EXPECT_TRUE(result.cutEdges.empty());
@@ -127,11 +122,10 @@ namespace Rodin::Tests::Unit
     // Same conflicting-moment setup as above but with a weak smoothing
     // edge: the data term wins and the labels split along the moment
     // sign, producing one cut edge.
-    const std::vector<Real> volumes{ 1.0, 1.0 };
-    const std::vector<Real> moments{ -0.4, +0.4 };
-    const std::vector<MinSTCut::Edge> edges{ { 0, 1, 1e-3 } };
-    const auto result =
-      MinSTCut().classify(volumes, moments, edges);
+    const std::vector<Real> volumes{1.0, 1.0};
+    const std::vector<Real> moments{-0.4, +0.4};
+    const std::vector<MinSTCut::Edge> edges{{0, 1, 1e-3}};
+    const auto result = MinSTCut().classify(volumes, moments, edges);
     ASSERT_EQ(result.labels.size(), 2u);
     EXPECT_EQ(result.labels[0], MinSTCut::Inside);
     EXPECT_EQ(result.labels[1], MinSTCut::Outside);
@@ -154,17 +148,13 @@ namespace Rodin::Tests::Unit
     constexpr std::size_t rows = 2;
     constexpr std::size_t cols = 2;
     const std::vector<Real> volumes(rows * cols, 1.0);
-    const std::vector<Real> moments{
-      -1.0,  +1.0,
-      +1.0,  -1.0
-    };
+    const std::vector<Real> moments{-1.0, +1.0, +1.0, -1.0};
     const auto edges = gridEdges(rows, cols, 1.0);
 
     {
       MinSTCut::Options weak;
       weak.lambdaScale = 1e-6;
-      const auto result =
-        MinSTCut().classify(volumes, moments, edges, weak);
+      const auto result = MinSTCut().classify(volumes, moments, edges, weak);
       // Checkerboard preserved (each cell matches its own sign).
       EXPECT_EQ(result.labels[0], MinSTCut::Inside);
       EXPECT_EQ(result.labels[1], MinSTCut::Outside);
@@ -174,8 +164,7 @@ namespace Rodin::Tests::Unit
     {
       MinSTCut::Options strong;
       strong.lambdaScale = 1e6;
-      const auto result =
-        MinSTCut().classify(volumes, moments, edges, strong);
+      const auto result = MinSTCut().classify(volumes, moments, edges, strong);
       // Strong smoothing collapses the 2x2 to a single label.
       EXPECT_EQ(result.labels[0], result.labels[1]);
       EXPECT_EQ(result.labels[1], result.labels[2]);
@@ -216,8 +205,7 @@ namespace Rodin::Tests::Unit
 
     MinSTCut::Options strong;
     strong.lambdaScale = 10;
-    const auto strongResult =
-      MinSTCut().classify(volumes, moments, baseEdges, strong);
+    const auto strongResult = MinSTCut().classify(volumes, moments, baseEdges, strong);
     EXPECT_EQ(strongResult.labels[center], MinSTCut::Outside);
   }
 
@@ -227,9 +215,9 @@ namespace Rodin::Tests::Unit
     // Two cells: moment +0.9 (definitely Outside) and moment -0.9
     // (definitely Inside), connected by an enormous edge that would
     // otherwise collapse them onto the same label.
-    const std::vector<Real> volumes{ 1, 1 };
-    const std::vector<Real> moments{ -0.9, +0.9 };
-    const std::vector<MinSTCut::Edge> edges{ { 0, 1, 1e6 } };
+    const std::vector<Real> volumes{1, 1};
+    const std::vector<Real> moments{-0.9, +0.9};
+    const std::vector<MinSTCut::Edge> edges{{0, 1, 1e6}};
 
     // Without pinning, the huge edge forces both labels to whichever
     // side wins on total unary; certainly the cut does not split them.
@@ -238,8 +226,7 @@ namespace Rodin::Tests::Unit
 
     MinSTCut::Options pinned;
     pinned.farFieldThreshold = 0.5;
-    const auto pinnedResult =
-      MinSTCut().classify(volumes, moments, edges, pinned);
+    const auto pinnedResult = MinSTCut().classify(volumes, moments, edges, pinned);
     EXPECT_EQ(pinnedResult.labels[0], MinSTCut::Inside);
     EXPECT_EQ(pinnedResult.labels[1], MinSTCut::Outside);
     EXPECT_EQ(pinnedResult.cutEdges.size(), 1u);
@@ -253,11 +240,11 @@ namespace Rodin::Tests::Unit
     // The fixed cells force the middle to flip along with the smoothing
     // term.
     const std::vector<Real> volumes(3, 1);
-    const std::vector<Real> moments{ -1, +1e-3, -1 };
+    const std::vector<Real> moments{-1, +1e-3, -1};
     const auto edges = gridEdges(1, 3, 10.0);
 
     MinSTCut::Options options;
-    options.cellInBand = { false, true, false };
+    options.cellInBand = {false, true, false};
     options.lambdaScale = 1.0;
 
     const auto result = MinSTCut().classify(volumes, moments, edges, options);
@@ -274,12 +261,12 @@ namespace Rodin::Tests::Unit
     // tiny per-edge lambda on edge (1,2) makes it the cheapest cut, while
     // boosting the other two edges. The cut must land on (1,2).
     const std::vector<Real> volumes(4, 1);
-    const std::vector<Real> moments{ -1, -0.4, +0.4, +1 };
+    const std::vector<Real> moments{-1, -0.4, +0.4, +1};
     const auto edges = gridEdges(1, 4, 1.0);
     ASSERT_EQ(edges.size(), 3u);
 
     MinSTCut::Options options;
-    options.perEdgeLambda = { 5.0, 1e-3, 5.0 };
+    options.perEdgeLambda = {5.0, 1e-3, 5.0};
 
     const auto result = MinSTCut().classify(volumes, moments, edges, options);
     EXPECT_EQ(result.labels[0], MinSTCut::Inside);
@@ -298,19 +285,17 @@ namespace Rodin::Tests::Unit
     // smoothing edge. Tiny unary lets smoothing dominate (same label);
     // large unary lets the data dominate (split).
     const std::vector<Real> volumes(2, 1);
-    const std::vector<Real> moments{ -0.1, +0.1 };
-    const std::vector<MinSTCut::Edge> edges{ { 0, 1, 1.0 } };
+    const std::vector<Real> moments{-0.1, +0.1};
+    const std::vector<MinSTCut::Edge> edges{{0, 1, 1.0}};
 
     MinSTCut::Options dataLight;
     dataLight.unaryScale = 1e-3;
-    const auto smoothed =
-      MinSTCut().classify(volumes, moments, edges, dataLight);
+    const auto smoothed = MinSTCut().classify(volumes, moments, edges, dataLight);
     EXPECT_EQ(smoothed.labels[0], smoothed.labels[1]);
 
     MinSTCut::Options dataHeavy;
     dataHeavy.unaryScale = 1e3;
-    const auto split =
-      MinSTCut().classify(volumes, moments, edges, dataHeavy);
+    const auto split = MinSTCut().classify(volumes, moments, edges, dataHeavy);
     EXPECT_NE(split.labels[0], split.labels[1]);
     EXPECT_EQ(split.labels[0], MinSTCut::Inside);
     EXPECT_EQ(split.labels[1], MinSTCut::Outside);
@@ -319,53 +304,36 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies mismatched input sizes throw for geometry min ST cut by checking exception behavior.
   TEST(Rodin_Geometry_MinSTCut, MismatchedInputSizesThrow)
   {
-    EXPECT_THROW(
-        MinSTCut().classify({ 1.0 }, { 1.0, 1.0 }, {}),
-        std::invalid_argument);
+    EXPECT_THROW(MinSTCut().classify({1.0}, {1.0, 1.0}, {}), std::invalid_argument);
 
     MinSTCut::Options options;
-    options.perEdgeLambda = { 1.0 };
+    options.perEdgeLambda = {1.0};
     EXPECT_THROW(
-        MinSTCut().classify({ 1.0, 1.0 }, { 0.0, 0.0 }, {}, options),
-        std::invalid_argument);
+      MinSTCut().classify({1.0, 1.0}, {0.0, 0.0}, {}, options), std::invalid_argument);
 
     MinSTCut::Options bandOptions;
-    bandOptions.cellInBand = { true };
-    EXPECT_THROW(
-        MinSTCut().classify({ 1.0, 1.0 }, { 0.0, 0.0 }, {}, bandOptions),
-        std::invalid_argument);
+    bandOptions.cellInBand = {true};
+    EXPECT_THROW(MinSTCut().classify({1.0, 1.0}, {0.0, 0.0}, {}, bandOptions),
+      std::invalid_argument);
   }
 
   /// @brief Verifies negative capacities throw for geometry min ST cut by checking exception behavior.
   TEST(Rodin_Geometry_MinSTCut, NegativeCapacitiesThrow)
   {
-    EXPECT_THROW(
-        MinSTCut().classify(
-            { 1.0, 1.0 },
-            { -1.0, +1.0 },
-            { { 0, 1, -1.0 } }),
-        std::invalid_argument);
+    EXPECT_THROW(MinSTCut().classify({1.0, 1.0}, {-1.0, +1.0}, {{0, 1, -1.0}}),
+      std::invalid_argument);
 
     MinSTCut::Options options;
-    options.perEdgeLambda = { -1.0 };
-    EXPECT_THROW(
-        MinSTCut().classify(
-            { 1.0, 1.0 },
-            { -1.0, +1.0 },
-            { { 0, 1, 1.0 } },
-            options),
-        std::invalid_argument);
+    options.perEdgeLambda = {-1.0};
+    EXPECT_THROW(MinSTCut().classify({1.0, 1.0}, {-1.0, +1.0}, {{0, 1, 1.0}}, options),
+      std::invalid_argument);
   }
 
   /// @brief Verifies out of range edge throws for geometry min ST cut by checking exception behavior.
   TEST(Rodin_Geometry_MinSTCut, OutOfRangeEdgeThrows)
   {
     EXPECT_THROW(
-        MinSTCut().classify(
-            { 1.0, 1.0 },
-            { -1.0, +1.0 },
-            { { 0, 5, 1.0 } }),
-        std::out_of_range);
+      MinSTCut().classify({1.0, 1.0}, {-1.0, +1.0}, {{0, 5, 1.0}}), std::out_of_range);
   }
 
   /// @brief Without edges the unary contribution equals the sum of the.
@@ -373,12 +341,11 @@ namespace Rodin::Tests::Unit
   {
     // Without edges the unary contribution equals the sum of the
     // selected-label costs.
-    const std::vector<Real> volumes{ 2.0, 3.0 };
-    const std::vector<Real> moments{ -0.25, +0.5 };
+    const std::vector<Real> volumes{2.0, 3.0};
+    const std::vector<Real> moments{-0.25, +0.5};
     const auto result = MinSTCut().classify(volumes, moments, {});
-    const Real expected =
-      MinSTCut::getInsideCost(volumes[0], moments[0])
-      + MinSTCut::getOutsideCost(volumes[1], moments[1]);
+    const Real expected = MinSTCut::getInsideCost(volumes[0], moments[0]) +
+      MinSTCut::getOutsideCost(volumes[1], moments[1]);
     EXPECT_DOUBLE_EQ(result.energy, expected);
   }
 }

--- a/tests/unit/Rodin/Geometry/ParametricTransformationTest.cpp
+++ b/tests/unit/Rodin/Geometry/ParametricTransformationTest.cpp
@@ -21,8 +21,12 @@ namespace Rodin::Tests::Unit
     constexpr const size_t n = 3;
 
     PointCloud pm(sdim, n);
-    pm(0,0) = 0; pm(0,1) = 1; pm(0,2) = 0;
-    pm(1,0) = 0; pm(1,1) = 0; pm(1,2) = 1;
+    pm(0, 0) = 0;
+    pm(0, 1) = 1;
+    pm(0, 2) = 0;
+    pm(1, 0) = 0;
+    pm(1, 1) = 0;
+    pm(1, 2) = 1;
 
     Variational::RealP1Element fe(Polytope::Type::Triangle);
     ParametricTransformation trans(pm, fe);
@@ -47,8 +51,12 @@ namespace Rodin::Tests::Unit
     constexpr const size_t n = 3;
 
     PointCloud pm(sdim, n);
-    pm(0,0) = -1; pm(0,1) = 1; pm(0,2) = 0;
-    pm(1,0) = -1; pm(1,1) = 1; pm(1,2) = 1;
+    pm(0, 0) = -1;
+    pm(0, 1) = 1;
+    pm(0, 2) = 0;
+    pm(1, 0) = -1;
+    pm(1, 1) = 1;
+    pm(1, 2) = 1;
 
     Variational::RealP1Element fe(Polytope::Type::Triangle);
     ParametricTransformation trans(pm, fe);
@@ -162,8 +170,7 @@ namespace Rodin::Tests::Unit
     for (size_t i = 0; i < fe.getCount(); ++i)
     {
       const auto& rc = fe.getNode(i);
-      Math::SpatialPoint x =
-        (Real(1) - rc[0] - rc[1]) * v0 + rc[0] * v1 + rc[1] * v2;
+      Math::SpatialPoint x = (Real(1) - rc[0] - rc[1]) * v0 + rc[0] * v1 + rc[1] * v2;
       if (std::abs(rc[1]) <= Real(1e-12))
       {
         const Real theta = (Pi / Real(2)) * rc[0];
@@ -179,24 +186,21 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Geometry_ParametricTransformation, P2CurvesInterfaceEdge)
   {
     Variational::RealH1Element<2> fe(Polytope::Type::Triangle);
-    ParametricTransformation trans(
-        makeQuarterCircleTrianglePointCloud<2>(), fe);
+    ParametricTransformation trans(makeQuarterCircleTrianglePointCloud<2>(), fe);
 
     Math::SpatialPoint x;
     trans.transform(x, Math::SpatialPoint{Real(0.5), Real(0)});
     EXPECT_NEAR(x.norm(), Real(1), Real(1e-12));
 
     const Math::SpatialPoint linearMidpoint{Real(0.5), Real(0.5)};
-    EXPECT_GT(std::abs(linearMidpoint.norm() - Real(1)),
-              std::abs(x.norm() - Real(1)));
+    EXPECT_GT(std::abs(linearMidpoint.norm() - Real(1)), std::abs(x.norm() - Real(1)));
   }
 
   /// @brief Verifies P 3 curved edge improves fit for geometry parametric transformation.
   TEST(Rodin_Geometry_ParametricTransformation, P3CurvedEdgeImprovesFit)
   {
     Variational::RealH1Element<3> fe(Polytope::Type::Triangle);
-    ParametricTransformation trans(
-        makeQuarterCircleTrianglePointCloud<3>(), fe);
+    ParametricTransformation trans(makeQuarterCircleTrianglePointCloud<3>(), fe);
 
     Real maxError = 0;
     for (Real s : {Real(0.25), Real(0.5), Real(0.75)})
@@ -214,14 +218,13 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Geometry_ParametricTransformation, CurvedTriangleJacobianStaysPositive)
   {
     Variational::RealH1Element<2> fe(Polytope::Type::Triangle);
-    ParametricTransformation trans(
-        makeQuarterCircleTrianglePointCloud<2>(), fe);
+    ParametricTransformation trans(makeQuarterCircleTrianglePointCloud<2>(), fe);
 
-    for (const Math::SpatialPoint& rc : {
-          Math::SpatialPoint{Real(1) / Real(3), Real(1) / Real(3)},
-          Math::SpatialPoint{Real(0.25), Real(0.25)},
-          Math::SpatialPoint{Real(0.5), Real(0.25)},
-          Math::SpatialPoint{Real(0.25), Real(0.5)}})
+    for (const Math::SpatialPoint& rc :
+      {Math::SpatialPoint{Real(1) / Real(3), Real(1) / Real(3)},
+        Math::SpatialPoint{Real(0.25), Real(0.25)},
+        Math::SpatialPoint{Real(0.5), Real(0.25)},
+        Math::SpatialPoint{Real(0.25), Real(0.5)}})
     {
       Math::SpatialMatrix<Real> J;
       trans.jacobian(J, rc);

--- a/tests/unit/Rodin/Geometry/PolytopeQuadratureIndexTest.cpp
+++ b/tests/unit/Rodin/Geometry/PolytopeQuadratureIndexTest.cpp
@@ -6,7 +6,10 @@
  */
 #include <gtest/gtest.h>
 
+#include <array>
+#include <atomic>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include <Rodin/Alert/Exception.h>
@@ -244,8 +247,8 @@ namespace Rodin::Tests::Unit
     }
   }
 
-  /// @brief Verifies rebuilds evicted formula after capacity exceeded for geometry polytope quadrature index by checking exact expected values.
-  TEST(Geometry_PolytopeQuadratureIndex, RebuildsEvictedFormulaAfterCapacityExceeded)
+  /// @brief Verifies formula entries remain stable beyond the former bounded-cache capacity.
+  TEST(Geometry_PolytopeQuadratureIndex, RetainsFormulaBeyondFormerCapacity)
   {
     auto mesh = makeTriangleMesh();
     const auto polytope = *mesh.getPolytope(2, 0);
@@ -280,8 +283,7 @@ namespace Rodin::Tests::Unit
 
     EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope);
 
-    // Insert one more distinct formula. This should evict one entry by
-    // round-robin replacement, not throw.
+    // Insert one more distinct formula.
     quadratureFormulas.emplace_back(
       std::make_unique<QF::Centroid>(Polytope::Type::Triangle));
 
@@ -299,9 +301,7 @@ namespace Rodin::Tests::Unit
 
     EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope + 1);
 
-    // The first inserted formula should have been evicted under round-robin
-    // replacement, since the insertion order was sequential and no older entry
-    // was reinserted into the bounded cache.
+    // Stable formula storage retains the first quadrature until clear().
     index.get(
       {2, 0},
       mesh.getPolytopeCount(2),
@@ -314,11 +314,11 @@ namespace Rodin::Tests::Unit
           *quadratureFormulas.front());
       });
 
-    EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope + 2);
+    EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope + 1);
   }
 
-  /// @brief Verifies hot entry preserves immediate repeat after overflow for geometry polytope quadrature index by checking exact expected values.
-  TEST(Geometry_PolytopeQuadratureIndex, HotEntryPreservesImmediateRepeatAfterOverflow)
+  /// @brief Verifies immediate repeated access after registering several formulas.
+  TEST(Geometry_PolytopeQuadratureIndex, PreservesImmediateRepeatAcrossFormulas)
   {
     auto mesh = makeTriangleMesh();
     const auto polytope = *mesh.getPolytope(2, 0);
@@ -352,8 +352,7 @@ namespace Rodin::Tests::Unit
 
     EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope + 1);
 
-    // Immediate repeat of the most recently inserted formula should be served
-    // from the hot entry or the bounded cache without rebuilding.
+    // Immediate repeat of the most recently inserted formula should not rebuild.
     const auto& q1 = index.get(
       {2, 0},
       mesh.getPolytopeCount(2),
@@ -380,5 +379,44 @@ namespace Rodin::Tests::Unit
 
     EXPECT_EQ(&q1, &q2);
     EXPECT_EQ(factoryCalls, kMaxQuadraturesPerPolytope + 1);
+  }
+
+  /// @brief Verifies that concurrent formula lookup constructs each cached entry once.
+  TEST(Geometry_PolytopeQuadratureIndex, ConstructsDistinctFormulasConcurrently)
+  {
+    constexpr size_t formulaCount = 8;
+    constexpr size_t repetitions = 64;
+
+    auto mesh = makeTriangleMesh();
+    const auto polytope = *mesh.getPolytope(2, 0);
+
+    PolytopeQuadratureIndex index;
+    index.initialize(mesh.getDimension());
+
+    std::array<std::unique_ptr<QF::Centroid>, formulaCount> formulas;
+    std::array<std::atomic<size_t>, formulaCount> factoryCalls{};
+    for (auto& formula : formulas)
+      formula = std::make_unique<QF::Centroid>(Polytope::Type::Triangle);
+
+    std::vector<std::thread> threads;
+    threads.reserve(formulaCount);
+    for (size_t i = 0; i < formulaCount; ++i)
+      threads.emplace_back([&, i]() {
+        for (size_t repetition = 0; repetition < repetitions; ++repetition)
+        {
+          const auto& quadrature =
+            index.get({2, 0}, mesh.getPolytopeCount(2), *formulas[i], [&]() {
+              ++factoryCalls[i];
+              return std::make_unique<PolytopeQuadrature>(polytope, *formulas[i]);
+            });
+          EXPECT_EQ(&quadrature.getQuadratureFormula(), formulas[i].get());
+        }
+      });
+
+    for (auto& thread : threads)
+      thread.join();
+
+    for (const auto& calls : factoryCalls)
+      EXPECT_EQ(calls.load(), 1u);
   }
 }

--- a/tests/unit/Rodin/Geometry/PolytopeTransformationIndexTest.cpp
+++ b/tests/unit/Rodin/Geometry/PolytopeTransformationIndexTest.cpp
@@ -1,0 +1,80 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <Rodin/Geometry/IdentityTransformation.h>
+#include <Rodin/Geometry/PolytopeTransformationIndex.h>
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+
+namespace Rodin::Tests::Unit
+{
+  /// @brief Verifies that concurrent lookup constructs each transformation once.
+  TEST(Geometry_PolytopeTransformationIndex, ConstructsEachSlotOnceConcurrently)
+  {
+    constexpr size_t count = 128;
+    constexpr size_t threadCount = 8;
+    constexpr size_t repetitions = 32;
+
+    PolytopeTransformationIndex index;
+    index.initialize(2);
+
+    std::array<std::atomic<size_t>, count> factoryCalls{};
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+    for (size_t thread = 0; thread < threadCount; ++thread)
+    {
+      threads.emplace_back([&, thread]() {
+        for (size_t repetition = 0; repetition < repetitions; ++repetition)
+          for (size_t offset = 0; offset < count; ++offset)
+          {
+            const Index i = static_cast<Index>((offset + thread) % count);
+            const auto& transformation = index.get({2, i}, count, [&](size_t, Index idx) {
+              ++factoryCalls[static_cast<size_t>(idx)];
+              return std::make_unique<IdentityTransformation>(2);
+            });
+            EXPECT_EQ(transformation.getReferenceDimension(), 2u);
+            EXPECT_EQ(transformation.getPhysicalDimension(), 2u);
+          }
+      });
+    }
+
+    for (auto& thread : threads)
+      thread.join();
+
+    for (const auto& calls : factoryCalls)
+      EXPECT_EQ(calls.load(), 1u);
+  }
+
+  /// @brief Verifies that clearing the index invalidates cached transformations.
+  TEST(Geometry_PolytopeTransformationIndex, ClearRebuildsTransformation)
+  {
+    PolytopeTransformationIndex index;
+    index.initialize(2);
+
+    size_t factoryCalls = 0;
+    const auto factory = [&](size_t, Index) {
+      ++factoryCalls;
+      return std::make_unique<IdentityTransformation>(2);
+    };
+
+    index.get({2, 0}, 1, factory);
+    index.get({2, 0}, 1, factory);
+    EXPECT_EQ(factoryCalls, 1u);
+
+    index.clear();
+    index.get({2, 0}, 1, factory);
+    EXPECT_EQ(factoryCalls, 2u);
+  }
+}

--- a/tests/unit/Rodin/Geometry/UniformGridTest.cpp
+++ b/tests/unit/Rodin/Geometry/UniformGridTest.cpp
@@ -7,6 +7,16 @@ using namespace Rodin::Geometry;
 
 namespace Rodin::Tests::Unit
 {
+  /// @brief Verifies that invalid grid dimensions raise a member-function exception.
+  TEST(Rodin_Geometry_Mesh_UniformGrid, InvalidDimensions)
+  {
+    EXPECT_THROW(LocalMesh::UniformGrid(Polytope::Type::Triangle, {2}), Alert::Exception);
+    EXPECT_THROW(
+      LocalMesh::UniformGrid(Polytope::Type::Triangle, {1, 4}), Alert::Exception);
+    EXPECT_THROW(
+      LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, {2, 0, 2}), Alert::Exception);
+  }
+
   /// @brief Verifies sanity test for geometry mesh uniform grid by checking exact expected values.
   TEST(Rodin_Geometry_Mesh_UniformGrid, SanityTest)
   {

--- a/tests/unit/Rodin/IO/HDF5IOTest.cpp
+++ b/tests/unit/Rodin/IO/HDF5IOTest.cpp
@@ -214,13 +214,13 @@ namespace Rodin::Tests::Unit
     const boost::filesystem::path stem = testDir / "vis";
 
     Mesh mesh = LocalMesh::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {0, 1, 2})
-      .finalize();
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {0, 1, 2})
+                  .finalize();
 
     RealH1Element<2> fe(Polytope::Type::Triangle);
     PointCloud pm(2, fe.getCount());
@@ -231,8 +231,7 @@ namespace Rodin::Tests::Unit
       pm(1, i) = rc[1];
     }
     mesh.setPolytopeTransformation(
-        {2, 0},
-        new ParametricTransformation<RealH1Element<2>>(pm, fe));
+      {2, 0}, new ParametricTransformation<RealH1Element<2>>(pm, fe));
 
     {
       XDMF xdmf(stem);
@@ -265,13 +264,9 @@ namespace Rodin::Tests::Unit
     ASSERT_EQ(static_cast<size_t>(tdims[0]), 1u);
     ASSERT_EQ(static_cast<size_t>(tdims[1]), 6u);
     std::vector<unsigned long long> topology(6);
-    ASSERT_GE(H5Dread(
-          tdset,
-          H5T_NATIVE_ULLONG,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          topology.data()), 0);
+    ASSERT_GE(
+      H5Dread(tdset, H5T_NATIVE_ULLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, topology.data()),
+      0);
     for (size_t i = 0; i < topology.size(); ++i)
       EXPECT_EQ(topology[i], static_cast<unsigned long long>(i));
     H5Sclose(tspace);
@@ -298,22 +293,20 @@ namespace Rodin::Tests::Unit
     switch (type)
     {
       case Polytope::Type::Segment:
-        return LocalMesh::UniformGrid(type, { 3 });
+        return LocalMesh::UniformGrid(type, {3});
       case Polytope::Type::Triangle:
       case Polytope::Type::Quadrilateral:
-        return LocalMesh::UniformGrid(type, { 2, 2 });
+        return LocalMesh::UniformGrid(type, {2, 2});
       case Polytope::Type::Tetrahedron:
       case Polytope::Type::Pyramid:
       case Polytope::Type::Hexahedron:
       case Polytope::Type::Wedge:
-        return LocalMesh::UniformGrid(type, { 2, 2, 2 });
+        return LocalMesh::UniformGrid(type, {2, 2, 2});
       case Polytope::Type::Point:
         break;
     }
 
-    Alert::Exception()
-      << "Unsupported quadratic XDMF test polytope."
-      << Alert::Raise;
+    Alert::Exception() << "Unsupported quadratic XDMF test polytope." << Alert::Raise;
     return {};
   }
 
@@ -321,14 +314,22 @@ namespace Rodin::Tests::Unit
   {
     switch (type)
     {
-      case Polytope::Type::Segment:       return "Segment1D";
-      case Polytope::Type::Triangle:      return "Triangle2D";
-      case Polytope::Type::Quadrilateral: return "Quad2D";
-      case Polytope::Type::Tetrahedron:   return "Tet3D";
-      case Polytope::Type::Pyramid:       return "Pyramid3D";
-      case Polytope::Type::Wedge:         return "Wedge3D";
-      case Polytope::Type::Hexahedron:    return "Hex3D";
-      case Polytope::Type::Point:         return "Point0D";
+      case Polytope::Type::Segment:
+        return "Segment1D";
+      case Polytope::Type::Triangle:
+        return "Triangle2D";
+      case Polytope::Type::Quadrilateral:
+        return "Quad2D";
+      case Polytope::Type::Tetrahedron:
+        return "Tet3D";
+      case Polytope::Type::Pyramid:
+        return "Pyramid3D";
+      case Polytope::Type::Wedge:
+        return "Wedge3D";
+      case Polytope::Type::Hexahedron:
+        return "Hex3D";
+      case Polytope::Type::Point:
+        return "Point0D";
     }
     return "Unknown";
   }
@@ -350,20 +351,18 @@ namespace Rodin::Tests::Unit
           pm(d, j) = pc(static_cast<Eigen::Index>(d));
       }
       mesh.setPolytopeTransformation(
-          {D, i},
-          new ParametricTransformation<RealH1Element<2>>(pm, fe));
+        {D, i}, new ParametricTransformation<RealH1Element<2>>(pm, fe));
     }
   }
 
   struct QuadraticXDMFCase
   {
-    Polytope::Type type;
-    unsigned long long topologyId;
-    size_t nodesPerCell;
+      Polytope::Type type;
+      unsigned long long topologyId;
+      size_t nodesPerCell;
   };
 
-  class Rodin_IO_HDF5_QuadraticXDMF
-    : public testing::TestWithParam<QuadraticXDMFCase>
+  class Rodin_IO_HDF5_QuadraticXDMF : public testing::TestWithParam<QuadraticXDMFCase>
   {};
 
   /// @brief Verifies supported quadratic topology for IO HDF 5 quadratic XDMF by checking exact expected values, true predicates, false predicates.
@@ -371,7 +370,7 @@ namespace Rodin::Tests::Unit
   {
     const auto c = GetParam();
     const boost::filesystem::path testDir =
-        "/tmp/rodin_xdmf_p2_" + quadraticXDMFLabel(c.type);
+      "/tmp/rodin_xdmf_p2_" + quadraticXDMFLabel(c.type);
     boost::filesystem::create_directories(testDir);
     const boost::filesystem::path stem = testDir / "vis";
 
@@ -409,15 +408,10 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(static_cast<size_t>(tdims[0]), mesh.getCellCount());
     EXPECT_EQ(static_cast<size_t>(tdims[1]), c.nodesPerCell);
 
-    std::vector<unsigned long long> topology(
-        static_cast<size_t>(tdims[0] * tdims[1]));
-    ASSERT_GE(H5Dread(
-          tdset,
-          H5T_NATIVE_ULLONG,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          topology.data()), 0);
+    std::vector<unsigned long long> topology(static_cast<size_t>(tdims[0] * tdims[1]));
+    ASSERT_GE(
+      H5Dread(tdset, H5T_NATIVE_ULLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, topology.data()),
+      0);
     ASSERT_FALSE(topology.empty());
     for (size_t i = 0; i < topology.size(); ++i)
       EXPECT_EQ(topology[i], static_cast<unsigned long long>(i));
@@ -433,7 +427,7 @@ namespace Rodin::Tests::Unit
   {
     const auto c = GetParam();
     const boost::filesystem::path meshH5 =
-        "/tmp/rodin_xdmf_p2_mixed_" + quadraticXDMFLabel(c.type) + ".h5";
+      "/tmp/rodin_xdmf_p2_mixed_" + quadraticXDMFLabel(c.type) + ".h5";
 
     auto mesh = makeQuadraticXDMFBaseMesh(c.type);
     setQuadraticCellTransformations(mesh);
@@ -451,26 +445,19 @@ namespace Rodin::Tests::Unit
     ASSERT_EQ(H5Sget_simple_extent_dims(tspace, &count, nullptr), 1);
 
     std::vector<unsigned long long> topology(static_cast<size_t>(count));
-    ASSERT_GE(H5Dread(
-          tdset,
-          H5T_NATIVE_ULLONG,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          topology.data()), 0);
+    ASSERT_GE(
+      H5Dread(tdset, H5T_NATIVE_ULLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, topology.data()),
+      0);
 
-    ASSERT_EQ(
-        topology.size(),
-        mesh.getCellCount() * (1 + c.nodesPerCell));
+    ASSERT_EQ(topology.size(), mesh.getCellCount() * (1 + c.nodesPerCell));
     for (size_t cell = 0; cell < mesh.getCellCount(); ++cell)
     {
       const size_t offset = cell * (1 + c.nodesPerCell);
       EXPECT_EQ(topology[offset], c.topologyId);
       for (size_t i = 0; i < c.nodesPerCell; ++i)
       {
-        EXPECT_EQ(
-            topology[offset + 1 + i],
-            static_cast<unsigned long long>(cell * c.nodesPerCell + i));
+        EXPECT_EQ(topology[offset + 1 + i],
+          static_cast<unsigned long long>(cell * c.nodesPerCell + i));
       }
     }
 
@@ -483,19 +470,18 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies XDMF mixed linear and curved cells uses mixed topology for IO HDF 5 by checking exact expected values.
   TEST(Rodin_IO_HDF5, XDMFMixedLinearAndCurvedCellsUsesMixedTopology)
   {
-    const boost::filesystem::path meshH5 =
-        "/tmp/rodin_xdmf_mixed_linear_curved.h5";
+    const boost::filesystem::path meshH5 = "/tmp/rodin_xdmf_mixed_linear_curved.h5";
 
     auto mesh = LocalMesh::Builder()
-      .initialize(2)
-      .nodes(4)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .vertex({1, 1})
-      .polytope(Polytope::Type::Triangle, {0, 1, 2})
-      .polytope(Polytope::Type::Triangle, {1, 3, 2})
-      .finalize();
+                  .initialize(2)
+                  .nodes(4)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .vertex({1, 1})
+                  .polytope(Polytope::Type::Triangle, {0, 1, 2})
+                  .polytope(Polytope::Type::Triangle, {1, 3, 2})
+                  .finalize();
 
     RealH1Element<2> fe(Polytope::Type::Triangle);
     PointCloud pm(2, fe.getCount());
@@ -508,8 +494,7 @@ namespace Rodin::Tests::Unit
       pm(1, i) = pc(1);
     }
     mesh.setPolytopeTransformation(
-        {2, 0},
-        new ParametricTransformation<RealH1Element<2>>(pm, fe));
+      {2, 0}, new ParametricTransformation<RealH1Element<2>>(pm, fe));
 
     HDF5::writeXDMFMesh(meshH5, mesh, true);
 
@@ -524,15 +509,12 @@ namespace Rodin::Tests::Unit
     ASSERT_EQ(static_cast<size_t>(count), HDF5::getXDMFMixedTopologySize(mesh));
 
     std::vector<unsigned long long> topology(static_cast<size_t>(count));
-    ASSERT_GE(H5Dread(
-          tdset,
-          H5T_NATIVE_ULLONG,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          topology.data()), 0);
+    ASSERT_GE(
+      H5Dread(tdset, H5T_NATIVE_ULLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, topology.data()),
+      0);
     ASSERT_GE(topology.size(), 11u);
-    EXPECT_EQ(topology[0], HDF5::getXDMFQuadraticMixedTopologyId(Polytope::Type::Triangle));
+    EXPECT_EQ(
+      topology[0], HDF5::getXDMFQuadraticMixedTopologyId(Polytope::Type::Triangle));
     EXPECT_EQ(topology[7], HDF5::getXDMFMixedTopologyId(Polytope::Type::Triangle));
 
     H5Sclose(tspace);
@@ -544,19 +526,17 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies XDMF curved attributes evaluate on visualization points for IO HDF 5 by checking tolerance-based numerical results, exact expected values.
   TEST(Rodin_IO_HDF5, XDMFCurvedAttributesEvaluateOnVisualizationPoints)
   {
-    const boost::filesystem::path nodeH5 =
-        "/tmp/rodin_xdmf_p2_attr_node.h5";
-    const boost::filesystem::path cellH5 =
-        "/tmp/rodin_xdmf_p2_attr_cell.h5";
+    const boost::filesystem::path nodeH5 = "/tmp/rodin_xdmf_p2_attr_node.h5";
+    const boost::filesystem::path cellH5 = "/tmp/rodin_xdmf_p2_attr_cell.h5";
 
     Mesh mesh = LocalMesh::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({2, 0})
-      .vertex({0, 3})
-      .polytope(Polytope::Type::Triangle, {0, 1, 2})
-      .finalize();
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({2, 0})
+                  .vertex({0, 3})
+                  .polytope(Polytope::Type::Triangle, {0, 1, 2})
+                  .finalize();
     setQuadraticCellTransformations(mesh);
 
     P1 fes(mesh);
@@ -575,13 +555,9 @@ namespace Rodin::Tests::Unit
     ASSERT_EQ(H5Sget_simple_extent_dims(dspace, &count, nullptr), 1);
     ASSERT_EQ(static_cast<size_t>(count), 6u);
     std::vector<double> nodeValues(static_cast<size_t>(count));
-    ASSERT_GE(H5Dread(
-          dset,
-          H5T_NATIVE_DOUBLE,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          nodeValues.data()), 0);
+    ASSERT_GE(
+      H5Dread(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, nodeValues.data()),
+      0);
     const auto nodes = HDF5::getXDMFReferenceNodes(Polytope::Type::Triangle, 2);
     const auto& trans = mesh.getPolytopeTransformation(2, 0);
     for (size_t i = 0; i < nodes.size(); ++i)
@@ -603,13 +579,8 @@ namespace Rodin::Tests::Unit
     ASSERT_EQ(H5Sget_simple_extent_dims(dspace, &count, nullptr), 1);
     ASSERT_EQ(static_cast<size_t>(count), 1u);
     double cellValue = 0.0;
-    ASSERT_GE(H5Dread(
-          dset,
-          H5T_NATIVE_DOUBLE,
-          H5S_ALL,
-          H5S_ALL,
-          H5P_DEFAULT,
-          &cellValue), 0);
+    ASSERT_GE(
+      H5Dread(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &cellValue), 0);
     EXPECT_NEAR(cellValue, 13.0 / 3.0, 1e-14);
     H5Sclose(dspace);
     H5Dclose(dset);
@@ -633,8 +604,7 @@ namespace Rodin::Tests::Unit
     sharder.shard(partitioner);
     const auto& shard = sharder.getShards().front();
 
-    const boost::filesystem::path meshH5 =
-        "/tmp/rodin_xdmf_shard_owned_curved.h5";
+    const boost::filesystem::path meshH5 = "/tmp/rodin_xdmf_shard_owned_curved.h5";
     HDF5::writeXDMFMesh(meshH5, shard, false);
 
     hid_t h5 = H5Fopen(meshH5.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -646,8 +616,7 @@ namespace Rodin::Tests::Unit
     hsize_t vdims[2] = {0, 0};
     ASSERT_EQ(H5Sget_simple_extent_dims(vspace, vdims, nullptr), 2);
     EXPECT_EQ(
-        static_cast<size_t>(vdims[0]),
-        HDF5::getXDMFVisualizationVertexCount(shard));
+      static_cast<size_t>(vdims[0]), HDF5::getXDMFVisualizationVertexCount(shard));
     EXPECT_EQ(static_cast<size_t>(vdims[1]), shard.getSpaceDimension());
     H5Sclose(vspace);
     H5Dclose(vdset);
@@ -657,20 +626,17 @@ namespace Rodin::Tests::Unit
     hid_t tspace = H5Dget_space(tdset);
     hsize_t tcount = 0;
     ASSERT_EQ(H5Sget_simple_extent_dims(tspace, &tcount, nullptr), 1);
-    EXPECT_EQ(
-        static_cast<size_t>(tcount),
-        HDF5::getXDMFMixedTopologySize(shard));
+    EXPECT_EQ(static_cast<size_t>(tcount), HDF5::getXDMFMixedTopologySize(shard));
     H5Sclose(tspace);
     H5Dclose(tdset);
 
-    hid_t adset = H5Dopen2(h5, HDF5::attributePath(shard.getDimension()).c_str(), H5P_DEFAULT);
+    hid_t adset =
+      H5Dopen2(h5, HDF5::attributePath(shard.getDimension()).c_str(), H5P_DEFAULT);
     ASSERT_GE(adset, 0);
     hid_t aspace = H5Dget_space(adset);
     hsize_t acount = 0;
     ASSERT_EQ(H5Sget_simple_extent_dims(aspace, &acount, nullptr), 1);
-    EXPECT_EQ(
-        static_cast<size_t>(acount),
-        HDF5::getXDMFRenderedCellCount(shard));
+    EXPECT_EQ(static_cast<size_t>(acount), HDF5::getXDMFRenderedCellCount(shard));
     H5Sclose(aspace);
     H5Dclose(adset);
 
@@ -679,17 +645,14 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates IO HDF 5 Quadratic XDMF over the IO HDF 5 parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-      Rodin_IO_HDF5,
-      Rodin_IO_HDF5_QuadraticXDMF,
-      testing::Values(
-        QuadraticXDMFCase{Polytope::Type::Segment,       34u, 3u},
-        QuadraticXDMFCase{Polytope::Type::Triangle,      36u, 6u},
-        QuadraticXDMFCase{Polytope::Type::Quadrilateral, 35u, 9u},
-        QuadraticXDMFCase{Polytope::Type::Tetrahedron,   38u, 10u},
-        QuadraticXDMFCase{Polytope::Type::Pyramid,       39u, 13u},
-        QuadraticXDMFCase{Polytope::Type::Wedge,         41u, 18u},
-        QuadraticXDMFCase{Polytope::Type::Hexahedron,    50u, 27u}));
+  INSTANTIATE_TEST_SUITE_P(Rodin_IO_HDF5, Rodin_IO_HDF5_QuadraticXDMF,
+    testing::Values(QuadraticXDMFCase{Polytope::Type::Segment, 34u, 3u},
+      QuadraticXDMFCase{Polytope::Type::Triangle, 36u, 6u},
+      QuadraticXDMFCase{Polytope::Type::Quadrilateral, 35u, 9u},
+      QuadraticXDMFCase{Polytope::Type::Tetrahedron, 38u, 10u},
+      QuadraticXDMFCase{Polytope::Type::Pyramid, 39u, 13u},
+      QuadraticXDMFCase{Polytope::Type::Wedge, 41u, 18u},
+      QuadraticXDMFCase{Polytope::Type::Hexahedron, 50u, 27u}));
 
   /// @brief The XDMF visualization path must write evaluated vertex data,.
   TEST(Rodin_IO_HDF5, XDMFVisualizationEvaluatedAttributes)
@@ -886,48 +849,45 @@ namespace
     {
       case 1:
       {
-        builder
-          .nodes(3)
-          .vertex({ 0.0 })
-          .vertex({ 1.0 })
-          .vertex({ 2.0 })
-          .polytope(Polytope::Type::Segment, { 0, 1 })
-          .attribute({ 1, 0 }, 11)
-          .polytope(Polytope::Type::Segment, { 1, 2 })
-          .attribute({ 1, 1 }, 22);
+        builder.nodes(3)
+          .vertex({0.0})
+          .vertex({1.0})
+          .vertex({2.0})
+          .polytope(Polytope::Type::Segment, {0, 1})
+          .attribute({1, 0}, 11)
+          .polytope(Polytope::Type::Segment, {1, 2})
+          .attribute({1, 1}, 22);
         break;
       }
       case 2:
       {
-        builder
-          .nodes(5)
-          .vertex({ 0.0, 0.0 })
-          .vertex({ 1.0, 0.0 })
-          .vertex({ 0.0, 1.0 })
-          .vertex({ 2.0, 0.0 })
-          .vertex({ 2.0, 1.0 })
-          .polytope(Polytope::Type::Triangle, { 0, 1, 2 })
-          .attribute({ 2, 0 }, 11)
-          .polytope(Polytope::Type::Quadrilateral, { 1, 3, 4, 2 })
-          .attribute({ 2, 1 }, 22);
+        builder.nodes(5)
+          .vertex({0.0, 0.0})
+          .vertex({1.0, 0.0})
+          .vertex({0.0, 1.0})
+          .vertex({2.0, 0.0})
+          .vertex({2.0, 1.0})
+          .polytope(Polytope::Type::Triangle, {0, 1, 2})
+          .attribute({2, 0}, 11)
+          .polytope(Polytope::Type::Quadrilateral, {1, 3, 4, 2})
+          .attribute({2, 1}, 22);
         break;
       }
       case 3:
       {
-        builder
-          .nodes(8)
-          .vertex({ 0.0, 0.0, 0.0 })
-          .vertex({ 1.0, 0.0, 0.0 })
-          .vertex({ 1.0, 1.0, 0.0 })
-          .vertex({ 0.0, 1.0, 0.0 })
-          .vertex({ 0.0, 0.0, 1.0 })
-          .vertex({ 1.0, 0.0, 1.0 })
-          .vertex({ 1.0, 1.0, 1.0 })
-          .vertex({ 0.0, 1.0, 1.0 })
-          .polytope(Polytope::Type::Tetrahedron, { 0, 1, 2, 4 })
-          .attribute({ 3, 0 }, 11)
-          .polytope(Polytope::Type::Hexahedron, { 0, 1, 2, 3, 4, 5, 6, 7 })
-          .attribute({ 3, 1 }, 22);
+        builder.nodes(8)
+          .vertex({0.0, 0.0, 0.0})
+          .vertex({1.0, 0.0, 0.0})
+          .vertex({1.0, 1.0, 0.0})
+          .vertex({0.0, 1.0, 0.0})
+          .vertex({0.0, 0.0, 1.0})
+          .vertex({1.0, 0.0, 1.0})
+          .vertex({1.0, 1.0, 1.0})
+          .vertex({0.0, 1.0, 1.0})
+          .polytope(Polytope::Type::Tetrahedron, {0, 1, 2, 4})
+          .attribute({3, 0}, 11)
+          .polytope(Polytope::Type::Hexahedron, {0, 1, 2, 3, 4, 5, 6, 7})
+          .attribute({3, 1}, 22);
         break;
       }
       default:
@@ -937,8 +897,7 @@ namespace
   }
 
   void expectAttributeRegressionMesh(
-      const Geometry::Mesh<Context::Local>& mesh,
-      size_t dim)
+    const Geometry::Mesh<Context::Local>& mesh, size_t dim)
   {
     ASSERT_EQ(mesh.getSpaceDimension(), dim);
     ASSERT_EQ(mesh.getDimension(), dim);
@@ -985,7 +944,8 @@ namespace
   }
   // Parameterized test fixture
   class HDF5MultiDim : public ::testing::TestWithParam<Polytope::Type> {};
-  class HDF5AttributeRegression : public ::testing::TestWithParam<size_t> {};
+  class HDF5AttributeRegression : public ::testing::TestWithParam<size_t>
+  {};
 
   // --- Mesh round-trip persistence across dimensions -------------------------
 
@@ -1037,7 +997,7 @@ namespace
   {
     const size_t dim = GetParam();
     const std::string meshFile =
-        "/tmp/rodin_hdf5_attr_regression_" + std::to_string(dim) + "d.h5";
+      "/tmp/rodin_hdf5_attr_regression_" + std::to_string(dim) + "d.h5";
 
     Mesh mesh = makeAttributeRegressionMesh(dim);
     mesh.save(meshFile, FileFormat::HDF5);
@@ -1475,12 +1435,8 @@ namespace
       ),
       PolytopeNameGenerator());
 
-  INSTANTIATE_TEST_SUITE_P(
-      Dimensions,
-      HDF5AttributeRegression,
-      ::testing::Values(1, 2, 3),
-      [](const ::testing::TestParamInfo<size_t>& info)
-      {
-        return "Dim" + std::to_string(info.param) + "D";
-      });
+  INSTANTIATE_TEST_SUITE_P(Dimensions, HDF5AttributeRegression,
+    ::testing::Values(1, 2, 3), [](const ::testing::TestParamInfo<size_t>& info) {
+      return "Dim" + std::to_string(info.param) + "D";
+    });
 }

--- a/tests/unit/Rodin/IO/MeshLoaderTest.cpp
+++ b/tests/unit/Rodin/IO/MeshLoaderTest.cpp
@@ -65,48 +65,45 @@ namespace Rodin::Tests::Unit
       {
         case 1:
         {
-          builder
-            .nodes(3)
-            .vertex({ 0.0 })
-            .vertex({ 1.0 })
-            .vertex({ 2.0 })
-            .polytope(Polytope::Type::Segment, { 0, 1 })
-            .attribute({ 1, 0 }, 11)
-            .polytope(Polytope::Type::Segment, { 1, 2 })
-            .attribute({ 1, 1 }, 22);
+          builder.nodes(3)
+            .vertex({0.0})
+            .vertex({1.0})
+            .vertex({2.0})
+            .polytope(Polytope::Type::Segment, {0, 1})
+            .attribute({1, 0}, 11)
+            .polytope(Polytope::Type::Segment, {1, 2})
+            .attribute({1, 1}, 22);
           break;
         }
         case 2:
         {
-          builder
-            .nodes(5)
-            .vertex({ 0.0, 0.0 })
-            .vertex({ 1.0, 0.0 })
-            .vertex({ 0.0, 1.0 })
-            .vertex({ 2.0, 0.0 })
-            .vertex({ 2.0, 1.0 })
-            .polytope(Polytope::Type::Triangle, { 0, 1, 2 })
-            .attribute({ 2, 0 }, 11)
-            .polytope(Polytope::Type::Quadrilateral, { 1, 3, 4, 2 })
-            .attribute({ 2, 1 }, 22);
+          builder.nodes(5)
+            .vertex({0.0, 0.0})
+            .vertex({1.0, 0.0})
+            .vertex({0.0, 1.0})
+            .vertex({2.0, 0.0})
+            .vertex({2.0, 1.0})
+            .polytope(Polytope::Type::Triangle, {0, 1, 2})
+            .attribute({2, 0}, 11)
+            .polytope(Polytope::Type::Quadrilateral, {1, 3, 4, 2})
+            .attribute({2, 1}, 22);
           break;
         }
         case 3:
         {
-          builder
-            .nodes(8)
-            .vertex({ 0.0, 0.0, 0.0 })
-            .vertex({ 1.0, 0.0, 0.0 })
-            .vertex({ 1.0, 1.0, 0.0 })
-            .vertex({ 0.0, 1.0, 0.0 })
-            .vertex({ 0.0, 0.0, 1.0 })
-            .vertex({ 1.0, 0.0, 1.0 })
-            .vertex({ 1.0, 1.0, 1.0 })
-            .vertex({ 0.0, 1.0, 1.0 })
-            .polytope(Polytope::Type::Tetrahedron, { 0, 1, 2, 4 })
-            .attribute({ 3, 0 }, 11)
-            .polytope(Polytope::Type::Hexahedron, { 0, 1, 2, 3, 4, 5, 6, 7 })
-            .attribute({ 3, 1 }, 22);
+          builder.nodes(8)
+            .vertex({0.0, 0.0, 0.0})
+            .vertex({1.0, 0.0, 0.0})
+            .vertex({1.0, 1.0, 0.0})
+            .vertex({0.0, 1.0, 0.0})
+            .vertex({0.0, 0.0, 1.0})
+            .vertex({1.0, 0.0, 1.0})
+            .vertex({1.0, 1.0, 1.0})
+            .vertex({0.0, 1.0, 1.0})
+            .polytope(Polytope::Type::Tetrahedron, {0, 1, 2, 4})
+            .attribute({3, 0}, 11)
+            .polytope(Polytope::Type::Hexahedron, {0, 1, 2, 3, 4, 5, 6, 7})
+            .attribute({3, 1}, 22);
           break;
         }
         default:
@@ -173,8 +170,7 @@ namespace Rodin::Tests::Unit
     }
 
     void expectSameMeshWithAttributes(
-        const Mesh<Context::Local>& actual,
-        const Mesh<Context::Local>& expected)
+      const Mesh<Context::Local>& actual, const Mesh<Context::Local>& expected)
     {
       expectSameMeshShape(actual, expected);
 
@@ -184,8 +180,8 @@ namespace Rodin::Tests::Unit
         {
           EXPECT_EQ(actual.getGeometry(d, i), expected.getGeometry(d, i))
             << "polytope (" << d << ", " << i << ")";
-          EXPECT_TRUE(Polytope::Key::SymmetricEquality()(
-              actual.getConnectivity().getPolytope(d, i),
+          EXPECT_TRUE(
+            Polytope::Key::SymmetricEquality()(actual.getConnectivity().getPolytope(d, i),
               expected.getConnectivity().getPolytope(d, i)))
             << "polytope (" << d << ", " << i << ")";
           EXPECT_EQ(actual.getAttribute(d, i), expected.getAttribute(d, i))
@@ -194,9 +190,7 @@ namespace Rodin::Tests::Unit
       }
     }
 
-    void expectAttributeRegressionMesh(
-        const Mesh<Context::Local>& mesh,
-        size_t dim)
+    void expectAttributeRegressionMesh(const Mesh<Context::Local>& mesh, size_t dim)
     {
       ASSERT_EQ(mesh.getSpaceDimension(), dim);
       ASSERT_EQ(mesh.getDimension(), dim);
@@ -293,28 +287,27 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies MEDIT load save load preserves canonical attributes for IO mesh loader by checking exact expected values.
   TEST(Rodin_IO_MeshLoader, MEDITLoadSaveLoadPreservesCanonicalAttributes)
   {
-    const std::string input =
-      "MeshVersionFormatted 1\n"
-      "Dimension 3\n"
-      "\n"
-      "Vertices\n"
-      "4\n"
-      "0 0 0 0\n"
-      "1 0 0 0\n"
-      "0 1 0 0\n"
-      "0 0 1 0\n"
-      "\n"
-      "Tetrahedra\n"
-      "1\n"
-      "1 2 3 4 7\n"
-      "\n"
-      "Triangles\n"
-      "3\n"
-      "1 2 3 11\n"
-      "1 2 3 22\n"
-      "1 2 4 33\n"
-      "\n"
-      "End\n";
+    const std::string input = "MeshVersionFormatted 1\n"
+                              "Dimension 3\n"
+                              "\n"
+                              "Vertices\n"
+                              "4\n"
+                              "0 0 0 0\n"
+                              "1 0 0 0\n"
+                              "0 1 0 0\n"
+                              "0 0 1 0\n"
+                              "\n"
+                              "Tetrahedra\n"
+                              "1\n"
+                              "1 2 3 4 7\n"
+                              "\n"
+                              "Triangles\n"
+                              "3\n"
+                              "1 2 3 11\n"
+                              "1 2 3 22\n"
+                              "1 2 4 33\n"
+                              "\n"
+                              "End\n";
 
     Mesh first;
     std::stringstream in(input);
@@ -341,14 +334,10 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates Mesh Attribute Regression over the Dimensions parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-      Dimensions,
-      MeshAttributeRegression,
-      ::testing::Values(1, 2, 3),
-      [](const ::testing::TestParamInfo<size_t>& info)
-      {
-        return "Dim" + std::to_string(info.param) + "D";
-      });
+  INSTANTIATE_TEST_SUITE_P(Dimensions, MeshAttributeRegression,
+    ::testing::Values(1, 2, 3), [](const ::testing::TestParamInfo<size_t>& info) {
+      return "Dim" + std::to_string(info.param) + "D";
+    });
 
   /// @brief Instantiates Mesh Format Coverage over the All Supported Geometries parameter coverage.
   INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/Rodin/MMG/MMGTest.cpp
+++ b/tests/unit/Rodin/MMG/MMGTest.cpp
@@ -34,21 +34,21 @@ namespace Rodin::Tests::Unit
   {
     mesh.getConnectivity().compute(mesh.getDimension() - 1, mesh.getDimension());
     for (auto it = mesh.getFace(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, attr);
   }
 
   static void setAllBoundaryAttributes(MMG::Mesh& mesh, Attribute attr)
   {
     mesh.getConnectivity().compute(mesh.getDimension() - 1, mesh.getDimension());
     for (auto it = mesh.getBoundary(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, attr);
   }
 
   static void setAllSegmentAttributes(MMG::Mesh& mesh, Attribute attr)
   {
     mesh.getConnectivity().compute(1, mesh.getDimension());
     for (auto it = mesh.getPolytope(1); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, attr);
   }
 
   static bool samePoint(const Point& a, const Point& b, Real tol = 1e-10)
@@ -85,7 +85,8 @@ namespace Rodin::Tests::Unit
     }
   }
 
-  static std::vector<Point> getVertexCoordinates(const Mesh<Context::Local>& mesh, const Polytope& p)
+  static std::vector<Point> getVertexCoordinates(
+    const Mesh<Context::Local>& mesh, const Polytope& p)
   {
     std::vector<Point> points;
     for (const auto& v : p.getVertices())
@@ -96,7 +97,8 @@ namespace Rodin::Tests::Unit
     return points;
   }
 
-  static bool containsPointSet(const std::vector<Point>& haystack, const std::vector<Point>& needles)
+  static bool containsPointSet(
+    const std::vector<Point>& haystack, const std::vector<Point>& needles)
   {
     for (const auto& needle : needles)
     {
@@ -116,9 +118,7 @@ namespace Rodin::Tests::Unit
   }
 
   static bool hasEntityWithCoordinates(
-      MMG::Mesh& mesh,
-      Polytope::Type type,
-      const std::vector<Point>& points)
+    MMG::Mesh& mesh, Polytope::Type type, const std::vector<Point>& points)
   {
     const size_t dimension = getDimension(type);
     if (dimension < mesh.getDimension())
@@ -146,10 +146,8 @@ namespace Rodin::Tests::Unit
     return false;
   }
 
-  static bool isCutByLevelSet(
-      const Mesh<Context::Local>& mesh,
-      const Polytope& p,
-      const std::function<Real(const Point&)>& ls)
+  static bool isCutByLevelSet(const Mesh<Context::Local>& mesh, const Polytope& p,
+    const std::function<Real(const Point&)>& ls)
   {
     bool hasNegative = false;
     bool hasPositive = false;
@@ -164,9 +162,7 @@ namespace Rodin::Tests::Unit
   }
 
   static Index getFirstCutEntity(
-      MMG::Mesh& mesh,
-      Polytope::Type type,
-      const std::function<Real(const Point&)>& ls)
+    MMG::Mesh& mesh, Polytope::Type type, const std::function<Real(const Point&)>& ls)
   {
     for (auto it = mesh.getPolytope(getDimension(type)); it; ++it)
     {
@@ -180,9 +176,7 @@ namespace Rodin::Tests::Unit
   }
 
   static Index getFirstUncutEntity(
-      MMG::Mesh& mesh,
-      Polytope::Type type,
-      const std::function<Real(const Point&)>& ls)
+    MMG::Mesh& mesh, Polytope::Type type, const std::function<Real(const Point&)>& ls)
   {
     for (auto it = mesh.getPolytope(getDimension(type)); it; ++it)
     {
@@ -196,9 +190,7 @@ namespace Rodin::Tests::Unit
   }
 
   static void setCellsContainingVertices(
-      MMG::Mesh& mesh,
-      const Polytope::Key& vertices,
-      Attribute attr)
+    MMG::Mesh& mesh, const Polytope::Key& vertices, Attribute attr)
   {
     for (auto it = mesh.getCell(); it; ++it)
     {
@@ -217,13 +209,12 @@ namespace Rodin::Tests::Unit
         containsAll = containsAll && containsVertex;
       }
       if (containsAll)
-        mesh.setAttribute({ it->getDimension(), it->getIndex() }, attr);
+        mesh.setAttribute({it->getDimension(), it->getIndex()}, attr);
     }
   }
 
   static std::vector<Index> getCellsContainingVertices(
-      MMG::Mesh& mesh,
-      const Polytope::Key& vertices)
+    MMG::Mesh& mesh, const Polytope::Key& vertices)
   {
     std::vector<Index> cells;
     for (auto it = mesh.getCell(); it; ++it)
@@ -248,7 +239,8 @@ namespace Rodin::Tests::Unit
     return cells;
   }
 
-  static std::vector<Index> getEdgesOnTriangle(MMG::Mesh& mesh, const Polytope::Key& vertices)
+  static std::vector<Index> getEdgesOnTriangle(
+    MMG::Mesh& mesh, const Polytope::Key& vertices)
   {
     std::vector<Index> edges;
     mesh.getConnectivity().compute(1, mesh.getDimension());
@@ -374,7 +366,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Mesh, SetRequiredTriangle)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {4, 4});
 
     mesh.setRequiredTriangle(0);
     mesh.setRequiredTriangle(3);
@@ -388,7 +380,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Mesh, SetRequiredTetrahedron)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
 
     mesh.setRequiredTetrahedron(0);
     mesh.setRequiredTetrahedron(2);
@@ -526,24 +518,23 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies builder with all MMG metadata for MMG mesh builder by checking exact expected values.
   TEST(Rodin_MMG_Mesh_Builder, BuilderWithAllMMGMetadata)
   {
-    MMG::Mesh mesh =
-      MMG::Mesh::Builder()
-      .initialize(3)
-      .nodes(4)
-      .vertex({0, 0, 0})
-      .vertex({1, 0, 0})
-      .vertex({0, 1, 0})
-      .vertex({0, 0, 1})
-      .polytope(Polytope::Type::Segment, {0, 1})
-      .polytope(Polytope::Type::Triangle, {0, 1, 2})
-      .polytope(Polytope::Type::Tetrahedron, {0, 1, 2, 3})
-      .corner(0)
-      .ridge(0)
-      .requiredVertex(1)
-      .requiredEdge(0)
-      .requiredTriangle(0)
-      .requiredTetrahedron(0)
-      .finalize();
+    MMG::Mesh mesh = MMG::Mesh::Builder()
+                       .initialize(3)
+                       .nodes(4)
+                       .vertex({0, 0, 0})
+                       .vertex({1, 0, 0})
+                       .vertex({0, 1, 0})
+                       .vertex({0, 0, 1})
+                       .polytope(Polytope::Type::Segment, {0, 1})
+                       .polytope(Polytope::Type::Triangle, {0, 1, 2})
+                       .polytope(Polytope::Type::Tetrahedron, {0, 1, 2, 3})
+                       .corner(0)
+                       .ridge(0)
+                       .requiredVertex(1)
+                       .requiredEdge(0)
+                       .requiredTriangle(0)
+                       .requiredTetrahedron(0)
+                       .finalize();
 
     EXPECT_EQ(mesh.getCorners().size(), 1);
     EXPECT_EQ(mesh.getRidges().size(), 1);
@@ -619,7 +610,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredTriangles2D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {4, 4});
 
     mesh.setRequiredTriangle(0);
     mesh.setRequiredTriangle(4);
@@ -643,7 +634,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredTriangles3D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     setAllFaceAttributes(mesh, 7);
     const Index required = 0;
     mesh.setRequiredTriangle(required);
@@ -666,7 +657,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Mesh_IO, SaveLoadMEDITRequiredEntities3D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     setAllSegmentAttributes(mesh, 8);
     setAllFaceAttributes(mesh, 7);
 
@@ -812,7 +803,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip2D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.setRequiredTriangle(0);
     mesh.setRequiredTriangle(3);
 
@@ -831,7 +822,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_MMG5, RequiredEntitiesRoundtrip2D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {4, 4});
     setAllSegmentAttributes(mesh, 8);
 
     const Index requiredVertex = 0;
@@ -859,7 +850,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip3DWithoutFaceAttributes)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     const Index required = getFirstBoundaryTriangleIndex(mesh);
     mesh.setRequiredTriangle(required);
 
@@ -873,10 +864,11 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Verifies required triangles roundtrip 3 D preserves boundary metadata with face attributes for MMG MMG 5 by checking exact expected values, true predicates.
-  TEST(Rodin_MMG_MMG5, RequiredTrianglesRoundtrip3DPreservesBoundaryMetadataWithFaceAttributes)
+  TEST(Rodin_MMG_MMG5,
+    RequiredTrianglesRoundtrip3DPreservesBoundaryMetadataWithFaceAttributes)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     setAllBoundaryAttributes(mesh, 7);
     const Index required = getFirstBoundaryTriangleIndex(mesh);
     mesh.setRequiredTriangle(required);
@@ -895,7 +887,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_MMG5, RequiredEntitiesRoundtrip3D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     setAllSegmentAttributes(mesh, 8);
     setAllBoundaryAttributes(mesh, 7);
 
@@ -994,13 +986,11 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Optimizer, PreservesRequiredTriangles2D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 6, 6 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {6, 6});
     const Index required = 0;
     mesh.setRequiredTriangle(required);
 
-    MMG::Optimizer()
-      .setHMax(0.5)
-      .optimize(mesh);
+    MMG::Optimizer().setHMax(0.5).optimize(mesh);
 
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_GT(mesh.getCellCount(), 0);
@@ -1012,13 +1002,11 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Optimizer, PreservesRequiredTriangles3D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     const Index required = getFirstBoundaryTriangleIndex(mesh);
     mesh.setRequiredTriangle(required);
 
-    MMG::Optimizer()
-      .setHMax(0.75)
-      .optimize(mesh);
+    MMG::Optimizer().setHMax(0.75).optimize(mesh);
 
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_GT(mesh.getCellCount(), 0);
@@ -1030,7 +1018,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Optimizer, PreservesRequiredEntities2D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { 6, 6 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {6, 6});
     setAllSegmentAttributes(mesh, 8);
 
     const Index requiredVertex = 0;
@@ -1040,9 +1028,7 @@ namespace Rodin::Tests::Unit
     mesh.setRequiredEdge(requiredEdge);
     mesh.setRequiredTriangle(requiredTriangle);
 
-    MMG::Optimizer()
-      .setHMax(0.5)
-      .optimize(mesh);
+    MMG::Optimizer().setHMax(0.5).optimize(mesh);
 
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_GT(mesh.getCellCount(), 0);
@@ -1058,7 +1044,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_MMG_Optimizer, PreservesRequiredEntities3D)
   {
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { 3, 3, 3 });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {3, 3, 3});
     setAllSegmentAttributes(mesh, 8);
     setAllFaceAttributes(mesh, 7);
 
@@ -1071,9 +1057,7 @@ namespace Rodin::Tests::Unit
     mesh.setRequiredTriangle(requiredTriangle);
     mesh.setRequiredTetrahedron(requiredTetrahedron);
 
-    MMG::Optimizer()
-      .setHMax(0.75)
-      .optimize(mesh);
+    MMG::Optimizer().setHMax(0.75).optimize(mesh);
 
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_GT(mesh.getCellCount(), 0);
@@ -1325,27 +1309,25 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
     const Index required = 0;
     mesh.setRequiredTriangle(required);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
-    ls = [](const Geometry::Point& p)
-    {
+    ls = [](const Geometry::Point& p) {
       return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
     };
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
     EXPECT_FALSE(result.isEmpty());
     EXPECT_GT(result.getCellCount(), 0);
@@ -1361,30 +1343,28 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     const Index required = getFirstBoundaryTriangleIndex(mesh);
     mesh.setRequiredTriangle(required);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
-    ls = [](const Geometry::Point& p)
-    {
+    ls = [](const Geometry::Point& p) {
       const Real dx = p.x() - 0.5;
       const Real dy = p.y() - 0.5;
       const Real dz = p.z() - 0.5;
       return dx * dx + dy * dy + dz * dz - 0.16;
     };
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
     EXPECT_FALSE(result.isEmpty());
     EXPECT_GT(result.getCellCount(), 0);
@@ -1400,7 +1380,7 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
     setAllSegmentAttributes(mesh, 8);
 
@@ -1412,21 +1392,19 @@ namespace Rodin::Tests::Unit
     mesh.setRequiredTriangle(requiredTriangle);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
-    ls = [](const Geometry::Point& p)
-    {
+    ls = [](const Geometry::Point& p) {
       return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
     };
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
     EXPECT_FALSE(result.isEmpty());
     EXPECT_GT(result.getCellCount(), 0);
@@ -1446,51 +1424,52 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(1, 2);
     setAllSegmentAttributes(mesh, 8);
 
-    const auto lsFn = [](const Point& p)
-    {
+    const auto lsFn = [](const Point& p) {
       return (p.x() - 0.5) * (p.x() - 0.5) + (p.y() - 0.5) * (p.y() - 0.5) - 0.1;
     };
 
     const Index requiredVertex = 0;
     const Index requiredEdge = getFirstUncutEntity(mesh, Polytope::Type::Segment, lsFn);
-    const Index requiredTriangle = getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const Index requiredTriangle =
+      getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
     const auto vertexCoords = mesh.getVertexCoordinates(requiredVertex);
     const Point requiredVertexPoint(
-        *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
-    const auto requiredEdgePoints =
-      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
-    const auto requiredTrianglePoints =
-      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
+      *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
+    const auto requiredEdgePoints = getVertexCoordinates(
+      mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
+    const auto requiredTrianglePoints = getVertexCoordinates(
+      mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
 
     mesh.setRequiredVertex(requiredVertex);
     mesh.setRequiredEdge(requiredEdge);
     mesh.setRequiredTriangle(requiredTriangle);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
     EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
     EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
     EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
     EXPECT_TRUE(hasVertexWithCoordinates(result, requiredVertexPoint));
-    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
-    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
+    EXPECT_TRUE(
+      hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
+    EXPECT_TRUE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
   }
 
   /// @brief Verifies preserves required entities 3 D for MMG level set discretizer by checking exact expected values, true predicates, false predicates.
@@ -1501,7 +1480,7 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     setAllSegmentAttributes(mesh, 8);
 
@@ -1513,12 +1492,11 @@ namespace Rodin::Tests::Unit
     mesh.setRequiredTriangle(requiredTriangle);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
-    ls = [](const Geometry::Point& p)
-    {
+    ls = [](const Geometry::Point& p) {
       const Real dx = p.x() - 0.5;
       const Real dy = p.y() - 0.5;
       const Real dz = p.z() - 0.5;
@@ -1546,12 +1524,11 @@ namespace Rodin::Tests::Unit
     ASSERT_TRUE(foundUncutTetrahedron);
     mesh.setRequiredTetrahedron(requiredTetrahedron);
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
     EXPECT_FALSE(result.isEmpty());
     EXPECT_GT(result.getCellCount(), 0);
@@ -1573,14 +1550,13 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(1, 3);
     mesh.getConnectivity().compute(2, 3);
     setAllSegmentAttributes(mesh, 8);
 
-    const auto lsFn = [](const Point& p)
-    {
+    const auto lsFn = [](const Point& p) {
       const Real dx = p.x() - 0.5;
       const Real dy = p.y() - 0.5;
       const Real dz = p.z() - 0.5;
@@ -1589,17 +1565,19 @@ namespace Rodin::Tests::Unit
 
     const Index requiredVertex = 0;
     const Index requiredEdge = getFirstUncutEntity(mesh, Polytope::Type::Segment, lsFn);
-    const Index requiredTriangle = getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const Index requiredTetrahedron = getFirstUncutEntity(mesh, Polytope::Type::Tetrahedron, lsFn);
+    const Index requiredTriangle =
+      getFirstUncutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const Index requiredTetrahedron =
+      getFirstUncutEntity(mesh, Polytope::Type::Tetrahedron, lsFn);
     const auto vertexCoords = mesh.getVertexCoordinates(requiredVertex);
     const Point requiredVertexPoint(
-        *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
-    const auto requiredEdgePoints =
-      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
-    const auto requiredTrianglePoints =
-      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
-    const auto requiredTetrahedronPoints =
-      getVertexCoordinates(mesh, *mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), requiredTetrahedron));
+      *mesh.getVertex(requiredVertex), vertexCoords, vertexCoords);
+    const auto requiredEdgePoints = getVertexCoordinates(
+      mesh, *mesh.getPolytope(getDimension(Polytope::Type::Segment), requiredEdge));
+    const auto requiredTrianglePoints = getVertexCoordinates(
+      mesh, *mesh.getPolytope(getDimension(Polytope::Type::Triangle), requiredTriangle));
+    const auto requiredTetrahedronPoints = getVertexCoordinates(mesh,
+      *mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), requiredTetrahedron));
 
     mesh.setRequiredVertex(requiredVertex);
     mesh.setRequiredEdge(requiredEdge);
@@ -1607,27 +1585,29 @@ namespace Rodin::Tests::Unit
     mesh.setRequiredTetrahedron(requiredTetrahedron);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, interior);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, interior);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(interior, { interior, exterior })
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(interior, {interior, exterior})
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
     EXPECT_TRUE(result.getRequiredVertices().count(requiredVertex));
     EXPECT_TRUE(result.getRequiredEdges().count(requiredEdge));
     EXPECT_TRUE(result.getRequiredTriangles().count(requiredTriangle));
     EXPECT_TRUE(result.getRequiredTetrahedra().count(requiredTetrahedron));
     EXPECT_TRUE(hasVertexWithCoordinates(result, requiredVertexPoint));
-    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
-    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
-    EXPECT_TRUE(hasEntityWithCoordinates(result, Polytope::Type::Tetrahedron, requiredTetrahedronPoints));
+    EXPECT_TRUE(
+      hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredEdgePoints));
+    EXPECT_TRUE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredTrianglePoints));
+    EXPECT_TRUE(hasEntityWithCoordinates(
+      result, Polytope::Type::Tetrahedron, requiredTetrahedronPoints));
   }
 
   /// @brief Verifies no split does not preserve cut required edge 2 D for MMG level set discretizer by checking true predicates, false predicates.
@@ -1639,7 +1619,7 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(1, 2);
 
@@ -1649,7 +1629,7 @@ namespace Rodin::Tests::Unit
     const auto requiredPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     mesh.setRequiredEdge(required);
     setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
 
@@ -1657,16 +1637,18 @@ namespace Rodin::Tests::Unit
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
   }
 
   /// @brief Verifies no split does not preserve cut required triangle 2 D for MMG level set discretizer by checking true predicates, false predicates.
@@ -1678,37 +1660,41 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() - 0.75; };
     const Index required = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
     const auto requiredPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     mesh.setRequiredTriangle(required);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
   }
 
   /// @brief Verifies no split does not preserve individually labeled cut triangle 2 D for MMG level set discretizer by checking true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle2D)
+  TEST(
+    Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle2D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -1716,32 +1702,36 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 16;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {n, n});
     mesh.scale(1.0 / (n - 1));
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() - 0.75; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.1)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.1)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split does not preserve cut required edge 3 D for MMG level set discretizer by checking true predicates, false predicates.
@@ -1753,7 +1743,7 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(1, 3);
 
@@ -1763,7 +1753,7 @@ namespace Rodin::Tests::Unit
     const auto requiredPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     mesh.setRequiredEdge(required);
     setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
 
@@ -1771,16 +1761,18 @@ namespace Rodin::Tests::Unit
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Segment, requiredPoints));
   }
 
   /// @brief Verifies no split does not preserve cut required triangle 3 D for MMG level set discretizer by checking true predicates, false predicates.
@@ -1792,17 +1784,18 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
     const Index required = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), required);
     const auto requiredPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     mesh.setRequiredTriangle(required);
     setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
 
@@ -1810,20 +1803,23 @@ namespace Rodin::Tests::Unit
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, requiredPoints));
   }
 
   /// @brief Verifies no split adjacent tetrahedra does not preserve cut triangle 3 D for MMG level set discretizer by checking true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
+  TEST(
+    Rodin_MMG_LevelSetDiscretizer, NoSplitAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -1831,37 +1827,42 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split adjacent tetrahedra does not preserve labeled required cut triangle 3 D for MMG level set discretizer by checking true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitAdjacentTetrahedraDoesNotPreserveLabeledRequiredCutTriangle3D)
+  TEST(Rodin_MMG_LevelSetDiscretizer,
+    NoSplitAdjacentTetrahedraDoesNotPreserveLabeledRequiredCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -1869,18 +1870,20 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
     mesh.setRequiredTriangle(protectedTriangle);
     setCellsContainingVertices(mesh, entity->getVertices(), protectedRef);
 
@@ -1888,20 +1891,23 @@ namespace Rodin::Tests::Unit
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split required adjacent tetrahedra does not preserve cut triangle 3 D for MMG level set discretizer by checking true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
+  TEST(Rodin_MMG_LevelSetDiscretizer,
+    NoSplitRequiredAdjacentTetrahedraDoesNotPreserveCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -1909,43 +1915,50 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
-    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    const auto adjacentTetrahedra =
+      getCellsContainingVertices(mesh, entity->getVertices());
     ASSERT_FALSE(adjacentTetrahedra.empty());
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     for (const auto& tetrahedron : adjacentTetrahedra)
     {
       mesh.setRequiredTetrahedron(tetrahedron);
-      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+      mesh.setAttribute(
+        {getDimension(Polytope::Type::Tetrahedron), tetrahedron}, protectedRef);
     }
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split required triangle closure does not preserve cut triangle 3 D for MMG level set discretizer by checking exact expected values, true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredTriangleClosureDoesNotPreserveCutTriangle3D)
+  TEST(Rodin_MMG_LevelSetDiscretizer,
+    NoSplitRequiredTriangleClosureDoesNotPreserveCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -1953,21 +1966,24 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
-    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    const auto adjacentTetrahedra =
+      getCellsContainingVertices(mesh, entity->getVertices());
     const auto edges = getEdgesOnTriangle(mesh, entity->getVertices());
     ASSERT_FALSE(adjacentTetrahedra.empty());
     ASSERT_EQ(edges.size(), 3);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     for (const auto& vertex : entity->getVertices())
       mesh.setRequiredVertex(vertex);
     for (const auto& edge : edges)
@@ -1975,27 +1991,31 @@ namespace Rodin::Tests::Unit
     for (const auto& tetrahedron : adjacentTetrahedra)
     {
       mesh.setRequiredTetrahedron(tetrahedron);
-      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+      mesh.setAttribute(
+        {getDimension(Polytope::Type::Tetrahedron), tetrahedron}, protectedRef);
     }
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split required full triangle closure does not preserve cut triangle 3 D for MMG level set discretizer by checking exact expected values, true predicates, false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitRequiredFullTriangleClosureDoesNotPreserveCutTriangle3D)
+  TEST(Rodin_MMG_LevelSetDiscretizer,
+    NoSplitRequiredFullTriangleClosureDoesNotPreserveCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -2003,51 +2023,58 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
-    const auto adjacentTetrahedra = getCellsContainingVertices(mesh, entity->getVertices());
+    const auto adjacentTetrahedra =
+      getCellsContainingVertices(mesh, entity->getVertices());
     const auto edges = getEdgesOnTriangle(mesh, entity->getVertices());
     ASSERT_FALSE(adjacentTetrahedra.empty());
     ASSERT_EQ(edges.size(), 3);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     for (const auto& vertex : entity->getVertices())
       mesh.setRequiredVertex(vertex);
     for (const auto& edge : edges)
       mesh.setRequiredEdge(edge);
     mesh.setRequiredTriangle(protectedTriangle);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
     for (const auto& tetrahedron : adjacentTetrahedra)
     {
       mesh.setRequiredTetrahedron(tetrahedron);
-      mesh.setAttribute({ getDimension(Polytope::Type::Tetrahedron), tetrahedron }, protectedRef);
+      mesh.setAttribute(
+        {getDimension(Polytope::Type::Tetrahedron), tetrahedron}, protectedRef);
     }
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split does not preserve individually labeled cut triangle 3 D for MMG level set discretizer by checking false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle3D)
+  TEST(
+    Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -2055,37 +2082,42 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_FALSE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_FALSE(result.getAttributeIndex()
+                   .getAttributes(result.getDimension())
+                   .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split does not preserve individually labeled required cut triangle 3 D for MMG level set discretizer by checking false predicates.
-  TEST(Rodin_MMG_LevelSetDiscretizer, NoSplitDoesNotPreserveIndividuallyLabeledRequiredCutTriangle3D)
+  TEST(Rodin_MMG_LevelSetDiscretizer,
+    NoSplitDoesNotPreserveIndividuallyLabeledRequiredCutTriangle3D)
   {
     static constexpr Attribute splitRef = 1;
     static constexpr Attribute exterior = 2;
@@ -2093,34 +2125,38 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
     mesh.getConnectivity().compute(2, 3);
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
-    const Index protectedTriangle = getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
+    const Index protectedTriangle =
+      getFirstCutEntity(mesh, Polytope::Type::Triangle, lsFn);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Triangle), protectedTriangle);
     const auto protectedPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
     mesh.setRequiredTriangle(protectedTriangle);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_FALSE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
+    EXPECT_FALSE(result.getAttributeIndex()
+                   .getAttributes(result.getDimension())
+                   .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Triangle, protectedPoints));
   }
 
   /// @brief Verifies no split does not preserve cut required tetrahedron 3 D for MMG level set discretizer by checking true predicates, false predicates.
@@ -2132,33 +2168,36 @@ namespace Rodin::Tests::Unit
 
     const size_t n = 4;
     MMG::Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+    mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
     mesh.scale(1.0 / (n - 1));
 
     const auto lsFn = [](const Point& p) { return p.x() + p.y() + p.z() - 0.8; };
     const Index required = getFirstCutEntity(mesh, Polytope::Type::Tetrahedron, lsFn);
-    const auto entity = mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), required);
+    const auto entity =
+      mesh.getPolytope(getDimension(Polytope::Type::Tetrahedron), required);
     const auto requiredPoints = getVertexCoordinates(mesh, *entity);
 
     for (auto it = mesh.getCell(); it; ++it)
-      mesh.setAttribute({ it->getDimension(), it->getIndex() }, splitRef);
+      mesh.setAttribute({it->getDimension(), it->getIndex()}, splitRef);
     mesh.setRequiredTetrahedron(required);
-    mesh.setAttribute({ entity->getDimension(), entity->getIndex() }, protectedRef);
+    mesh.setAttribute({entity->getDimension(), entity->getIndex()}, protectedRef);
 
     P1 fes(mesh);
     MMG::RealGridFunction ls(fes);
     ls = lsFn;
 
-    MMG::Mesh result =
-      MMG::LevelSetDiscretizer()
-        .split(splitRef, { splitRef, exterior })
-        .noSplit(protectedRef)
-        .setBoundaryReference(10)
-        .setHMax(0.35)
-        .discretize(ls);
+    MMG::Mesh result = MMG::LevelSetDiscretizer()
+                         .split(splitRef, {splitRef, exterior})
+                         .noSplit(protectedRef)
+                         .setBoundaryReference(10)
+                         .setHMax(0.35)
+                         .discretize(ls);
 
-    EXPECT_TRUE(result.getAttributeIndex().getAttributes(result.getDimension()).count(protectedRef));
-    EXPECT_FALSE(hasEntityWithCoordinates(result, Polytope::Type::Tetrahedron, requiredPoints));
+    EXPECT_TRUE(result.getAttributeIndex()
+                  .getAttributes(result.getDimension())
+                  .count(protectedRef));
+    EXPECT_FALSE(
+      hasEntityWithCoordinates(result, Polytope::Type::Tetrahedron, requiredPoints));
   }
 
   // ========================================================================

--- a/tests/unit/Rodin/Math/CommonTest.cpp
+++ b/tests/unit/Rodin/Math/CommonTest.cpp
@@ -6,6 +6,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <type_traits>
+#include <utility>
+
 #include "Rodin/Math/Common.h"
 #include "Rodin/Math/SpatialVector.h"
 #include "Rodin/Math/SpatialMatrix.h"
@@ -89,8 +92,12 @@ TEST_F(CommonTest, ConjFunction)
 /// @brief Test conjugate of real matrix (should be unchanged).
 TEST_F(CommonTest, ConjMatrixFunction)
 {
+  using MatrixType = Eigen::Matrix<Real, 2, 2>;
+  static_assert(
+    std::is_same_v<decltype(conj(std::declval<const MatrixType&>())), MatrixType>);
+
   // Test conjugate of real matrix (should be unchanged)
-  Eigen::Matrix<Real, 2, 2> realMat;
+  MatrixType realMat;
   realMat << 1.0, 2.0,
              3.0, 4.0;
 

--- a/tests/unit/Rodin/PETSc/FormTest.cpp
+++ b/tests/unit/Rodin/PETSc/FormTest.cpp
@@ -29,9 +29,7 @@ namespace
 
       template <class TrialFunctionType, class TestFunctionType>
       ToggleLocalBilinearIntegrator(
-          const TrialFunctionType& u,
-          const TestFunctionType& v,
-          const PetscScalar* offdiag)
+        const TrialFunctionType& u, const TestFunctionType& v, const PetscScalar* offdiag)
         : Parent(u, v),
           m_offdiag(offdiag)
       {}
@@ -78,16 +76,16 @@ namespace
   void checkPETScReassemblyKeepsExplicitZeroStructuralEntries()
   {
     auto mesh = Mesh<Context::Local>::Builder()
-      .initialize(1)
-      .nodes(2)
-      .vertex({0.0})
-      .vertex({1.0})
-      .polytope(Polytope::Type::Segment, {0, 1})
-      .finalize();
+                  .initialize(1)
+                  .nodes(2)
+                  .vertex({0.0})
+                  .vertex({1.0})
+                  .polytope(Polytope::Type::Segment, {0, 1})
+                  .finalize();
 
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
 
     PetscScalar offdiag = 0;
     using LinearSystemType = PETSc::Math::LinearSystem;
@@ -97,17 +95,15 @@ namespace
     ToggleLocalBilinearIntegrator integrator(u, v, &offdiag);
     ProblemBodyType body(integrator);
 
-    Assembly::ProblemAssemblyInput<
-      ProblemBodyType,
-      decltype(u), decltype(v)> input(body, u, v);
+    Assembly::ProblemAssemblyInput<ProblemBodyType, decltype(u), decltype(v)> input(
+      body, u, v);
 
     LinearSystemType ls(PETSC_COMM_SELF);
     Assembler<LinearSystemType, ProblemType> assembler;
     assembler.execute(ls, input);
 
     auto& A = ls.getOperator();
-    PetscErrorCode ierr =
-      MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+    PetscErrorCode ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
     ASSERT_EQ(ierr, PETSC_SUCCESS);
 
     offdiag = 2;
@@ -613,12 +609,12 @@ namespace
 
   void checkPETScStandaloneOpenMPFormsMatchSequential()
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
 
     LinearForm lf(v);
     lf = Integral(RealFunction(2.0), v);
@@ -633,8 +629,8 @@ namespace
 
     PETSc::Assembly::Sequential<::Vec, LFType> seqLF;
     PETSc::Assembly::OpenMP<::Vec, LFType> ompLF;
-    seqLF.execute(seqVec, { fes, lf.getIntegrators() });
-    ompLF.execute(ompVec, { fes, lf.getIntegrators() });
+    seqLF.execute(seqVec, {fes, lf.getIntegrators()});
+    ompLF.execute(ompVec, {fes, lf.getIntegrators()});
     expectSameStandaloneVector(seqVec, ompVec);
 
     ierr = VecDestroy(&seqVec);
@@ -655,10 +651,10 @@ namespace
 
     PETSc::Assembly::Sequential<::Mat, BFType> seqBF;
     PETSc::Assembly::OpenMP<::Mat, BFType> ompBF;
-    seqBF.execute(seqMat, {
-        fes, fes, bf.getLocalIntegrators(), bf.getGlobalIntegrators() });
-    ompBF.execute(ompMat, {
-        fes, fes, bf.getLocalIntegrators(), bf.getGlobalIntegrators() });
+    seqBF.execute(
+      seqMat, {fes, fes, bf.getLocalIntegrators(), bf.getGlobalIntegrators()});
+    ompBF.execute(
+      ompMat, {fes, fes, bf.getLocalIntegrators(), bf.getGlobalIntegrators()});
     expectSameStandaloneMatrix(seqMat, ompMat);
 
     ierr = MatDestroy(&seqMat);

--- a/tests/unit/Rodin/PETSc/GridFunctionTest.cpp
+++ b/tests/unit/Rodin/PETSc/GridFunctionTest.cpp
@@ -54,10 +54,46 @@ namespace
     cgf.flush();
   }
 
+  TEST(PETSc_GridFunction, SequentialPointEvaluationMatchesMappedBasisExpansion)
+  {
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Tetrahedron, {2, 2, 2});
+    mesh.getConnectivity().compute(3, 2);
+    mesh.getConnectivity().compute(2, 1);
+    mesh.getConnectivity().compute(1, 0);
+    mesh.getConnectivity().compute(2, 0);
+    mesh.getConnectivity().compute(3, 0);
+    P1 fes(mesh, 3);
+    Rodin::PETSc::Variational::GridFunction gf(fes);
+
+    for (Index i = 0; i < gf.getSize(); ++i)
+      gf[i] = static_cast<PetscScalar>(Real(-0.4) + Real(0.07) * i);
+    gf.flush();
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.17, 0.23, 0.19});
+    const auto& fe = fes.getFiniteElement(3, cell->getIndex());
+    const auto& dofs = fes.getDOFs(3, cell->getIndex());
+    const auto& cgf = gf;
+    Math::SpatialVector<PetscScalar> expected;
+    for (size_t local = 0; local < fe.getCount(); ++local)
+    {
+      const auto basis = fes.getPushforward({3, cell->getIndex()}, fe.getBasis(local));
+      const auto term = cgf[dofs[local]] * basis(p);
+      if (local == 0)
+        expected = term;
+      else
+        expected += term;
+    }
+
+    const auto value = cgf(p);
+    EXPECT_NEAR((value - expected).norm(), 0, 1e-14);
+    cgf.flush();
+  }
+
   /// @brief Verifies sequential min returns value and index for PET sc grid function by checking tolerance-based numerical results, exact expected values.
   TEST(PETSc_GridFunction, SequentialMinReturnsValueAndIndex)
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     P1 fes(mesh);
     Rodin::PETSc::Variational::GridFunction gf(fes);
 
@@ -77,7 +113,7 @@ namespace
   /// @brief Verifies sequential max returns value and index for PET sc grid function by checking tolerance-based numerical results, exact expected values.
   TEST(PETSc_GridFunction, SequentialMaxReturnsValueAndIndex)
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     P1 fes(mesh);
     Rodin::PETSc::Variational::GridFunction gf(fes);
 

--- a/tests/unit/Rodin/PETSc/MPIFormTest.cpp
+++ b/tests/unit/Rodin/PETSc/MPIFormTest.cpp
@@ -255,6 +255,63 @@ namespace
     }
   }
 
+  /// @brief Regression: block (multi-trial) assemble() must seed the block
+  ///        solution vector with each trial function's data as the initial
+  ///        guess. In the distributed case this needs per-field owned-range
+  ///        index sets; an earlier version used a globally-sized index set and
+  ///        the wrong scatter direction, aborting with an IS/Vec local-length
+  ///        mismatch under MPI. Verifies each field's guess round-trips through
+  ///        the documented offset scatter used by solve().
+  TEST(PETSc_MPI_Form, DistributedBlockAssembleSeedsPerFieldInitialGuess)
+  {
+    const auto& world = *g_world;
+    Context::MPI ctx(*g_env, world);
+    auto mesh = distributeFromRoot(ctx);
+    P1 fes(mesh);
+    PETSc::Variational::TrialFunction u(fes);
+    PETSc::Variational::TestFunction v(fes);
+    PETSc::Variational::TrialFunction eta(fes);
+    PETSc::Variational::TestFunction zeta(fes);
+
+    // Distinct, nonzero per-field guesses carried by the trial functions.
+    constexpr PetscScalar guessU = 3.0;
+    constexpr PetscScalar guessEta = -5.0;
+    u.getSolution() = guessU;
+    eta.getSolution() = guessEta;
+
+    Problem problem(u, v, eta, zeta);
+    problem = Integral(Grad(u), Grad(v)) + Integral(Grad(eta), Grad(zeta)) -
+      Integral(RealFunction(1.0), v) - Integral(RealFunction(1.0), zeta);
+    problem.assemble(); // regression: this aborted under MPI
+
+    // Recover each field from the seeded block solution vector using the same
+    // offset scatter that solve() uses, and confirm the guesses survived.
+    Vec x = problem.getLinearSystem().getSolution();
+    const auto& offsets = problem.getTrialOffsets();
+
+    PETSc::Variational::GridFunction uRecovered(fes);
+    PETSc::Variational::GridFunction etaRecovered(fes);
+    uRecovered = PetscScalar(0);
+    etaRecovered = PetscScalar(0);
+    uRecovered.setData(x, offsets[0]);
+    etaRecovered.setData(x, offsets[1]);
+
+    auto expectOwnedConstant = [](const Vec& data, PetscScalar expected) {
+      PetscInt begin = 0;
+      PetscInt end = 0;
+      EXPECT_EQ(VecGetOwnershipRange(data, &begin, &end), PETSC_SUCCESS);
+      for (PetscInt i = begin; i < end; ++i)
+      {
+        PetscScalar value = 0;
+        EXPECT_EQ(VecGetValues(data, 1, &i, &value), PETSC_SUCCESS);
+        EXPECT_NEAR(PetscRealPart(value), PetscRealPart(expected), 1e-14) << "row " << i;
+      }
+    };
+
+    expectOwnedConstant(uRecovered.getData(), guessU);
+    expectOwnedConstant(etaRecovered.getData(), guessEta);
+  }
+
   /// @brief Verifies distributed self identification matches zero value constraint for PET sc MPI form by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(PETSc_MPI_Form, DistributedSelfIdentificationMatchesZeroValueConstraint)
   {

--- a/tests/unit/Rodin/PETSc/MPIGridFunctionTest.cpp
+++ b/tests/unit/Rodin/PETSc/MPIGridFunctionTest.cpp
@@ -104,6 +104,34 @@ namespace
     world.barrier();
     SUCCEED();
   }
+
+  TEST(PETSc_MPI_GridFunction, PointEvaluationUsesOwnedAndGhostCoefficients)
+  {
+    auto& world = *g_world;
+    Context::MPI ctx(*g_env, world);
+    auto mesh = distributeFromRoot(ctx);
+    P1 fes(mesh);
+    P1 vectorFES(mesh, size_t(2));
+    Rodin::PETSc::Variational::GridFunction gf(fes);
+    Rodin::PETSc::Variational::GridFunction vector(vectorFES);
+    gf = static_cast<PetscScalar>(3.25);
+    vector = static_cast<PetscScalar>(-1.75);
+
+    size_t evaluated = 0;
+    for (auto cell = mesh.getCell(); cell; ++cell)
+    {
+      const Point p(*cell, Polytope::Traits(cell->getGeometry()).getCentroid());
+      EXPECT_NEAR(static_cast<Real>(PetscRealPart(gf(p))), 3.25, 1e-14);
+      const auto value = vector(p);
+      EXPECT_NEAR(static_cast<Real>(PetscRealPart(value(0))), -1.75, 1e-14);
+      EXPECT_NEAR(static_cast<Real>(PetscRealPart(value(1))), -1.75, 1e-14);
+      ++evaluated;
+    }
+    EXPECT_GT(evaluated, 0);
+    static_cast<const decltype(gf)&>(gf).flush();
+    static_cast<const decltype(vector)&>(vector).flush();
+    world.barrier();
+  }
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/Rodin/Serialization/SerializationMeshTest.cpp
+++ b/tests/unit/Rodin/Serialization/SerializationMeshTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
+#include "Rodin/Serialization/Export.h"
 #include "Rodin/Serialization/Optional.h"
 
 #include "Rodin/Geometry/Mesh.h"
@@ -16,7 +17,7 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Serialization_Mesh, to_stringstream)
   {
     Mesh original;
-    original = original.UniformGrid(Polytope::Type::Triangle, { 16, 16 });
+    original = original.UniformGrid(Polytope::Type::Triangle, {16, 16});
 
     // Serialize the mesh into an in-memory string stream.
     std::stringstream ss;
@@ -36,5 +37,45 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(original.getVertexCount(), deserialized.getVertexCount());
     EXPECT_EQ(original.getCellCount(), deserialized.getCellCount());
   }
-}
 
+  /// @brief Verifies polymorphic serialization of a parametric transformation.
+  TEST(Rodin_Serialization_Mesh, ParametricTransformationRoundTrip)
+  {
+    PointCloud points(2, 3);
+    points(0, 0) = 0;
+    points(0, 1) = 1;
+    points(0, 2) = 0;
+    points(1, 0) = 0;
+    points(1, 1) = 0;
+    points(1, 2) = 1;
+
+    std::unique_ptr<PolytopeTransformation> original(
+      new ParametricTransformation(points, RealP1Element(Polytope::Type::Triangle)));
+
+    std::stringstream stream;
+    {
+      boost::archive::text_oarchive archive(stream);
+      archive << original.get();
+    }
+
+    PolytopeTransformation* loadedRaw = nullptr;
+    {
+      boost::archive::text_iarchive archive(stream);
+      archive >> loadedRaw;
+    }
+    std::unique_ptr<PolytopeTransformation> loaded(loadedRaw);
+
+    Math::SpatialPoint reference(2);
+    reference[0] = 0.25;
+    reference[1] = 0.5;
+    Math::SpatialPoint expected;
+    Math::SpatialPoint actual;
+    original->transform(expected, reference);
+    loaded->transform(actual, reference);
+
+    EXPECT_EQ(loaded->getReferenceDimension(), 2);
+    EXPECT_EQ(loaded->getPhysicalDimension(), 2);
+    EXPECT_EQ(loaded->getOrder(), 1);
+    EXPECT_NEAR((actual - expected).norm(), 0, RODIN_FUZZY_CONSTANT);
+  }
+}

--- a/tests/unit/Rodin/Solver/CMakeLists.txt
+++ b/tests/unit/Rodin/Solver/CMakeLists.txt
@@ -12,6 +12,20 @@ gtest_discover_tests(RodinNewtonSolverTest
     LABELS unit
 )
 
+add_executable(RodinInitialGuessTest InitialGuessTest.cpp)
+target_link_libraries(RodinInitialGuessTest
+  PUBLIC
+  GTest::gtest
+  GTest::gtest_main
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::Solver
+)
+gtest_discover_tests(RodinInitialGuessTest
+  PROPERTIES
+    LABELS unit
+)
+
 add_executable(RodinSolverConceptTest SolverConceptTest.cpp)
 target_link_libraries(RodinSolverConceptTest
   GTest::gtest

--- a/tests/unit/Rodin/Solver/InitialGuessTest.cpp
+++ b/tests/unit/Rodin/Solver/InitialGuessTest.cpp
@@ -1,0 +1,148 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2025.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <gtest/gtest.h>
+
+#include "Rodin/Assembly.h"
+#include "Rodin/Geometry/Mesh.h"
+#include "Rodin/Solver/CG.h"
+#include "Rodin/Solver/NewtonSolver.h"
+#include "Rodin/Solver/SparseLU.h"
+#include "Rodin/Variational.h"
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+using Rodin::Solver::CG;
+using Rodin::Solver::SparseLU;
+
+namespace Rodin::Tests::Unit::InitialGuess
+{
+  /**
+   * A full assemble() must seed the linear system's solution vector (the
+   * initial guess) from the trial function data.
+   */
+  TEST(Rodin_Solver_InitialGuess, AssembleSeedsGuessFromTrialFunction)
+  {
+    Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {4, 4});
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 vh(mesh);
+    TrialFunction u(vh);
+    TestFunction v(vh);
+
+    RealFunction f = 1.0;
+
+    Problem poisson(u, v);
+    poisson = Integral(Grad(u), Grad(v)) - Integral(f, v) + DirichletBC(u, Zero());
+
+    u.getSolution() = [](const Geometry::Point& p) { return p.x() + 2.0 * p.y(); };
+
+    poisson.assemble();
+
+    const auto& guess = poisson.getLinearSystem().getSolution();
+    const auto& data = u.getSolution().getData();
+    ASSERT_EQ(guess.size(), data.size());
+    EXPECT_EQ((guess - data).norm(), 0.0);
+  }
+
+  /**
+   * An iterative solver must use the seeded guess: with the exact solution
+   * as the guess, CG must succeed within an iteration budget that is
+   * insufficient from a zero guess.
+   */
+  TEST(Rodin_Solver_InitialGuess, IterativeSolverHonorsGuess)
+  {
+    Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {16, 16});
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 vh(mesh);
+    TrialFunction u(vh);
+    TestFunction v(vh);
+
+    RealFunction f = 1.0;
+
+    auto define = [&](auto& pb) {
+      pb = Integral(Grad(u), Grad(v)) - Integral(f, v) + DirichletBC(u, Zero());
+    };
+
+    // Reference solution with a direct solver.
+    Problem direct(u, v);
+    define(direct);
+    SparseLU lu(direct);
+    direct.solve(lu);
+    const Math::Vector<Real> exact = u.getSolution().getData();
+    ASSERT_GT(exact.norm(), 0.0);
+
+    // u's solution holds the exact data; assemble seeds it as the guess and
+    // a single CG iteration suffices.
+    Problem warm(u, v);
+    define(warm);
+    CG cg(warm);
+    cg.setTolerance(1e-10).setMaxIterations(1);
+    warm.solve(cg);
+    EXPECT_TRUE(cg.success());
+    EXPECT_NEAR((u.getSolution().getData() - exact).norm(), 0.0, 1e-10);
+
+    // From a zero guess, the same iteration budget must fail.
+    Problem cold(u, v);
+    define(cold);
+    u.getSolution() = Zero();
+    CG coldCG(cold);
+    coldCG.setTolerance(1e-10).setMaxIterations(1);
+    cold.solve(coldCG);
+    EXPECT_FALSE(coldCG.success());
+  }
+
+  /**
+   * The Newton increment solve always starts from a zero guess, regardless
+   * of what the assembly seeded: a direct and an iterative solver must
+   * converge to the same Newton solution.
+   */
+  TEST(Rodin_Solver_InitialGuess, NewtonIncrementStartsFromZero)
+  {
+    Mesh mesh;
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {8, 8});
+    mesh.getConnectivity().compute(1, 2);
+
+    P1 vh(mesh);
+
+    auto solveWith = [&](auto makeSolver) -> Math::Vector<Real> {
+      TrialFunction du(vh);
+      TestFunction v(vh);
+
+      GridFunction u(vh);
+      u = Zero();
+
+      RealFunction f = 1.0;
+
+      // Newton form of the linear Poisson problem: J du = -F(u).
+      Problem newton(du, v);
+      newton = Integral(Grad(du), Grad(v)) + Integral(Grad(u), Grad(v)) - Integral(f, v) +
+        DirichletBC(du, Zero());
+
+      auto linearSolver = makeSolver(newton);
+      Solver::NewtonSolver solver(linearSolver);
+      solver.setMaxIterations(10).setAbsoluteTolerance(1e-12).setRelativeTolerance(1e-10);
+      solver.solve(u);
+      EXPECT_TRUE(solver.getReport().converged);
+      return u.getData();
+    };
+
+    const auto direct = solveWith([](auto& pb) { return SparseLU(pb); });
+
+    const auto iterative = solveWith([](auto& pb) {
+      CG cg(pb);
+      cg.setTolerance(1e-12).setMaxIterations(2000);
+      return cg;
+    });
+
+    EXPECT_GT(direct.norm(), 0.0);
+    EXPECT_NEAR((direct - iterative).norm(), 0.0, 1e-8);
+  }
+}

--- a/tests/unit/Rodin/Test/CMakeLists.txt
+++ b/tests/unit/Rodin/Test/CMakeLists.txt
@@ -32,3 +32,16 @@ gtest_discover_tests(RodinTestExpectedResultTableTest
   PROPERTIES
     LABELS unit
 )
+
+add_executable(RodinTestFDProbeTest FDProbeTest.cpp)
+target_link_libraries(RodinTestFDProbeTest
+  PUBLIC
+  GTest::gtest
+  GTest::gtest_main
+  Rodin::Geometry
+  Rodin::Variational
+  Rodin::Test)
+gtest_discover_tests(RodinTestFDProbeTest
+  PROPERTIES
+    LABELS unit
+)

--- a/tests/unit/Rodin/Test/FDProbeTest.cpp
+++ b/tests/unit/Rodin/Test/FDProbeTest.cpp
@@ -47,13 +47,13 @@ namespace
     switch (type)
     {
       case Polytope::Type::Segment:
-        mesh = LocalMesh::UniformGrid(type, { 5 });
+        mesh = LocalMesh::UniformGrid(type, {5});
         mesh.scale(1.0 / 4.0);
         mesh.getConnectivity().compute(0, 1);
         break;
       case Polytope::Type::Triangle:
       case Polytope::Type::Quadrilateral:
-        mesh = LocalMesh::UniformGrid(type, { 4, 4 });
+        mesh = LocalMesh::UniformGrid(type, {4, 4});
         mesh.scale(1.0 / 3.0);
         mesh.getConnectivity().compute(1, 2);
         break;
@@ -61,17 +61,17 @@ namespace
       case Polytope::Type::Pyramid:
       case Polytope::Type::Hexahedron:
       case Polytope::Type::Wedge:
-        mesh = LocalMesh::UniformGrid(type, { 3, 3, 3 });
+        mesh = LocalMesh::UniformGrid(type, {3, 3, 3});
         mesh.scale(1.0 / 2.0);
         mesh.getConnectivity().compute(2, 3);
         break;
       case Polytope::Type::Point:
         mesh = LocalMesh::Builder()
-          .initialize(1)
-          .nodes(1)
-          .vertex({ 0.0 })
-          .polytope(Polytope::Type::Point, { 0 })
-          .finalize();
+                 .initialize(1)
+                 .nodes(1)
+                 .vertex({0.0})
+                 .polytope(Polytope::Type::Point, {0})
+                 .finalize();
         break;
     }
     return mesh;
@@ -85,8 +85,7 @@ namespace
   template <class State>
   void setSmoothState(State& state)
   {
-    state = [](const Geometry::Point& p)
-    {
+    state = [](const Geometry::Point& p) {
       const auto& x = p.getPhysicalCoordinates();
       Real value = 0.3;
       for (Index d = 0; d < x.size(); ++d)
@@ -112,8 +111,7 @@ namespace
     auto direction = problem.getTrialFunction().getSolution().getData();
     direction.setZero();
 
-    const auto& fes =
-      problem.getTrialFunction().getFiniteElementSpace();
+    const auto& fes = problem.getTrialFunction().getFiniteElementSpace();
     for (auto it = mesh.getVertex(); it; ++it)
     {
       const auto& x = it->getCoordinates();
@@ -143,9 +141,7 @@ TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPasses)
 
   const auto& u = du.getSolution();
   Problem problem(du, v);
-  problem =
-      2.0 * Integral(u * du, v)
-    + Integral(u * u, v);
+  problem = 2.0 * Integral(u * du, v) + Integral(u * u, v);
 
   Rodin::Test::FDProbe probe(problem);
   const auto report = probe.test(1e-6);
@@ -158,14 +154,9 @@ TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPasses)
 
 TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPassesAcrossGeometries)
 {
-  for (const Polytope::Type type : {
-      Polytope::Type::Segment,
-      Polytope::Type::Triangle,
-      Polytope::Type::Quadrilateral,
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Wedge })
+  for (const Polytope::Type type : {Polytope::Type::Segment, Polytope::Type::Triangle,
+         Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+         Polytope::Type::Pyramid, Polytope::Type::Hexahedron, Polytope::Type::Wedge})
   {
     SCOPED_TRACE(getName(type));
 
@@ -178,9 +169,7 @@ TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPassesAcrossGeometries)
 
     const auto& u = du.getSolution();
     Problem problem(du, v);
-    problem =
-        2.0 * Integral(u * du, v)
-      + Integral(u * u, v);
+    problem = 2.0 * Integral(u * du, v) + Integral(u * u, v);
 
     const auto report = runNonlinearScalarProbe(problem);
     EXPECT_LT(report.relativeError, 1e-6)
@@ -231,9 +220,7 @@ TEST(Rodin_Test_FDProbe, WrongTangentFails)
 
   const auto& u = du.getSolution();
   Problem problem(du, v);
-  problem =
-      Integral(u * du, v)
-    + Integral(u * u, v);
+  problem = Integral(u * du, v) + Integral(u * u, v);
 
   Rodin::Test::FDProbe probe(problem);
   const auto report = probe.test(1e-6);
@@ -252,10 +239,7 @@ TEST(Rodin_Test_FDProbe, DirichletProblemPassesWithAdmissibleDirection)
 
   const auto& u = du.getSolution();
   Problem problem(du, v);
-  problem =
-      2.0 * Integral(u * du, v)
-    + Integral(u * u, v)
-    + DirichletBC(du, Zero());
+  problem = 2.0 * Integral(u * du, v) + Integral(u * u, v) + DirichletBC(du, Zero());
 
   Rodin::Test::FDProbe probe(problem);
   const auto direction = makeInteriorVertexDirection(mesh, problem);

--- a/tests/unit/Rodin/Test/FDProbeTest.cpp
+++ b/tests/unit/Rodin/Test/FDProbeTest.cpp
@@ -1,0 +1,269 @@
+/*
+ *          Copyright Carlos BRITO PACHECO 2021 - 2026.
+ * Distributed under the Boost Software License, Version 1.0.
+ *       (See accompanying file LICENSE or copy at
+ *          https://www.boost.org/LICENSE_1_0.txt)
+ */
+#include <gtest/gtest.h>
+
+#include "Rodin/Assembly.h"
+#include "Rodin/Math/LinearSystem.h"
+#include "Rodin/Test/FDProbe.h"
+#include "Rodin/Variational.h"
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace
+{
+  const char* getName(Polytope::Type type)
+  {
+    switch (type)
+    {
+      case Polytope::Type::Point:
+        return "Point";
+      case Polytope::Type::Segment:
+        return "Segment";
+      case Polytope::Type::Triangle:
+        return "Triangle";
+      case Polytope::Type::Quadrilateral:
+        return "Quadrilateral";
+      case Polytope::Type::Tetrahedron:
+        return "Tetrahedron";
+      case Polytope::Type::Pyramid:
+        return "Pyramid";
+      case Polytope::Type::Hexahedron:
+        return "Hexahedron";
+      case Polytope::Type::Wedge:
+        return "Wedge";
+    }
+    return "Unknown";
+  }
+
+  LocalMesh makeUnitMesh(Polytope::Type type)
+  {
+    LocalMesh mesh;
+    switch (type)
+    {
+      case Polytope::Type::Segment:
+        mesh = LocalMesh::UniformGrid(type, { 5 });
+        mesh.scale(1.0 / 4.0);
+        mesh.getConnectivity().compute(0, 1);
+        break;
+      case Polytope::Type::Triangle:
+      case Polytope::Type::Quadrilateral:
+        mesh = LocalMesh::UniformGrid(type, { 4, 4 });
+        mesh.scale(1.0 / 3.0);
+        mesh.getConnectivity().compute(1, 2);
+        break;
+      case Polytope::Type::Tetrahedron:
+      case Polytope::Type::Pyramid:
+      case Polytope::Type::Hexahedron:
+      case Polytope::Type::Wedge:
+        mesh = LocalMesh::UniformGrid(type, { 3, 3, 3 });
+        mesh.scale(1.0 / 2.0);
+        mesh.getConnectivity().compute(2, 3);
+        break;
+      case Polytope::Type::Point:
+        mesh = LocalMesh::Builder()
+          .initialize(1)
+          .nodes(1)
+          .vertex({ 0.0 })
+          .polytope(Polytope::Type::Point, { 0 })
+          .finalize();
+        break;
+    }
+    return mesh;
+  }
+
+  LocalMesh makeUnitSquareMesh()
+  {
+    return makeUnitMesh(Polytope::Type::Triangle);
+  }
+
+  template <class State>
+  void setSmoothState(State& state)
+  {
+    state = [](const Geometry::Point& p)
+    {
+      const auto& x = p.getPhysicalCoordinates();
+      Real value = 0.3;
+      for (Index d = 0; d < x.size(); ++d)
+      {
+        const Real scale = static_cast<Real>(d + 1);
+        value += 0.04 * scale * x(d);
+        value += 0.01 * std::sin(scale * Math::Constants::pi() * x(d));
+      }
+      return value;
+    };
+  }
+
+  template <class ProblemType>
+  Rodin::Test::FDProbeReport runNonlinearScalarProbe(ProblemType& problem)
+  {
+    Rodin::Test::FDProbe probe(problem);
+    return probe.test(1e-6);
+  }
+
+  template <class ProblemType>
+  auto makeInteriorVertexDirection(const LocalMesh& mesh, ProblemType& problem)
+  {
+    auto direction = problem.getTrialFunction().getSolution().getData();
+    direction.setZero();
+
+    const auto& fes =
+      problem.getTrialFunction().getFiniteElementSpace();
+    for (auto it = mesh.getVertex(); it; ++it)
+    {
+      const auto& x = it->getCoordinates();
+      if (x(0) > 0.0 && x(0) < 1.0 && x(1) > 0.0 && x(1) < 1.0)
+      {
+        const auto& dofs = fes.getDOFs(0, it->getIndex());
+        for (decltype(dofs.size()) i = 0; i < dofs.size(); ++i)
+          direction[dofs[i]] = 1.0;
+      }
+    }
+
+    const Real norm = direction.norm();
+    if (norm > 0.0)
+      direction *= 1.0 / norm;
+    return direction;
+  }
+}
+
+TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPasses)
+{
+  LocalMesh mesh = makeUnitSquareMesh();
+  P1 Vh(mesh);
+  TrialFunction du(Vh);
+  TestFunction v(Vh);
+
+  setSmoothState(du.getSolution());
+
+  const auto& u = du.getSolution();
+  Problem problem(du, v);
+  problem =
+      2.0 * Integral(u * du, v)
+    + Integral(u * u, v);
+
+  Rodin::Test::FDProbe probe(problem);
+  const auto report = probe.test(1e-6);
+
+  EXPECT_LT(report.relativeError, 1e-6)
+    << "absoluteError = " << report.absoluteError
+    << ", tangentNorm = " << report.tangentNorm
+    << ", finiteDifferenceNorm = " << report.finiteDifferenceNorm;
+}
+
+TEST(Rodin_Test_FDProbe, NonlinearScalarProblemPassesAcrossGeometries)
+{
+  for (const Polytope::Type type : {
+      Polytope::Type::Segment,
+      Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral,
+      Polytope::Type::Tetrahedron,
+      Polytope::Type::Pyramid,
+      Polytope::Type::Hexahedron,
+      Polytope::Type::Wedge })
+  {
+    SCOPED_TRACE(getName(type));
+
+    LocalMesh mesh = makeUnitMesh(type);
+    P1 Vh(mesh);
+    TrialFunction du(Vh);
+    TestFunction v(Vh);
+
+    setSmoothState(du.getSolution());
+
+    const auto& u = du.getSolution();
+    Problem problem(du, v);
+    problem =
+        2.0 * Integral(u * du, v)
+      + Integral(u * u, v);
+
+    const auto report = runNonlinearScalarProbe(problem);
+    EXPECT_LT(report.relativeError, 1e-6)
+      << "absoluteError = " << report.absoluteError
+      << ", tangentNorm = " << report.tangentNorm
+      << ", finiteDifferenceNorm = " << report.finiteDifferenceNorm;
+  }
+}
+
+TEST(Rodin_Test_FDProbe, LinearSystemSpecializationPasses)
+{
+  Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>> system;
+
+  std::vector<Eigen::Triplet<Real>> triplets;
+  triplets.emplace_back(0, 0, 4.0);
+  triplets.emplace_back(0, 1, -1.0);
+  triplets.emplace_back(1, 0, 2.0);
+  triplets.emplace_back(1, 1, 3.0);
+  triplets.emplace_back(1, 2, 0.5);
+  triplets.emplace_back(2, 1, -2.0);
+  triplets.emplace_back(2, 2, 5.0);
+  system.getOperator().resize(3, 3);
+  system.getOperator().setFromTriplets(triplets.begin(), triplets.end());
+
+  system.getVector().resize(3);
+  system.getVector() << 1.0, -2.0, 0.5;
+
+  system.getSolution().resize(3);
+  system.getSolution() << 0.1, -0.2, 0.3;
+
+  Rodin::Test::FDProbe probe(system);
+  const auto report = probe.test(1e-6);
+
+  EXPECT_LT(report.relativeError, 1e-10)
+    << "absoluteError = " << report.absoluteError
+    << ", tangentNorm = " << report.tangentNorm
+    << ", finiteDifferenceNorm = " << report.finiteDifferenceNorm;
+}
+
+TEST(Rodin_Test_FDProbe, WrongTangentFails)
+{
+  LocalMesh mesh = makeUnitSquareMesh();
+  P1 Vh(mesh);
+  TrialFunction du(Vh);
+  TestFunction v(Vh);
+
+  setSmoothState(du.getSolution());
+
+  const auto& u = du.getSolution();
+  Problem problem(du, v);
+  problem =
+      Integral(u * du, v)
+    + Integral(u * u, v);
+
+  Rodin::Test::FDProbe probe(problem);
+  const auto report = probe.test(1e-6);
+
+  EXPECT_GT(report.relativeError, 1e-3);
+}
+
+TEST(Rodin_Test_FDProbe, DirichletProblemPassesWithAdmissibleDirection)
+{
+  LocalMesh mesh = makeUnitSquareMesh();
+  P1 Vh(mesh);
+  TrialFunction du(Vh);
+  TestFunction v(Vh);
+
+  setSmoothState(du.getSolution());
+
+  const auto& u = du.getSolution();
+  Problem problem(du, v);
+  problem =
+      2.0 * Integral(u * du, v)
+    + Integral(u * u, v)
+    + DirichletBC(du, Zero());
+
+  Rodin::Test::FDProbe probe(problem);
+  const auto direction = makeInteriorVertexDirection(mesh, problem);
+  ASSERT_GT(direction.norm(), 0.0);
+
+  const auto report = probe.test(direction, 1e-6);
+  EXPECT_LT(report.relativeError, 1e-6)
+    << "absoluteError = " << report.absoluteError
+    << ", tangentNorm = " << report.tangentNorm
+    << ", finiteDifferenceNorm = " << report.finiteDifferenceNorm;
+}

--- a/tests/unit/Rodin/Variational/GradTest.cpp
+++ b/tests/unit/Rodin/Variational/GradTest.cpp
@@ -1,4 +1,8 @@
 #include <gtest/gtest.h>
+
+#include <type_traits>
+#include <utility>
+
 #include "Rodin/Test/Random.h"
 
 #include "Rodin/Variational.h"
@@ -12,6 +16,33 @@ using namespace Rodin::Test::Random;
 
 namespace Rodin::Tests::Unit
 {
+  /// @brief Verifies that basis forwarding preserves cached references and values.
+  TEST(Rodin_Variational_Grad, ShapeFunctionBasisValueCategories)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+
+    P1 scalarP1(mesh);
+    TrialFunction scalarTrial(scalarP1);
+    using P1GradType = decltype(Grad(scalarTrial));
+    using P1GradBasisType = decltype(std::declval<const P1GradType&>().getBasis(0));
+    static_assert(std::is_lvalue_reference_v<P1GradBasisType>);
+    static_assert(std::is_const_v<std::remove_reference_t<P1GradBasisType>>);
+
+    P1 vectorP1(mesh, 2);
+    TrialFunction vectorTrial(vectorP1);
+    using P1JacobianType = decltype(Jacobian(vectorTrial));
+    using P1JacobianBasisType =
+      decltype(std::declval<const P1JacobianType&>().getBasis(0));
+    static_assert(std::is_lvalue_reference_v<P1JacobianBasisType>);
+    static_assert(std::is_const_v<std::remove_reference_t<P1JacobianBasisType>>);
+
+    P0 scalarP0(mesh);
+    TrialFunction p0Trial(scalarP0);
+    using P0GradType = decltype(Grad(p0Trial));
+    using P0GradBasisType = decltype(std::declval<const P0GradType&>().getBasis(0));
+    static_assert(!std::is_reference_v<P0GradBasisType>);
+  }
+
   /// @brief Verifies shape function construction for variational grad.
   TEST(Rodin_Variational_Grad, ShapeFunction_Construction)
   {

--- a/tests/unit/Rodin/Variational/GridFunctionTest.cpp
+++ b/tests/unit/Rodin/Variational/GridFunctionTest.cpp
@@ -2,6 +2,7 @@
 #include "Rodin/Test/Random.h"
 
 #include "Rodin/Variational.h"
+#include "Rodin/Variational/H1.h"
 
 using namespace Rodin;
 using namespace Rodin::IO;
@@ -11,6 +12,110 @@ using namespace Rodin::Test::Random;
 
 namespace Rodin::Tests::Unit
 {
+  class RangeTransformingSpace final
+    : public FiniteElementSpace<LocalMesh, RangeTransformingSpace>
+  {
+    public:
+      template <class Callable>
+      class Pushforward : public FiniteElementSpacePushforwardBase<Pushforward<Callable>>
+      {
+        public:
+          template <class Function>
+          Pushforward(Function&& function, size_t& evaluations)
+            : m_function(std::forward<Function>(function)),
+              m_evaluations(evaluations)
+          {}
+
+          Math::SpatialVector<Real> operator()(const Point& p) const
+          {
+            ++m_evaluations.get();
+            const auto value = m_function(p.getReferenceCoordinates());
+            Math::SpatialVector<Real> out(2);
+            out(0) = 2.0 * value(0) + value(1);
+            out(1) = -value(0) + 3.0 * value(1);
+            return out;
+          }
+
+        private:
+          Callable m_function;
+          std::reference_wrapper<size_t> m_evaluations;
+      };
+
+      explicit RangeTransformingSpace(const LocalMesh& mesh)
+        : m_mesh(mesh),
+          m_element(Polytope::Type::Triangle, 2)
+      {}
+
+      size_t getSize() const override
+      {
+        return 6;
+      }
+
+      size_t getVectorDimension() const override
+      {
+        return 2;
+      }
+
+      const LocalMesh& getMesh() const override
+      {
+        return m_mesh.get();
+      }
+
+      const P1Element<Math::SpatialVector<Real>>& getFiniteElement(size_t, Index) const
+      {
+        return m_element;
+      }
+
+      const IndexArray& getDOFs(size_t, Index) const override
+      {
+        static const IndexArray s_dofs{{0, 1, 2, 3, 4, 5}};
+        return s_dofs;
+      }
+
+      template <class Callable>
+      auto getPushforward(const std::pair<size_t, Index>&, Callable&& function) const
+      {
+        return Pushforward<Callable>(
+          std::forward<Callable>(function), m_pushforwardEvaluations);
+      }
+
+      size_t getPushforwardEvaluationCount() const
+      {
+        return m_pushforwardEvaluations;
+      }
+
+    private:
+      std::reference_wrapper<const LocalMesh> m_mesh;
+      P1Element<Math::SpatialVector<Real>> m_element;
+      mutable size_t m_pushforwardEvaluations = 0;
+  };
+
+  /// @brief Verifies that a nontrivial range pushforward is applied once to an expansion.
+  TEST(Rodin_Variational_FiniteElementSpace, RangeTransformingPushforwardIsApplied)
+  {
+    LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    RangeTransformingSpace fes(mesh);
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const std::array<Real, 6> coefficients{1.0, 2.0, 4.0, -1.0, 3.0, 5.0};
+    Math::SpatialVector<Real> value;
+
+    fes.evaluate(
+      value, {mesh.getDimension(), 0}, [&](size_t local) { return coefficients[local]; },
+      p);
+
+    const auto& fe = fes.getFiniteElement(mesh.getDimension(), 0);
+    Math::SpatialVector<Real> referenceValue;
+    fe.evaluate(
+      referenceValue, [&](size_t local) { return coefficients[local]; },
+      p.getReferenceCoordinates());
+    Math::SpatialVector<Real> expected(2);
+    expected(0) = 2.0 * referenceValue(0) + referenceValue(1);
+    expected(1) = -referenceValue(0) + 3.0 * referenceValue(1);
+    EXPECT_NEAR((value - expected).norm(), 0, 1e-14);
+    EXPECT_EQ(fes.getPushforwardEvaluationCount(), 1);
+  }
+
   /// @brief Verifies sanity test build for variational real P1 grid function by checking exact expected values.
   TEST(Rodin_Variational_Real_P1_GridFunction, SanityTest_Build)
   {
@@ -50,9 +155,9 @@ namespace Rodin::Tests::Unit
     RealFunction linear_func([](const Geometry::Point& p) { return p.x() + p.y(); });
     gf.project(linear_func);
 
-    // For P1 elements, a linear function should be represented exactly
-    // Check a few known values based on mesh structure
-    EXPECT_GT(gf.getSize(), 0);
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    EXPECT_NEAR(gf(p), p.x() + p.y(), 1e-12);
   }
 
   /// @brief Verifies arithmetic operations for variational real P1 grid function by checking tolerance-based numerical results.
@@ -175,6 +280,138 @@ namespace Rodin::Tests::Unit
     gf.project(vf);
 
     EXPECT_GT(gf.getSize(), 0);
+  }
+
+  /// @brief Verifies vector P1 grid-function evaluation at an interior cell point.
+  TEST(Rodin_Variational_Vector_P1_GridFunction, EvaluateAtCellInterior)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    P1 fes(mesh, 2);
+    GridFunction gf(fes);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + 2.0 * p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + p.x() + 3.0 * p.y(); }};
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto value = gf(p);
+
+    EXPECT_NEAR(value(0), 1.0 + 2.0 * p.x() - p.y(), 1e-12);
+    EXPECT_NEAR(value(1), -2.0 + p.x() + 3.0 * p.y(), 1e-12);
+  }
+
+  /// @brief Verifies scalar and vector P1 evaluation against mapped-basis expansion.
+  TEST(Rodin_Variational_P1_GridFunction, EvaluationMatchesMappedBasisExpansion)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, {2, 2, 2});
+    mesh.getConnectivity().compute(3, 2);
+    mesh.getConnectivity().compute(2, 1);
+    mesh.getConnectivity().compute(1, 0);
+    mesh.getConnectivity().compute(2, 0);
+    mesh.getConnectivity().compute(3, 0);
+    P1 scalarFES(mesh);
+    P1 vectorFES(mesh, 3);
+    GridFunction scalar(scalarFES);
+    GridFunction vector(vectorFES);
+
+    for (Index i = 0; i < scalar.getSize(); ++i)
+      scalar[i] = Real(0.25) + Real(0.5) * i;
+    for (Index i = 0; i < vector.getSize(); ++i)
+      vector[i] = Real(-0.75) + Real(0.125) * i;
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.17, 0.23, 0.19});
+
+    Real expectedScalar = 0;
+    const auto& scalarFE = scalarFES.getFiniteElement(3, cell->getIndex());
+    const auto& scalarDOFs = scalarFES.getDOFs(3, cell->getIndex());
+    for (size_t local = 0; local < scalarFE.getCount(); ++local)
+    {
+      const auto basis =
+        scalarFES.getPushforward({3, cell->getIndex()}, scalarFE.getBasis(local));
+      expectedScalar += scalar[scalarDOFs[local]] * basis(p);
+    }
+
+    Math::SpatialVector<Real> expectedVector;
+    const auto& vectorFE = vectorFES.getFiniteElement(3, cell->getIndex());
+    const auto& vectorDOFs = vectorFES.getDOFs(3, cell->getIndex());
+    for (size_t local = 0; local < vectorFE.getCount(); ++local)
+    {
+      const auto basis =
+        vectorFES.getPushforward({3, cell->getIndex()}, vectorFE.getBasis(local));
+      const auto term = vector[vectorDOFs[local]] * basis(p);
+      if (local == 0)
+        expectedVector = term;
+      else
+        expectedVector += term;
+    }
+
+    EXPECT_NEAR(scalar(p), expectedScalar, 1e-14);
+    EXPECT_NEAR((vector(p) - expectedVector).norm(), 0, 1e-14);
+  }
+
+  /// @brief Verifies scalar and vector P2 evaluation on a curved cell.
+  TEST(Rodin_Variational_H1_GridFunction, CurvedP2EvaluationMatchesMappedBasisExpansion)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    mesh.getConnectivity().compute(2, 1);
+    mesh.getConnectivity().compute(1, 0);
+
+    const auto cell = mesh.getCell(0);
+    RealH1Element<2> geometryFE(Polytope::Type::Triangle);
+    PointCloud nodes(2, geometryFE.getCount());
+    for (size_t local = 0; local < geometryFE.getCount(); ++local)
+    {
+      const auto& rc = geometryFE.getNode(local);
+      Math::SpatialPoint x;
+      cell->getTransformation().transform(x, rc);
+      bool isVertex = false;
+      const Polytope::Traits traits(Polytope::Type::Triangle);
+      for (size_t vertex = 0; vertex < traits.getVertexCount(); ++vertex)
+        isVertex = isVertex || (rc - traits.getVertex(vertex)).norm() < 1e-14;
+      if (!isVertex)
+        x(1) += 0.08;
+      nodes(0, local) = x(0);
+      nodes(1, local) = x(1);
+    }
+    mesh.setPolytopeTransformation({2, cell->getIndex()},
+      new ParametricTransformation<RealH1Element<2>>(std::move(nodes), geometryFE));
+
+    H1 scalarFES(std::integral_constant<size_t, 2>{}, mesh);
+    H1 vectorFES(std::integral_constant<size_t, 2>{}, mesh, size_t(2));
+    GridFunction scalar(scalarFES);
+    GridFunction vector(vectorFES);
+    for (Index i = 0; i < scalar.getSize(); ++i)
+      scalar[i] = Real(0.31) - Real(0.12) * i;
+    for (Index i = 0; i < vector.getSize(); ++i)
+      vector[i] = Real(-0.47) + Real(0.08) * i;
+
+    const Point p(*mesh.getCell(0), Math::SpatialPoint{0.23, 0.29});
+    const auto& scalarFE = scalarFES.getFiniteElement(2, cell->getIndex());
+    const auto& scalarDOFs = scalarFES.getDOFs(2, cell->getIndex());
+    Real expectedScalar = 0;
+    for (size_t local = 0; local < scalarFE.getCount(); ++local)
+    {
+      const auto basis =
+        scalarFES.getPushforward({2, cell->getIndex()}, scalarFE.getBasis(local));
+      expectedScalar += scalar[scalarDOFs[local]] * basis(p);
+    }
+
+    const auto& vectorFE = vectorFES.getFiniteElement(2, cell->getIndex());
+    const auto& vectorDOFs = vectorFES.getDOFs(2, cell->getIndex());
+    Math::SpatialVector<Real> expectedVector;
+    for (size_t local = 0; local < vectorFE.getCount(); ++local)
+    {
+      const auto basis =
+        vectorFES.getPushforward({2, cell->getIndex()}, vectorFE.getBasis(local));
+      const auto term = vector[vectorDOFs[local]] * basis(p);
+      if (local == 0)
+        expectedVector = term;
+      else
+        expectedVector += term;
+    }
+
+    EXPECT_NEAR(scalar(p), expectedScalar, 1e-13);
+    EXPECT_NEAR((vector(p) - expectedVector).norm(), 0, 1e-13);
   }
 
   /// @brief Verifies get value for variational real P1 grid function by checking tolerance-based numerical results.

--- a/tests/unit/Rodin/Variational/H1Test.cpp
+++ b/tests/unit/Rodin/Variational/H1Test.cpp
@@ -1909,6 +1909,77 @@ namespace Rodin::Tests::Unit
     testVectorGridFunction(H1(std::integral_constant<size_t, 6>{}, mesh, vdim));
   }
 
+  /// @brief Verifies scalar and vector H1 evaluation at an interior cell point.
+  TEST(Rodin_Variational_H1_Space, VectorGridFunctionEvaluationAtCellInterior)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    mesh.getConnectivity().compute(2, 1);
+    mesh.getConnectivity().compute(1, 0);
+
+    H1 fes(std::integral_constant<size_t, 2>{}, mesh, size_t(2));
+    H1 scalarFES(std::integral_constant<size_t, 2>{}, mesh);
+    GridFunction gf(fes);
+    GridFunction scalar(scalarFES);
+    gf = VectorFunction{[](const Point& p) { return 1.0 + 2.0 * p.x() - p.y(); },
+      [](const Point& p) { return -2.0 + p.x() + 3.0 * p.y(); }};
+    scalar = RealFunction([](const Point& p) { return 3.0 - p.x() + 2.0 * p.y(); });
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto value = gf(p);
+
+    EXPECT_NEAR(scalar(p), 3.0 - p.x() + 2.0 * p.y(), 1e-11);
+    EXPECT_NEAR(value(0), 1.0 + 2.0 * p.x() - p.y(), 1e-11);
+    EXPECT_NEAR(value(1), -2.0 + p.x() + 3.0 * p.y(), 1e-11);
+  }
+
+  /// @brief Verifies scalar and vector P2 evaluation against mapped-basis expansion.
+  TEST(Rodin_Variational_H1_Space, P2EvaluationMatchesMappedBasisExpansion)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    mesh.getConnectivity().compute(2, 1);
+    mesh.getConnectivity().compute(1, 0);
+
+    H1 scalarFES(std::integral_constant<size_t, 2>{}, mesh);
+    H1 vectorFES(std::integral_constant<size_t, 2>{}, mesh, size_t(2));
+    GridFunction scalar(scalarFES);
+    GridFunction vector(vectorFES);
+    for (Index i = 0; i < scalar.getSize(); ++i)
+      scalar[i] = Real(-0.5) + Real(0.17) * i;
+    for (Index i = 0; i < vector.getSize(); ++i)
+      vector[i] = Real(0.75) - Real(0.09) * i;
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.21, 0.34});
+
+    Real expectedScalar = 0;
+    const auto& scalarFE = scalarFES.getFiniteElement(2, cell->getIndex());
+    const auto& scalarDOFs = scalarFES.getDOFs(2, cell->getIndex());
+    for (size_t local = 0; local < scalarFE.getCount(); ++local)
+    {
+      const auto basis =
+        scalarFES.getPushforward({2, cell->getIndex()}, scalarFE.getBasis(local));
+      expectedScalar += scalar[scalarDOFs[local]] * basis(p);
+    }
+
+    Math::SpatialVector<Real> expectedVector;
+    const auto& vectorFE = vectorFES.getFiniteElement(2, cell->getIndex());
+    const auto& vectorDOFs = vectorFES.getDOFs(2, cell->getIndex());
+    for (size_t local = 0; local < vectorFE.getCount(); ++local)
+    {
+      const auto basis =
+        vectorFES.getPushforward({2, cell->getIndex()}, vectorFE.getBasis(local));
+      const auto term = vector[vectorDOFs[local]] * basis(p);
+      if (local == 0)
+        expectedVector = term;
+      else
+        expectedVector += term;
+    }
+
+    EXPECT_NEAR(scalar(p), expectedScalar, 1e-13);
+    EXPECT_NEAR((vector(p) - expectedVector).norm(), 0, 1e-13);
+  }
+
   // Vector H1 16x16 mesh test
   /// @brief Verifies vector H1 16 x 16 mesh K 1 to K 6 for variational H1 space by checking exact expected values.
   TEST(Rodin_Variational_H1_Space, VectorH1_16x16_Mesh_K1_to_K6)

--- a/tests/unit/Rodin/Variational/P0gTest.cpp
+++ b/tests/unit/Rodin/Variational/P0gTest.cpp
@@ -93,6 +93,27 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(dofs[1], 1);
   }
 
+  /// @brief Verifies scalar and vector P0g grid-function evaluation.
+  TEST(Rodin_Variational_P0g, GridFunctionEvaluation)
+  {
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
+    P0g scalarFES(mesh);
+    P0g<Math::SpatialVector<Real>, Geometry::Mesh<Context::Local>> vectorFES(mesh, 2);
+    GridFunction scalar(scalarFES);
+    GridFunction vector(vectorFES);
+    scalar = RealFunction(3.5);
+    vector.getData()(0) = -1.25;
+    vector.getData()(1) = 2.75;
+
+    const auto cell = mesh.getCell(0);
+    const Point p(*cell, Math::SpatialPoint{0.2, 0.3});
+    const auto value = vector(p);
+
+    EXPECT_NEAR(scalar(p), 3.5, 1e-14);
+    EXPECT_NEAR(value(0), -1.25, 1e-14);
+    EXPECT_NEAR(value(1), 2.75, 1e-14);
+  }
+
   // ---- P0g element properties ----
 
   /// @brief Verifies scalar element properties for variational P0 g by checking tolerance-based numerical results, exact expected values.


### PR DESCRIPTION
## Summary

- Add `Rodin::Test::FDProbe` for nonlinear variational problems and assembled linear systems.
- Add FDProbe unit coverage across element geometries, Dirichlet directions, wrong-tangent detection, and linear-system probing.
- Add manufactured Solid checks for Neo-Hookean and dynamic `ActiveContraction` internal virtual work tangents in 2D and 3D.
- Make `ActiveContractionPlaneWave` accept optional mesh resolution and time-step truncation for small 3D smoke runs while preserving the full default run.
- Fix local build issues around METIS/SuiteSparse component discovery and the CHOLMOD `LinearSystem` template type.

## Why

This gives us a reusable finite-difference probe for Jacobian/tangent systems and verifies that the assembled active-contraction tangent matches centered finite differences through the actual `Solid::InternalVirtualWork` path. The active tests zero the passive law and require a nonzero finite-difference response, so they exercise the active branch rather than passing through passive elasticity.

## Validation

- `./build/tests/unit/Rodin/Test/RodinTestFDProbeTest`
- `./build/tests/manufactured/Rodin/P1/RodinManufacturedP1HyperElasticity`
- `/Users/carlos/Projects/rodin/build/examples/Solid/RodinSolidActiveContractionPlaneWave 8 2` from a scratch `/tmp` directory
- `cmake --build build -j8`