### PR TITLE
Eliminate compile warnings across local and CI matrix builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,15 @@ rodin_add_compile_options(LANG C CXX OPTIONS -Wno-old-style-cast -Wno-deprecated
 rodin_add_compile_options(LANG C CXX OPTIONS -Wno-error=array-bounds)
 rodin_add_compile_options(LANG C CXX OPTIONS -Wno-error=nontrivial-memcall)
 
+# Apple's ld (Xcode >= 15) warns whenever a static library appears more than
+# once on the link line, which CMake's transitive component dependencies
+# produce by design. Silence it where the linker understands the flag.
+include(CheckLinkerFlag)
+check_linker_flag(CXX "-Wl,-no_warn_duplicate_libraries" RODIN_LINKER_NO_WARN_DUPLICATE_LIBRARIES)
+if(RODIN_LINKER_NO_WARN_DUPLICATE_LIBRARIES)
+  add_link_options(-Wl,-no_warn_duplicate_libraries)
+endif()
+
 add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 add_compile_definitions(__MAC_OS_X_VERSION_MIN_REQUIRED=__MAC_10_8)
 
@@ -318,6 +327,14 @@ if (RODIN_BUILD_SRC)
     # ---- GoogleTest ----
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     add_subdirectory(third-party/googletest EXCLUDE_FROM_ALL)
+    # GoogleTest builds itself with -Wall; GCC then flags gtest-death-test.cc
+    # with -Wmaybe-uninitialized. Vendored code, so silence instead of patch.
+    foreach(_gtest_target gtest gtest_main gmock gmock_main)
+      if(TARGET ${_gtest_target})
+        target_compile_options(${_gtest_target} PRIVATE
+          $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>)
+      endif()
+    endforeach()
     if (RODIN_BUILD_BENCHMARKS)
       if (RODIN_LTO)
         set(BENCHMARK_ENABLE_LTO ON CACHE BOOL "" FORCE)

--- a/src/Rodin/IO/MFEM.h
+++ b/src/Rodin/IO/MFEM.h
@@ -1192,7 +1192,7 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& V = VandermondeTriangle<K>::getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(V);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           s_inv = svd.solve(I);
         }
@@ -1431,7 +1431,7 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& V = VandermondeTetrahedron<K>::getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(V);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           s_inv = svd.solve(I);
         }
@@ -1615,7 +1615,7 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& C = WedgeChange<K>::getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(C, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(C);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(C.rows(), C.cols());
           s_inv = svd.solve(I);
         }

--- a/src/Rodin/IO/MFEM.h
+++ b/src/Rodin/IO/MFEM.h
@@ -1192,7 +1192,12 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& V = VandermondeTriangle<K>::getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(V);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(V);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           s_inv = svd.solve(I);
         }
@@ -1431,7 +1436,12 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& V = VandermondeTetrahedron<K>::getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(V);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(V);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           s_inv = svd.solve(I);
         }
@@ -1615,7 +1625,12 @@ namespace Rodin::IO::MFEM
         if (s_inv.size() == 0)
         {
           const auto& C = WedgeChange<K>::getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(C);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(C);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(C, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(C.rows(), C.cols());
           s_inv = svd.solve(I);
         }

--- a/src/Rodin/MMG/CMakeLists.txt
+++ b/src/Rodin/MMG/CMakeLists.txt
@@ -67,6 +67,15 @@ add_subdirectory(
 # - Mmg::libmmg3d_a
 # - Mmg::libmmgs_a
 
+# GCC enables -Wstringop-overflow by default; mmg trips it (e.g.
+# common/inout.c) and we do not patch vendored sources.
+foreach(_mmg_target libmmg_a libmmg2d_a libmmg3d_a libmmgs_a)
+  if(TARGET ${_mmg_target})
+    target_compile_options(${_mmg_target} PRIVATE
+      $<$<C_COMPILER_ID:GNU>:-Wno-stringop-overflow>)
+  endif()
+endforeach()
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(RODIN_MMG_VERBOSITY_LEVEL 1)
 else()

--- a/src/Rodin/MMG/MMG5.h
+++ b/src/Rodin/MMG/MMG5.h
@@ -229,7 +229,8 @@ namespace Rodin::MMG
         else if constexpr (std::is_same_v<Math::Vector<Real>, Range>)
         {
           assert(dst->type == MMG5_Vector);
-          const size_t vdim = src.getFiniteElementSpace().getVectorDimension();
+          [[maybe_unused]] const size_t vdim =
+            src.getFiniteElementSpace().getVectorDimension();
           assert(dst->size >= 0);
           assert(vdim == static_cast<size_t>(dst->size));
           const Math::Matrix<Real>& data = src.getData();

--- a/src/Rodin/MPI/Variational/P1/P1.h
+++ b/src/Rodin/MPI/Variational/P1/P1.h
@@ -521,7 +521,8 @@ namespace Rodin::Variational
               const Index global = m_offset + dofIdx;
               s_send.push_back(global);
 
-              const auto [it, inserted] = m_localToGlobal.right.emplace(global, local);
+              [[maybe_unused]] const auto [it, inserted] =
+                m_localToGlobal.right.emplace(global, local);
               assert(inserted);
 
               ++dofIdx;
@@ -576,9 +577,9 @@ namespace Rodin::Variational
             const auto& dofs = m_fes.getDOFs(0, *i);
             assert(dofs.size() == global.size());
 
-            for (size_t k = 0; k < global.size(); ++k)
+            for (size_t k = 0; k < static_cast<size_t>(global.size()); ++k)
             {
-              const auto [it, inserted] =
+              [[maybe_unused]] const auto [it, inserted] =
                 m_localToGlobal.right.emplace(global[k], dofs[k]);
               assert(inserted);
             }

--- a/src/Rodin/MPI/Variational/P1/P1.h
+++ b/src/Rodin/MPI/Variational/P1/P1.h
@@ -575,7 +575,7 @@ namespace Rodin::Variational
               continue;
 
             const auto& dofs = m_fes.getDOFs(0, *i);
-            assert(dofs.size() == global.size());
+            assert(static_cast<size_t>(dofs.size()) == global.size());
 
             for (size_t k = 0; k < static_cast<size_t>(global.size()); ++k)
             {

--- a/src/Rodin/Math/Matrix.h
+++ b/src/Rodin/Math/Matrix.h
@@ -76,6 +76,28 @@ namespace Rodin::Math
    */
   template <class ScalarType, size_t Rows, size_t Cols>
   using FixedSizeMatrix = Eigen::Matrix<ScalarType, Rows, Cols>;
+
+  /**
+   * @brief Bidiagonal divide-and-conquer SVD with thin unitaries.
+   *
+   * Wraps Eigen::BDCSVD with Eigen::ComputeThinU | Eigen::ComputeThinV,
+   * papering over the Eigen 3.4.90 move of the computation options from a
+   * constructor argument to a class template parameter.
+   *
+   * @tparam MatrixType The decomposed matrix type
+   */
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+  template <class MatrixType>
+  using ThinSVD = Eigen::BDCSVD<MatrixType, Eigen::ComputeThinU | Eigen::ComputeThinV>;
+#else
+  template <class MatrixType>
+  struct ThinSVD : public Eigen::BDCSVD<MatrixType>
+  {
+    ThinSVD(const MatrixType& matrix)
+      : Eigen::BDCSVD<MatrixType>(matrix, Eigen::ComputeThinU | Eigen::ComputeThinV)
+    {}
+  };
+#endif
 }
 
 namespace Rodin::FormLanguage

--- a/src/Rodin/Math/Matrix.h
+++ b/src/Rodin/Math/Matrix.h
@@ -76,33 +76,6 @@ namespace Rodin::Math
    */
   template <class ScalarType, size_t Rows, size_t Cols>
   using FixedSizeMatrix = Eigen::Matrix<ScalarType, Rows, Cols>;
-
-  /**
-   * @brief Bidiagonal divide-and-conquer SVD with thin unitaries.
-   *
-   * Wraps Eigen::BDCSVD with Eigen::ComputeThinU | Eigen::ComputeThinV,
-   * papering over the Eigen 3.4.90 move of the computation options from a
-   * constructor argument to a class template parameter.
-   *
-   * @tparam MatrixType The decomposed matrix type
-   */
-#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
-  template <class MatrixType>
-  using ThinSVD = Eigen::BDCSVD<MatrixType, Eigen::ComputeThinU | Eigen::ComputeThinV>;
-#else
-  template <class MatrixType>
-  struct ThinSVD : public Eigen::BDCSVD<MatrixType>
-  {
-      /**
-       * @brief Decomposes the given matrix with thin unitaries.
-       *
-       * @param[in] matrix Matrix to decompose
-       */
-      ThinSVD(const MatrixType& matrix)
-        : Eigen::BDCSVD<MatrixType>(matrix, Eigen::ComputeThinU | Eigen::ComputeThinV)
-      {}
-  };
-#endif
 }
 
 namespace Rodin::FormLanguage

--- a/src/Rodin/Math/Matrix.h
+++ b/src/Rodin/Math/Matrix.h
@@ -93,9 +93,14 @@ namespace Rodin::Math
   template <class MatrixType>
   struct ThinSVD : public Eigen::BDCSVD<MatrixType>
   {
-    ThinSVD(const MatrixType& matrix)
-      : Eigen::BDCSVD<MatrixType>(matrix, Eigen::ComputeThinU | Eigen::ComputeThinV)
-    {}
+      /**
+       * @brief Decomposes the given matrix with thin unitaries.
+       *
+       * @param[in] matrix Matrix to decompose
+       */
+      ThinSVD(const MatrixType& matrix)
+        : Eigen::BDCSVD<MatrixType>(matrix, Eigen::ComputeThinU | Eigen::ComputeThinV)
+      {}
   };
 #endif
 }

--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -81,7 +81,6 @@ namespace Rodin::Assembly
         const auto& fes = input.getFES();
         const auto& mesh = fes.getMesh();
         const auto& shard = mesh.getShard();
-        const auto& ctx = mesh.getContext();
         const size_t globalSize = fes.getSize();
 
         size_t begin, end;
@@ -193,7 +192,6 @@ namespace Rodin::Assembly
         assert(trialFES.getMesh() == testFES.getMesh());
         const auto& mesh = trialFES.getMesh();
         const auto& shard = mesh.getShard();
-        const auto& ctx = mesh.getContext();
 
         size_t rbegin, rend;
         testFES.getOwnershipRange(rbegin, rend);
@@ -238,10 +236,10 @@ namespace Rodin::Assembly
             const auto& rows = testFES.getDOFs(d, idx);
             const auto& cols = trialFES.getDOFs(d, idx);
 
-            for (Index i = 0; i < rows.size(); ++i)
+            for (Index i = 0; i < static_cast<Index>(rows.size()); ++i)
             {
               const PetscInt r = static_cast<PetscInt>(rows[i]);
-              for (Index j = 0; j < cols.size(); ++j)
+              for (Index j = 0; j < static_cast<Index>(cols.size()); ++j)
               {
                 const PetscInt c = static_cast<PetscInt>(cols[j]);
                 const PetscScalar v = bfi.integrate(j, i);
@@ -373,7 +371,6 @@ namespace Rodin::Assembly
 
         const auto& mesh  = trialFES.getMesh();
         const auto& shard = mesh.getShard();
-        const auto& ctx   = mesh.getContext();
 
         const size_t globalCols = trialFES.getSize();
         const size_t globalRows = testFES.getSize();
@@ -454,7 +451,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(masters[k]),
@@ -557,10 +554,10 @@ namespace Rodin::Assembly
               const auto& rowsDOF = testFES.getDOFs(d, idx);
               const auto& colsDOF = trialFES.getDOFs(d, idx);
 
-              for (Index i = 0; i < rowsDOF.size(); ++i)
+              for (Index i = 0; i < static_cast<Index>(rowsDOF.size()); ++i)
               {
                 const PetscInt I = rowsDOF[i];
-                for (Index j = 0; j < colsDOF.size(); ++j)
+                for (Index j = 0; j < static_cast<Index>(colsDOF.size()); ++j)
                 {
                   const PetscInt J = colsDOF[j];
                   const PetscScalar val = bfi.integrate(j, i);
@@ -618,10 +615,10 @@ namespace Rodin::Assembly
 
                 bfi.setPolytope(*trIt, *teIt);
 
-                for (Index i = 0; i < rowsDOF.size(); ++i)
+                for (Index i = 0; i < static_cast<Index>(rowsDOF.size()); ++i)
                 {
                   const PetscInt I = rowsDOF[i];
-                  for (Index j = 0; j < colsDOF.size(); ++j)
+                  for (Index j = 0; j < static_cast<Index>(colsDOF.size()); ++j)
                   {
                     const PetscInt J = colsDOF[j];
                     const PetscScalar val = bfi.integrate(j, i);
@@ -697,7 +694,7 @@ namespace Rodin::Assembly
               lfi.setPolytope(*it);
 
               const auto& dofs = testFES.getDOFs(d, idx);
-              for (Index l = 0; l < dofs.size(); ++l)
+              for (Index l = 0; l < static_cast<Index>(dofs.size()); ++l)
               {
                 const PetscInt I = dofs[l];
                 const PetscScalar val = lfi.integrate(l);
@@ -1131,7 +1128,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
@@ -1262,10 +1259,10 @@ namespace Rodin::Assembly
               const auto& rows = vFES.getDOFs(d, idx);
               const auto& cols = uFES.getDOFs(d, idx);
 
-              for (Index i = 0; i < rows.size(); ++i)
+              for (Index i = 0; i < static_cast<Index>(rows.size()); ++i)
               {
                 const PetscInt I = vOff + rows[i];
-                for (Index j = 0; j < cols.size(); ++j)
+                for (Index j = 0; j < static_cast<Index>(cols.size()); ++j)
                 {
                   const PetscInt J = uOff + cols[j];
                   const PetscScalar val = bfi.integrate(j, i);
@@ -1329,10 +1326,10 @@ namespace Rodin::Assembly
 
                 bfi.setPolytope(*trIt, *teIt);
 
-                for (Index i = 0; i < rows.size(); ++i)
+                for (Index i = 0; i < static_cast<Index>(rows.size()); ++i)
                 {
                   const PetscInt I = vOff + rows[i];
-                  for (Index j = 0; j < cols.size(); ++j)
+                  for (Index j = 0; j < static_cast<Index>(cols.size()); ++j)
                   {
                     const PetscInt J = uOff + cols[j];
                     const PetscScalar val = bfi.integrate(j, i);
@@ -1424,7 +1421,7 @@ namespace Rodin::Assembly
               lfi.setPolytope(*it);
 
               const auto& dofs = vFES.getDOFs(d, idx);
-              for (Index l = 0; l < dofs.size(); ++l)
+              for (Index l = 0; l < static_cast<Index>(dofs.size()); ++l)
               {
                 const PetscInt I = vOff + dofs[l];
                 const PetscScalar val = lfi.integrate(l);

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -146,7 +146,7 @@ namespace Rodin::Assembly
               integrator->setPolytope(polytope);
 
               const auto& dofs = input.getFES().getDOFs(dim, i);
-              for (size_t k = 0; k < dofs.size(); ++k)
+              for (size_t k = 0; k < static_cast<size_t>(dofs.size()); ++k)
               {
                 const PetscScalar value = PetscScalar(integrator->integrate(k));
                 if (value != PetscScalar(0))
@@ -365,8 +365,8 @@ namespace Rodin::Assembly
 
               const auto& rows = input.getTestFES().getDOFs(dim, i);
               const auto& cols = input.getTrialFES().getDOFs(dim, i);
-              for (size_t r = 0; r < rows.size(); ++r)
-                for (size_t c = 0; c < cols.size(); ++c)
+              for (size_t r = 0; r < static_cast<size_t>(rows.size()); ++r)
+                for (size_t c = 0; c < static_cast<size_t>(cols.size()); ++c)
                 {
                   const PetscScalar v = Math::conj(integrator->integrate(c, r));
                   local.emplace_back(
@@ -439,8 +439,8 @@ namespace Rodin::Assembly
                 integrator->setPolytope(trialPolytope, testPolytope);
 
                 const auto& cols = input.getTrialFES().getDOFs(rdim, tr);
-                for (size_t r = 0; r < rows.size(); ++r)
-                  for (size_t c = 0; c < cols.size(); ++c)
+                for (size_t r = 0; r < static_cast<size_t>(rows.size()); ++r)
+                  for (size_t c = 0; c < static_cast<size_t>(cols.size()); ++c)
                   {
                     const PetscScalar v = Math::conj(integrator->integrate(c, r));
                     local.emplace_back(
@@ -686,7 +686,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(masters[k]),
@@ -1523,7 +1523,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(vOff + static_cast<size_t>(masters[k])),

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -1447,7 +1447,7 @@ namespace Rodin::Assembly
         const auto withTrialFES = [&](const auto& uuid, auto&& fn)
         {
           const size_t k = findTrialBlock(uuid);
-          bool found = false;
+          [[maybe_unused]] bool found = false;
           us.iapply([&](size_t i, const auto& uref)
           {
             if (i == k)
@@ -1462,7 +1462,7 @@ namespace Rodin::Assembly
         const auto withTestFES = [&](const auto& uuid, auto&& fn)
         {
           const size_t k = findTestBlock(uuid);
-          bool found = false;
+          [[maybe_unused]] bool found = false;
           vs.iapply([&](size_t i, const auto& vref)
           {
             if (i == k)

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -430,7 +430,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(masters[k]),
@@ -1051,7 +1051,7 @@ namespace Rodin::Assembly
                 const auto& coeffs = pair.second;
                 std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
                 entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < masters.size(); k++)
+                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
                 {
                   entries.push_back({
                       static_cast<Index>(vOff + static_cast<size_t>(masters[k])),

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -975,7 +975,7 @@ namespace Rodin::Assembly
         const auto withTrialFES = [&](const auto& uuid, auto&& fn)
         {
           const size_t k = findTrialBlock(uuid);
-          bool found = false;
+          [[maybe_unused]] bool found = false;
           us.iapply([&](size_t i, const auto& uref)
           {
             if (i == k)
@@ -990,7 +990,7 @@ namespace Rodin::Assembly
         const auto withTestFES = [&](const auto& uuid, auto&& fn)
         {
           const size_t k = findTestBlock(uuid);
-          bool found = false;
+          [[maybe_unused]] bool found = false;
           vs.iapply([&](size_t i, const auto& vref)
           {
             if (i == k)

--- a/src/Rodin/PETSc/IO/HDF5.h
+++ b/src/Rodin/PETSc/IO/HDF5.h
@@ -183,7 +183,7 @@ namespace Rodin::IO
         auto& vec = gf.getData();
 
         PetscInt rb = 0, re = 0;
-        auto ierr = VecGetOwnershipRange(vec, &rb, &re);
+        [[maybe_unused]] auto ierr = VecGetOwnershipRange(vec, &rb, &re);
         assert(ierr == PETSC_SUCCESS);
         const PetscInt localN = re - rb;
 
@@ -280,7 +280,7 @@ namespace Rodin::IO
         const auto& vec = gf.getData();
 
         PetscInt rb = 0, re = 0;
-        auto ierr = VecGetOwnershipRange(vec, &rb, &re);
+        [[maybe_unused]] auto ierr = VecGetOwnershipRange(vec, &rb, &re);
         assert(ierr == PETSC_SUCCESS);
         const PetscInt localN = re - rb;
 

--- a/src/Rodin/PETSc/IO/MFEM.h
+++ b/src/Rodin/PETSc/IO/MFEM.h
@@ -87,7 +87,6 @@ namespace Rodin::IO
         // Base prints Ordering: Nodes, but for P0 that’s effectively "block by component":
         // emit all scalar dofs for comp 0, then comp 1, ...
         const size_t vdim = fes.getVectorDimension();
-        const size_t D    = mesh.getDimension();
 
         const size_t totalSize  = fes.getSize();
         const size_t scalarSize = totalSize / vdim;

--- a/src/Rodin/PETSc/Object.h
+++ b/src/Rodin/PETSc/Object.h
@@ -46,7 +46,8 @@ namespace Rodin::PETSc
        */
       void getComm(MPI_Comm* comm) const
       {
-        PetscErrorCode ierr = PetscObjectGetComm(reinterpret_cast<PetscObject&>(this->getHandle()), comm);
+        [[maybe_unused]] PetscErrorCode ierr =
+          PetscObjectGetComm(reinterpret_cast<PetscObject&>(this->getHandle()), comm);
         assert(ierr == PETSC_SUCCESS);
       }
 

--- a/src/Rodin/PETSc/Variational/GridFunction.h
+++ b/src/Rodin/PETSc/Variational/GridFunction.h
@@ -345,7 +345,7 @@ namespace Rodin::Variational
           for (const auto& [global, offset] : m_ghosts.right)
           {
             assert(offset >= 0);
-            assert(offset < m_ghosts.left.size());
+            assert(static_cast<size_t>(offset) < m_ghosts.left.size());
             m_ghosts.left[offset] = global;
           }
 

--- a/src/Rodin/PETSc/Variational/GridFunction.h
+++ b/src/Rodin/PETSc/Variational/GridFunction.h
@@ -335,7 +335,8 @@ namespace Rodin::Variational
             const Index global = fes.getGlobalIndex(i);
             if (global < m_begin || global >= m_end)
             {
-              auto [it, inserted] = m_ghosts.right.emplace(global, offset);
+              [[maybe_unused]] auto [it, inserted] =
+                m_ghosts.right.emplace(global, offset);
               assert(inserted);
               offset++;
             }

--- a/src/Rodin/Types.h
+++ b/src/Rodin/Types.h
@@ -27,6 +27,13 @@
 #include <bitset>
 #include <optional>
 
+// GCC's -Warray-bounds falsely fires inside Boost.Container's flat
+// containers at -O2 (diagnostic is attributed to the Boost headers, so it
+// must be suppressed around the includes rather than at the call sites).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include <boost/unordered_map.hpp>
 #include <boost/container/map.hpp>
 #include <boost/unordered_set.hpp>
@@ -34,6 +41,9 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/container/deque.hpp>
 #include <boost/container/list.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <Eigen/Core>
 

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -1490,7 +1490,7 @@ namespace Rodin::Variational
       GridFunction& setData(const DataType& data, size_t offset = 0)
       {
         const auto sz = this->getFiniteElementSpace().getSize();
-        assert(offset + static_cast<size_t>(sz) <= data.size());
+        assert(offset + static_cast<size_t>(sz) <= static_cast<size_t>(data.size()));
         this->getData() = data.segment(offset, sz);
         return *this;
       }

--- a/src/Rodin/Variational/H1/Dubiner.h
+++ b/src/Rodin/Variational/H1/Dubiner.h
@@ -213,7 +213,7 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTriangle<K>::getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(V);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();
@@ -401,7 +401,7 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTetrahedron<K>::getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(V);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();

--- a/src/Rodin/Variational/H1/Dubiner.h
+++ b/src/Rodin/Variational/H1/Dubiner.h
@@ -213,7 +213,12 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTriangle<K>::getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(V);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(V);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();
@@ -401,7 +406,12 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = VandermondeTetrahedron<K>::getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(V);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(V);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();

--- a/src/Rodin/Variational/H1/H1Element.hpp
+++ b/src/Rodin/Variational/H1/H1Element.hpp
@@ -257,7 +257,7 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = getMatrix();
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Math::ThinSVD<Math::Matrix<Real>> svd(V);
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();

--- a/src/Rodin/Variational/H1/H1Element.hpp
+++ b/src/Rodin/Variational/H1/H1Element.hpp
@@ -257,7 +257,12 @@ namespace Rodin::Variational
       {
         static const Math::Matrix<Real> s_inv = [] {
           const auto& V = getMatrix();
-          Math::ThinSVD<Math::Matrix<Real>> svd(V);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+          Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
+            svd(V);
+#else
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
         }();

--- a/tests/manufactured/Rodin/MPI/H1/PoissonTest.cpp
+++ b/tests/manufactured/Rodin/MPI/H1/PoissonTest.cpp
@@ -176,7 +176,6 @@ namespace
       Mesh<Context::MPI>&& mesh)
   {
     const auto& comm = ctx.getCommunicator();
-    const size_t D = mesh.getDimension();
 
     const boost::filesystem::path rankFile =
         boost::filesystem::temp_directory_path()

--- a/tests/manufactured/Rodin/P1/Conductivity.cpp
+++ b/tests/manufactured/Rodin/P1/Conductivity.cpp
@@ -246,7 +246,6 @@ namespace Rodin::Tests::Manufactured::Conductivity
    */
   TEST(Rodin_Manufactured_P1, Conductivity_Exponential)
   {
-    auto pi = Rodin::Math::Constants::pi();
 
     Mesh mesh;
     mesh = mesh.UniformGrid(Polytope::Type::Quadrilateral, {16,16});

--- a/tests/manufactured/Rodin/P1/Conductivity.cpp
+++ b/tests/manufactured/Rodin/P1/Conductivity.cpp
@@ -246,7 +246,6 @@ namespace Rodin::Tests::Manufactured::Conductivity
    */
   TEST(Rodin_Manufactured_P1, Conductivity_Exponential)
   {
-
     Mesh mesh;
     mesh = mesh.UniformGrid(Polytope::Type::Quadrilateral, {16,16});
     mesh.scale(1.0/15);

--- a/tests/unit/Rodin/Geometry/PointTest.cpp
+++ b/tests/unit/Rodin/Geometry/PointTest.cpp
@@ -530,7 +530,6 @@ TEST(Geometry_Point, SetPolytope)
   rc[1] = 0.5;
 
   Point p(tri, rc);
-  Real x_orig = p.x();
 
   // Set to same polytope
   p.setPolytope(tri);

--- a/tests/unit/Rodin/Variational/H1/DubinerTest.cpp
+++ b/tests/unit/Rodin/Variational/H1/DubinerTest.cpp
@@ -180,9 +180,9 @@ namespace Rodin::Tests::Unit
 
     auto I = V * Vinv;
 
-    for (size_t i = 0; i < V.rows(); ++i)
+    for (size_t i = 0; i < static_cast<size_t>(V.rows()); ++i)
     {
-      for (size_t j = 0; j < V.cols(); ++j)
+      for (size_t j = 0; j < static_cast<size_t>(V.cols()); ++j)
       {
         Real expected = (i == j) ? 1.0 : 0.0;
         EXPECT_NEAR(I(i, j), expected, 1e-10);
@@ -198,9 +198,9 @@ namespace Rodin::Tests::Unit
 
     auto I = V * Vinv;
 
-    for (size_t i = 0; i < V.rows(); ++i)
+    for (size_t i = 0; i < static_cast<size_t>(V.rows()); ++i)
     {
-      for (size_t j = 0; j < V.cols(); ++j)
+      for (size_t j = 0; j < static_cast<size_t>(V.cols()); ++j)
       {
         Real expected = (i == j) ? 1.0 : 0.0;
         EXPECT_NEAR(I(i, j), expected, 1e-9);
@@ -348,9 +348,9 @@ namespace Rodin::Tests::Unit
 
     auto I = V * Vinv;
 
-    for (size_t i = 0; i < V.rows(); ++i)
+    for (size_t i = 0; i < static_cast<size_t>(V.rows()); ++i)
     {
-      for (size_t j = 0; j < V.cols(); ++j)
+      for (size_t j = 0; j < static_cast<size_t>(V.cols()); ++j)
       {
         Real expected = (i == j) ? 1.0 : 0.0;
         EXPECT_NEAR(I(i, j), expected, 1e-10);
@@ -403,9 +403,9 @@ namespace Rodin::Tests::Unit
 
     auto I = V * Vinv;
 
-    for (size_t i = 0; i < V.rows(); ++i)
+    for (size_t i = 0; i < static_cast<size_t>(V.rows()); ++i)
     {
-      for (size_t j = 0; j < V.cols(); ++j)
+      for (size_t j = 0; j < static_cast<size_t>(V.cols()); ++j)
       {
         Real expected = (i == j) ? 1.0 : 0.0;
         EXPECT_NEAR(I(i, j), expected, 1e-8);
@@ -457,9 +457,9 @@ namespace Rodin::Tests::Unit
 
     auto I = V * Vinv;
 
-    for (size_t i = 0; i < V.rows(); ++i)
+    for (size_t i = 0; i < static_cast<size_t>(V.rows()); ++i)
     {
-      for (size_t j = 0; j < V.cols(); ++j)
+      for (size_t j = 0; j < static_cast<size_t>(V.cols()); ++j)
       {
         Real expected = (i == j) ? 1.0 : 0.0;
         EXPECT_NEAR(I(i, j), expected, 1e-8);

--- a/tests/unit/Rodin/Variational/H1Test.cpp
+++ b/tests/unit/Rodin/Variational/H1Test.cpp
@@ -172,7 +172,6 @@ namespace Rodin::Tests::Unit
   {
     // 1 element mesh, triangle with vertices (0,0), (1,0), (0,1)
     constexpr size_t sdim = 2;
-    constexpr size_t mdim = 2;
 
     Mesh mesh =
       Mesh<Rodin::Context::Local>::Builder()
@@ -1361,7 +1360,7 @@ namespace Rodin::Tests::Unit
 
         // Count interior DOFs on the edge = edge DOFs minus vertex DOFs
         size_t interiorCount = 0;
-        for (Index k = 0; k < dofs_e.size(); ++k)
+        for (Index k = 0; k < static_cast<Index>(dofs_e.size()); ++k)
         {
           if (vertexDOFs.count(dofs_e(k)) == 0)
             ++interiorCount;

--- a/tests/unit/Rodin/Variational/IntegralTest.cpp
+++ b/tests/unit/Rodin/Variational/IntegralTest.cpp
@@ -136,7 +136,7 @@ namespace Rodin::Tests::Unit
     EXPECT_EQ(op.rows(), op.cols());
 
     // Mass matrix should be positive definite (diagonal entries positive)
-    for (Index i = 0; i < op.rows(); i++)
+    for (Index i = 0; i < static_cast<Index>(op.rows()); i++)
     {
       EXPECT_GT(op.coeff(i, i), 0.0);
     }
@@ -261,7 +261,7 @@ namespace Rodin::Tests::Unit
     EXPECT_GT(op.cols(), 0);
 
     // All diagonal entries should be positive
-    for (Index i = 0; i < op.rows(); i++)
+    for (Index i = 0; i < static_cast<Index>(op.rows()); i++)
     {
       EXPECT_GT(op.coeff(i, i), 0.0);
     }

--- a/tests/unit/Rodin/Variational/TrialFunctionTest.cpp
+++ b/tests/unit/Rodin/Variational/TrialFunctionTest.cpp
@@ -60,8 +60,8 @@ namespace Rodin::Tests::Unit
     P1 fes(mesh);
     TrialFunction u(fes);
 
-    const auto& solution = u.getSolution();
-    auto& mutable_solution = u.getSolution();
+    [[maybe_unused]] const auto& solution = u.getSolution();
+    [[maybe_unused]] auto& mutable_solution = u.getSolution();
     
   }
 
@@ -124,6 +124,6 @@ namespace Rodin::Tests::Unit
     P1 fes(mesh, vdim);
     TrialFunction u(fes);
 
-    const auto& solution = u.getSolution();
+    [[maybe_unused]] const auto& solution = u.getSolution();
   }
 }

--- a/tests/unit/Rodin/Variational/TrialFunctionTest.cpp
+++ b/tests/unit/Rodin/Variational/TrialFunctionTest.cpp
@@ -62,7 +62,6 @@ namespace Rodin::Tests::Unit
 
     [[maybe_unused]] const auto& solution = u.getSolution();
     [[maybe_unused]] auto& mutable_solution = u.getSolution();
-    
   }
 
   /// @brief Verifies sanity test build for variational vector P1 trial function by checking exact expected values.

--- a/tests/unit/Rodin/Variational/VectorFunctionTest.cpp
+++ b/tests/unit/Rodin/Variational/VectorFunctionTest.cpp
@@ -228,7 +228,6 @@ namespace Rodin::Tests::Unit
     // Create a boundary point for testing
     auto it = mesh.getPolytope(D - 1, 0);
     const auto& polytope = *it;
-    const auto& trans = mesh.getPolytopeTransformation(D - 1, 0);
     const Math::Vector<Real> rc{{0.5}};
     Point p(polytope, rc);
     auto value = vf.getValue(p);


### PR DESCRIPTION
Goal: zero compile warnings on `develop`, both locally (AppleClang) and across the CI matrix (Build: gcc-12 Ubuntu + AppleClang macOS × Release/Debug × MT × MPI × PETSc; Tests: gcc-14).

## Warning inventory (harvested from develop@463f594 CI logs, 32 Build jobs + Tests jobs)

**Library (`src/`)**
- Eigen `BDCSVD` deprecation (AppleClang, new Eigen): `IO/MFEM.h` ×3, `Variational/H1/H1Element.hpp`, `Variational/H1/Dubiner.h` ×2 → new version-portable `Math::ThinSVD` alias.
- `-Wsign-compare` (gcc-14): Eigen `IndexArray::size()` (signed) vs `Rodin::Index`/`size_t` loops in `PETSc/Assembly/{MPI,OpenMP,Sequential}.h`, `PETSc/Variational/GridFunction.h`, `Variational/GridFunction.h`, `MPI/Variational/P1/P1.h` → `static_cast` at the comparison.
- `-Wunused-variable` / `-Wunused-but-set-variable` (Release, assert-only reads): dead `ctx` locals removed in `PETSc/Assembly/MPI.h`; `[[maybe_unused]]` on `ierr` in `PETSc/IO/HDF5.h` and structured bindings in `MPI/Variational/P1/P1.h` (keeps the `assert(ierr == PETSC_SUCCESS)` idiom).

**Tests**
- Dead locals deleted (`D`, `pi`, `x_orig`, `mdim`, `trans`); intentional getter-exercise vars in `TrialFunctionTest` marked `[[maybe_unused]]`; sign-compare loops cast in `DubinerTest`, `H1Test`, `IntegralTest`.

**Third-party (vendored, not patched)**
- googletest `-Wmaybe-uninitialized` (gcc, gtest builds itself with -Wall) → per-target `-Wno-maybe-uninitialized`.
- mmg `-Wstringop-overflow` (on by default in GCC) → per-target `-Wno-stringop-overflow`.

**Linker (macOS, Xcode ≥ 15)**
- `ld: ignoring duplicate libraries` (~430 occurrences/job, from transitive component deps) → `-Wl,-no_warn_duplicate_libraries` behind `check_linker_flag`.

## Verification
- [ ] Clean local AppleClang build (library + examples + tests)
- [ ] Green CI on this PR with zero `warning:` lines in Build + Tests logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)