### PR TITLE
Format develop backlog to .clang-format (unblocks develop→master #317)

### DIFF
--- a/examples/Geometry/LevelSetWNGIRAdvection.cpp
+++ b/examples/Geometry/LevelSetWNGIRAdvection.cpp
@@ -77,9 +77,7 @@ namespace
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const LocalMesh& mesh,
-      LocalMesh& moved,
-      const Displacement& u)
+    const LocalMesh& mesh, LocalMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -110,10 +108,9 @@ namespace
         pm(0, a) = X(0) + ux;
         pm(1, a) = X(1) + uy;
       }
-      moved.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      moved.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
 #endif
   }
@@ -134,127 +131,123 @@ namespace
   // -------------------------------------------------------------------------
   struct WavyCircleLevelSet
   {
-    Real cx = Real(0.5);
-    Real cy = Real(0.5);
-    Real R0 = Real(0.18);
-    Real amp = Real(0.04);
-    Real k = Real(5);
-    Real phase = Real(0);
+      Real cx = Real(0.5);
+      Real cy = Real(0.5);
+      Real R0 = Real(0.18);
+      Real amp = Real(0.04);
+      Real k = Real(5);
+      Real phase = Real(0);
 
-    Real phi(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r = std::sqrt(dx * dx + dy * dy);
-      const Real theta = std::atan2(dy, dx);
-      const Real R = R0 + amp * std::cos(k * theta + phase);
-      return r - R;
-    }
+      Real phi(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r = std::sqrt(dx * dx + dy * dy);
+        const Real theta = std::atan2(dy, dx);
+        const Real R = R0 + amp * std::cos(k * theta + phase);
+        return r - R;
+      }
 
     // grad phi = (dx/r, dy/r) - dR/dtheta * grad(theta).
     // grad(theta) = (-dy / r^2, dx / r^2).
-    Vec2 grad(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r2 = dx * dx + dy * dy;
-      const Real r = std::max(std::sqrt(r2), Real(1e-14));
-      const Real theta = std::atan2(dy, dx);
-      const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
-      const Real r2safe = std::max(r2, Real(1e-28));
-      return vec2(
-          dx / r - dRdtheta * (-dy / r2safe),
-          dy / r - dRdtheta * ( dx / r2safe));
-    }
+      Vec2 grad(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r2 = dx * dx + dy * dy;
+        const Real r = std::max(std::sqrt(r2), Real(1e-14));
+        const Real theta = std::atan2(dy, dx);
+        const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
+        const Real r2safe = std::max(r2, Real(1e-28));
+        return vec2(
+          dx / r - dRdtheta * (-dy / r2safe), dy / r - dRdtheta * (dx / r2safe));
+      }
 
-    // Hess phi = Hess(r) - R'(theta) Hess(theta) - R''(theta) grad(theta) grad(theta)^T.
-    //
-    //   Hess(r)_ij = (delta_ij - dx_i dx_j / r^2) / r,
-    //
-    //   grad(theta) = (-dy, dx) / r^2,
-    //
-    //   Hess(theta)_xx = 2 dx dy / r^4,
-    //   Hess(theta)_yy = -2 dx dy / r^4,
-    //   Hess(theta)_xy = (dy^2 - dx^2) / r^4.
-    //
-    // Consumed by the PSD-projected full-Newton tangent.
-    Math::SpatialMatrix<Real> hess(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r2 = dx * dx + dy * dy;
-      const Real r = std::max(std::sqrt(r2), Real(1e-14));
-      const Real r3 = r * r * r;
-      const Real r4 = r2 * r2;
+      // Hess phi = Hess(r) - R'(theta) Hess(theta) - R''(theta) grad(theta) grad(theta)^T.
+      //
+      //   Hess(r)_ij = (delta_ij - dx_i dx_j / r^2) / r,
+      //
+      //   grad(theta) = (-dy, dx) / r^2,
+      //
+      //   Hess(theta)_xx = 2 dx dy / r^4,
+      //   Hess(theta)_yy = -2 dx dy / r^4,
+      //   Hess(theta)_xy = (dy^2 - dx^2) / r^4.
+      //
+      // Consumed by the PSD-projected full-Newton tangent.
+      Math::SpatialMatrix<Real> hess(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r2 = dx * dx + dy * dy;
+        const Real r = std::max(std::sqrt(r2), Real(1e-14));
+        const Real r3 = r * r * r;
+        const Real r4 = r2 * r2;
 
-      const Real theta = std::atan2(dy, dx);
-      const Real ka = k * theta + phase;
-      const Real Rpp = -amp * k * std::sin(ka);
-      const Real Rpp2 = -amp * k * k * std::cos(ka);
+        const Real theta = std::atan2(dy, dx);
+        const Real ka = k * theta + phase;
+        const Real Rpp = -amp * k * std::sin(ka);
+        const Real Rpp2 = -amp * k * k * std::cos(ka);
 
-      // Hess(r)
-      Math::SpatialMatrix<Real> Hr(2, 2);
-      Hr(0, 0) = (Real(1) - dx * dx / r2) / r;   // = dy^2 / r^3
-      Hr(1, 1) = (Real(1) - dy * dy / r2) / r;
-      Hr(0, 1) = -dx * dy / r3;
-      Hr(1, 0) = Hr(0, 1);
+        // Hess(r)
+        Math::SpatialMatrix<Real> Hr(2, 2);
+        Hr(0, 0) = (Real(1) - dx * dx / r2) / r; // = dy^2 / r^3
+        Hr(1, 1) = (Real(1) - dy * dy / r2) / r;
+        Hr(0, 1) = -dx * dy / r3;
+        Hr(1, 0) = Hr(0, 1);
 
-      // Hess(theta)
-      Math::SpatialMatrix<Real> Ht(2, 2);
-      Ht(0, 0) =  Real(2) * dx * dy / r4;
-      Ht(1, 1) = -Real(2) * dx * dy / r4;
-      Ht(0, 1) = (dy * dy - dx * dx) / r4;
-      Ht(1, 0) = Ht(0, 1);
+        // Hess(theta)
+        Math::SpatialMatrix<Real> Ht(2, 2);
+        Ht(0, 0) = Real(2) * dx * dy / r4;
+        Ht(1, 1) = -Real(2) * dx * dy / r4;
+        Ht(0, 1) = (dy * dy - dx * dx) / r4;
+        Ht(1, 0) = Ht(0, 1);
 
-      // grad(theta) outer product
-      const Vec2 gth = vec2(-dy / r2, dx / r2);
-      Math::SpatialMatrix<Real> GG(2, 2);
-      GG(0, 0) = gth(0) * gth(0);
-      GG(0, 1) = gth(0) * gth(1);
-      GG(1, 0) = GG(0, 1);
-      GG(1, 1) = gth(1) * gth(1);
+        // grad(theta) outer product
+        const Vec2 gth = vec2(-dy / r2, dx / r2);
+        Math::SpatialMatrix<Real> GG(2, 2);
+        GG(0, 0) = gth(0) * gth(0);
+        GG(0, 1) = gth(0) * gth(1);
+        GG(1, 0) = GG(0, 1);
+        GG(1, 1) = gth(1) * gth(1);
 
-      Math::SpatialMatrix<Real> H(2, 2);
-      H = Hr - Rpp * Ht - Rpp2 * GG;
-      return H;
-    }
+        Math::SpatialMatrix<Real> H(2, 2);
+        H = Hr - Rpp * Ht - Rpp2 * GG;
+        return H;
+      }
   };
 
   // -------------------------------------------------------------------------
   // Triangle-barycentric quadrature for the phase moments (triangle-only,
   // NOT FES-independent — same caveat as the parent example).
   // -------------------------------------------------------------------------
-  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {{
-    {{ Real(2) / 3, Real(1) / 6, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(2) / 3, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(1) / 6, Real(2) / 3 }}
-  }};
+  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {
+    {{{Real(2) / 3, Real(1) / 6, Real(1) / 6}}, {{Real(1) / 6, Real(2) / 3, Real(1) / 6}},
+      {{Real(1) / 6, Real(1) / 6, Real(2) / 3}}}};
 
   Real applyPhaseMomentMap(Real phi, Real epsilon)
   {
     return std::tanh(phi / epsilon);
   }
 
-  Vec2 interpolateVec(const std::array<Vec2, 3>& values,
-                      const std::array<Real, 3>& bary)
+  Vec2 interpolateVec(const std::array<Vec2, 3>& values, const std::array<Real, 3>& bary)
   {
     return bary[0] * values[0] + bary[1] * values[1] + bary[2] * values[2];
   }
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real area = 0;
-    Real moment = 0;
-    std::array<Vec2, 3> x;
-    std::array<Index, 3> vertices = {{ 0, 0, 0 }};
+      Index index = 0;
+      Real area = 0;
+      Real moment = 0;
+      std::array<Vec2, 3> x;
+      std::array<Index, 3> vertices = {{0, 0, 0}};
   };
 
   // Templated on a `phi(Vec2)` callable so the helper is reusable across
   // any level set type.
   template <class PhiFn>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
+    const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -264,8 +257,7 @@ namespace
       const auto& cellPolytope = *cellIt;
       const auto& vertices = cellPolytope.getVertices();
       if (vertices.size() != 3)
-        throw std::runtime_error(
-            "LevelSetWNGIRAdvection expects triangular cells.");
+        throw std::runtime_error("LevelSetWNGIRAdvection expects triangular cells.");
 
       CellMomentInfo info;
       info.index = cellPolytope.getIndex();
@@ -277,8 +269,7 @@ namespace
 
       const Vec2 e1 = info.x[1] - info.x[0];
       const Vec2 e2 = info.x[2] - info.x[0];
-      info.area =
-        std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
+      info.area = std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
 
       Real moment = 0;
       for (const auto& bary : TriangleBarycentricQuadrature)
@@ -315,7 +306,7 @@ namespace
   }
 
   std::size_t parseSizeTOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -327,8 +318,7 @@ namespace
     return fallback;
   }
 
-  Real parseRealOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -341,7 +331,7 @@ namespace
   }
 
   std::string parseStringOption(
-      int argc, char** argv, const std::string& name, std::string fallback)
+    int argc, char** argv, const std::string& name, std::string fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -363,47 +353,65 @@ namespace
   //               exactly (modulo discretisation).
   //   None      : v = 0. phi_h stays at its frame-0 reconstruction; the
   //               sweep reduces to a non-advection consistency check.
-  enum class VelocityField { Rotation, None };
+  enum class VelocityField
+  {
+    Rotation,
+    None
+  };
 
-  VelocityField parseVelocityField(
-      int argc, char** argv, const std::string& name)
+  VelocityField parseVelocityField(int argc, char** argv, const std::string& name)
   {
     const std::string value = parseStringOption(argc, argv, name, "rotation");
-    if (value == "rotation") return VelocityField::Rotation;
-    if (value == "none")     return VelocityField::None;
+    if (value == "rotation")
+      return VelocityField::Rotation;
+    if (value == "none")
+      return VelocityField::None;
     throw std::runtime_error(
-        "Unknown --" + name + "=" + value
-        + " (expected rotation or none).");
+      "Unknown --" + name + "=" + value + " (expected rotation or none).");
   }
 
-  enum class PhiInitialRepresentative { Analytic, Screened, Fmm };
+  enum class PhiInitialRepresentative
+  {
+    Analytic,
+    Screened,
+    Fmm
+  };
 
   PhiInitialRepresentative parsePhiInitialRepresentative(
-      int argc, char** argv, const std::string& name)
+    int argc, char** argv, const std::string& name)
   {
     const std::string value = parseStringOption(argc, argv, name, "analytic");
-    if (value == "analytic") return PhiInitialRepresentative::Analytic;
-    if (value == "screened") return PhiInitialRepresentative::Screened;
-    if (value == "fmm")      return PhiInitialRepresentative::Fmm;
+    if (value == "analytic")
+      return PhiInitialRepresentative::Analytic;
+    if (value == "screened")
+      return PhiInitialRepresentative::Screened;
+    if (value == "fmm")
+      return PhiInitialRepresentative::Fmm;
     throw std::runtime_error(
-        "Unknown --" + name + "=" + value
-        + " (expected analytic, screened, or fmm).");
+      "Unknown --" + name + "=" + value + " (expected analytic, screened, or fmm).");
   }
 
-  enum class PhiRedistance { Off, ScreenedMoved, FmmMoved, ProjectedPhiH1Moved };
+  enum class PhiRedistance
+  {
+    Off,
+    ScreenedMoved,
+    FmmMoved,
+    ProjectedPhiH1Moved
+  };
 
-  PhiRedistance parsePhiRedistance(
-      int argc, char** argv, const std::string& name)
+  PhiRedistance parsePhiRedistance(int argc, char** argv, const std::string& name)
   {
     const std::string value = parseStringOption(argc, argv, name, "fmm-moved");
-    if (value == "off") return PhiRedistance::Off;
-    if (value == "screened-moved") return PhiRedistance::ScreenedMoved;
-    if (value == "fmm-moved") return PhiRedistance::FmmMoved;
+    if (value == "off")
+      return PhiRedistance::Off;
+    if (value == "screened-moved")
+      return PhiRedistance::ScreenedMoved;
+    if (value == "fmm-moved")
+      return PhiRedistance::FmmMoved;
     if (value == "projected-phi-h1-moved" || value == "projection-h1-moved")
       return PhiRedistance::ProjectedPhiH1Moved;
-    throw std::runtime_error(
-        "Unknown --" + name + "=" + value
-        + " (expected off, screened-moved, fmm-moved, or projected-phi-h1-moved).");
+    throw std::runtime_error("Unknown --" + name + "=" + value +
+      " (expected off, screened-moved, fmm-moved, or projected-phi-h1-moved).");
   }
 
   bool hasFlag(int argc, char** argv, const std::string& name)
@@ -423,24 +431,19 @@ int main(int argc, char** argv)
   // -------------------------------------------------------------------------
   // Step 0: frame schedule, mesh, and constants.
   // -------------------------------------------------------------------------
-  const std::size_t n =
-    parseSizeTOption(argc, argv, "n", 50);          ///< n x n nodes.
+  const std::size_t n = parseSizeTOption(argc, argv, "n", 50); ///< n x n nodes.
   const std::size_t nFrames =
-    parseSizeTOption(argc, argv, "frames", 200);    ///< orbit snapshots.
-  const Real orbitR =
-    parseRealOption(argc, argv, "orbitR", Real(0.10));
-  const Real            amp =
-    parseRealOption(argc, argv, "amp", Real(0.05)); ///< radial amplitude.
-  const Real R0 =
-    parseRealOption(argc, argv, "R0", Real(0.20));
-  const Real kLobes =
-    parseRealOption(argc, argv, "lobes", Real(6));
+    parseSizeTOption(argc, argv, "frames", 200); ///< orbit snapshots.
+  const Real orbitR = parseRealOption(argc, argv, "orbitR", Real(0.10));
+  const Real amp = parseRealOption(argc, argv, "amp", Real(0.05)); ///< radial amplitude.
+  const Real R0 = parseRealOption(argc, argv, "R0", Real(0.20));
+  const Real kLobes = parseRealOption(argc, argv, "lobes", Real(6));
 
   const Real h = Real(1) / static_cast<Real>(n - 1);
   const Real epsilon = 1.25 * h;
   const Real lambdaC = 0.008;
-  const Real delta   = 1.75 * h;
-  const Real deltaW  = 1.5 * delta;
+  const Real delta = 1.75 * h;
+  const Real deltaW = 1.5 * delta;
 
   const PhiInitialRepresentative phiInitialRepresentative =
     parsePhiInitialRepresentative(argc, argv, "phi-init");
@@ -450,18 +453,15 @@ int main(int argc, char** argv)
   // LevelSetWNGIRReconstruction: phiEll = ellMult * h,
   // M = magMult * psiEll. Calibration rescales |grad phi_h| -> |grad
   // phi_analytic| in the band.
-  const Real kPsiEllMult =
-    parseRealOption(argc, argv, "phi-ell-mult", Real(2));
+  const Real kPsiEllMult = parseRealOption(argc, argv, "phi-ell-mult", Real(2));
   const Real kPsiEll = kPsiEllMult * h;
   const Real kPsiSourceMagMult =
     parseRealOption(argc, argv, "phi-source-mag-mult", Real(5));
   const Real kPsiSourceMagnitude = kPsiSourceMagMult * kPsiEll;
 
   // -----  Advection velocity  ---------------------------------------------
-  const VelocityField velocityField =
-    parseVelocityField(argc, argv, "velocity");
-  const PhiRedistance phiRedistance =
-    parsePhiRedistance(argc, argv, "phi-redistance");
+  const VelocityField velocityField = parseVelocityField(argc, argv, "velocity");
+  const PhiRedistance phiRedistance = parsePhiRedistance(argc, argv, "phi-redistance");
   // dt per frame is one orbit step (T = 1, n frames => dt = 1/n).
   const Real kAdvectionDt = Real(1) / static_cast<Real>(nFrames);
 
@@ -469,7 +469,12 @@ int main(int argc, char** argv)
   //   Residual : classic ||R|| < tol (fails to recognise the GN data-floor).
   //   Geometry : ||phi(X+u)||_RMS < ~h^2 (honest "did we capture Γ?").
   //   Either   : converged if EITHER residual or geometry tolerance holds.
-  enum class ConvergenceMode { Residual, Geometry, Either };
+  enum class ConvergenceMode
+  {
+    Residual,
+    Geometry,
+    Either
+  };
   constexpr ConvergenceMode kConvergenceMode = ConvergenceMode::Either;
   // Knobs are CLI-overridable so convergence settings can be swept without
   // rebuilding.
@@ -478,22 +483,20 @@ int main(int argc, char** argv)
 #else
   constexpr Real kDefaultFitTolMult = Real(4.0);
 #endif
-  const Real        kFitTolMult      =
-    parseRealOption(argc, argv, "fittol-mult", kDefaultFitTolMult); ///< fitTol = mult * h^2
-  const Real        kInterfaceFitTol = kFitTolMult * h * h;
-  constexpr Real    kResidualAbsTol  = Real(1e-6);
-  const Real        kResidualRelTol  =
-    parseRealOption(argc, argv, "rrtol", Real(5e-3));
-  const std::size_t kStallPatience   =
-    parseSizeTOption(argc, argv, "stall", 5);
+  const Real kFitTolMult = parseRealOption(
+    argc, argv, "fittol-mult", kDefaultFitTolMult); ///< fitTol = mult * h^2
+  const Real kInterfaceFitTol = kFitTolMult * h * h;
+  constexpr Real kResidualAbsTol = Real(1e-6);
+  const Real kResidualRelTol = parseRealOption(argc, argv, "rrtol", Real(5e-3));
+  const std::size_t kStallPatience = parseSizeTOption(argc, argv, "stall", 5);
 
-  constexpr Attribute interiorAttribute  = 1;
-  constexpr Attribute exteriorAttribute  = 2;
+  constexpr Attribute interiorAttribute = 1;
+  constexpr Attribute exteriorAttribute = 2;
   constexpr Attribute interfaceAttribute = 10;
-  constexpr Attribute boundaryAttribute  = 20;
+  constexpr Attribute boundaryAttribute = 20;
 
   // Build the background mesh ONCE; only attributes change per frame.
-  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { n, n });
+  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {n, n});
   mesh.scale(h);
   mesh.getConnectivity().compute(2, 1);
   mesh.getConnectivity().compute(1, 2);
@@ -503,8 +506,7 @@ int main(int argc, char** argv)
   // Tag the static boundary attribute once; the per-frame loop will
   // re-tag interior / exterior / interface cells from the classifier.
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
   // -------------------------------------------------------------------------
   // FE spaces and persistent grid functions used across frames.
@@ -536,19 +538,25 @@ int main(int argc, char** argv)
   auto& cellCacheBg = cellGeomBg.first;
 
   // phiGf: analytic phi sampled at original X (diagnostic only).
-  GridFunction phiGf(p1Fes);          phiGf.setName("phi_analytic");
+  GridFunction phiGf(p1Fes);
+  phiGf.setName("phi_analytic");
   // phiH: ADVECTED P1 grid function used by the WNGIR solve. Built
   // from screened Poisson at frame 0, advected one step per subsequent
   // frame. NO analytic dependency once initialised.
-  GridFunction phiH(p1Fes);           phiH.setName("phi");
+  GridFunction phiH(p1Fes);
+  phiH.setName("phi");
   // Diagnostic: pointwise difference phi_h - phi_analytic.
-  GridFunction phiHError(p1Fes);      phiHError.setName("phi_error");
-  GridFunction cellLabel(p0Fes);      cellLabel.setName("cell_label");
-  GridFunction phaseMoment(p0Fes);    phaseMoment.setName("phase_moment");
-  GridFunction sigmaKgf(p0Fes);       sigmaKgf.setName("sigma_K");
+  GridFunction phiHError(p1Fes);
+  phiHError.setName("phi_error");
+  GridFunction cellLabel(p0Fes);
+  cellLabel.setName("cell_label");
+  GridFunction phaseMoment(p0Fes);
+  phaseMoment.setName("phase_moment");
+  GridFunction sigmaKgf(p0Fes);
+  sigmaKgf.setName("sigma_K");
 
   TrialFunction wngirTrial(vectorFes);
-  TestFunction  wngirTest(vectorFes);
+  TestFunction wngirTest(vectorFes);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");
 
@@ -562,25 +570,32 @@ int main(int argc, char** argv)
   ScalarP1 p1FesMoved(moved);
   ScalarP0 p0FesMoved(moved);
 
-  GridFunction cellLabelPhi(p0FesMoved); cellLabelPhi.setName("cell_label");
+  GridFunction cellLabelPhi(p0FesMoved);
+  cellLabelPhi.setName("cell_label");
   // phi_redist : FMM signed distance computed on the WNGIR-displaced
   // (moved) mesh using the classifier interior/skeleton attributes.
   // This IS the WNGIR-reconstructed-domain SDF; it becomes phi_h for the
   // next frame's advection.
-  GridFunction phiRedist(p1FesMoved);    phiRedist.setName("phi_redist");
+  GridFunction phiRedist(p1FesMoved);
+  phiRedist.setName("phi_redist");
   // Background copy of phiRedist for side-by-side visualisation on
   // the background mesh next to phi_analytic and phi_drifted.
-  GridFunction phiRedistBg(p1Fes);       phiRedistBg.setName("phi_redist");
-  GridFunction jKgf(p0FesMoved);        jKgf.setName("j");
+  GridFunction phiRedistBg(p1Fes);
+  phiRedistBg.setName("phi_redist");
+  GridFunction jKgf(p0FesMoved);
+  jKgf.setName("j");
   // q_abs = Q_abs(A_K^u): absolute intrinsic shape quality of the moved
   //                       cell (similarity of REFERENCE cell at value 1).
   // q_rel = Q_rel(F),  F = A_K^u (A_K)^{-1} = I + grad u:
   //                       relative-distortion measure minimised by the
   //                       admissibility barrier; equals 1 at u = 0 for every
   //                       cell regardless of background shape.
-  GridFunction qAbs(p0FesMoved);        qAbs.setName("q_abs");
-  GridFunction qRel(p0FesMoved);        qRel.setName("q_rel");
-  GridFunction phiMoved(p1FesMoved);    phiMoved.setName("phi_moved");
+  GridFunction qAbs(p0FesMoved);
+  qAbs.setName("q_abs");
+  GridFunction qRel(p0FesMoved);
+  qRel.setName("q_rel");
+  GridFunction phiMoved(p1FesMoved);
+  phiMoved.setName("phi_moved");
 
   // -------------------------------------------------------------------------
   // XDMF writer in transient mode (background and moved grids).
@@ -588,23 +603,24 @@ int main(int argc, char** argv)
   IO::XDMF xdmf("LevelSetWNGIRAdvection");
   auto backgroundGrid = xdmf.grid("background");
   backgroundGrid.setMesh(mesh, IO::XDMF::MeshPolicy::Transient);
-  backgroundGrid.add(cellLabel,   IO::XDMF::Center::Cell);
+  backgroundGrid.add(cellLabel, IO::XDMF::Center::Cell);
   backgroundGrid.add(phaseMoment, IO::XDMF::Center::Cell);
-  backgroundGrid.add(sigmaKgf,    IO::XDMF::Center::Cell);
-  backgroundGrid.add(phiGf,        IO::XDMF::Center::Node);  // phi_analytic
-  backgroundGrid.add(phiH,         IO::XDMF::Center::Node);  // phi consumed by WNGIR
-  backgroundGrid.add(phiHError,    IO::XDMF::Center::Node);  // phi - phi_analytic
-  backgroundGrid.add(phiRedistBg,  IO::XDMF::Center::Node);  // phi_redist copied to background DOFs
-  backgroundGrid.add(u,            IO::XDMF::Center::Node);
+  backgroundGrid.add(sigmaKgf, IO::XDMF::Center::Cell);
+  backgroundGrid.add(phiGf, IO::XDMF::Center::Node); // phi_analytic
+  backgroundGrid.add(phiH, IO::XDMF::Center::Node); // phi consumed by WNGIR
+  backgroundGrid.add(phiHError, IO::XDMF::Center::Node); // phi - phi_analytic
+  backgroundGrid.add(
+    phiRedistBg, IO::XDMF::Center::Node); // phi_redist copied to background DOFs
+  backgroundGrid.add(u, IO::XDMF::Center::Node);
 
   auto phiGrid = xdmf.grid("phi");
   phiGrid.setMesh(moved, IO::XDMF::MeshPolicy::Transient);
   phiGrid.add(cellLabelPhi, IO::XDMF::Center::Cell);
-  phiGrid.add(jKgf,        IO::XDMF::Center::Cell);
-  phiGrid.add(qAbs,        IO::XDMF::Center::Cell);
-  phiGrid.add(qRel,        IO::XDMF::Center::Cell);
-  phiGrid.add(phiMoved,    IO::XDMF::Center::Node);
-  phiGrid.add(phiRedist,   IO::XDMF::Center::Node);
+  phiGrid.add(jKgf, IO::XDMF::Center::Cell);
+  phiGrid.add(qAbs, IO::XDMF::Center::Cell);
+  phiGrid.add(qRel, IO::XDMF::Center::Cell);
+  phiGrid.add(phiMoved, IO::XDMF::Center::Node);
+  phiGrid.add(phiRedist, IO::XDMF::Center::Node);
 
   // -------------------------------------------------------------------------
   // Frame loop.
@@ -615,18 +631,16 @@ int main(int argc, char** argv)
             << "  orbit R=" << orbitR << '\n';
   std::cout << "  phi-init="
             << (phiInitialRepresentative == PhiInitialRepresentative::Analytic
-                  ? "analytic"
-                  : phiInitialRepresentative == PhiInitialRepresentative::Fmm
-                      ? "fmm"
-                      : "screened")
+                   ? "analytic"
+                   : phiInitialRepresentative == PhiInitialRepresentative::Fmm
+                   ? "fmm"
+                   : "screened")
             << "  phi-redistance="
-            << (phiRedistance == PhiRedistance::FmmMoved
-                  ? "fmm-moved"
-                  : phiRedistance == PhiRedistance::ProjectedPhiH1Moved
-                      ? "projected-phi-h1-moved"
-                  : phiRedistance == PhiRedistance::ScreenedMoved
-                      ? "screened-moved"
-                      : "off")
+            << (phiRedistance == PhiRedistance::FmmMoved ? "fmm-moved"
+                   : phiRedistance == PhiRedistance::ProjectedPhiH1Moved
+                   ? "projected-phi-h1-moved"
+                   : phiRedistance == PhiRedistance::ScreenedMoved ? "screened-moved"
+                                                                   : "off")
             << '\n';
 
   std::size_t framesConverged = 0;
@@ -644,11 +658,10 @@ int main(int argc, char** argv)
     levelSet.R0 = R0;
     levelSet.amp = amp;
     levelSet.k = kLobes;
-    levelSet.phase = angle;  // co-rotate the lobes for visual variety.
+    levelSet.phase = angle; // co-rotate the lobes for visual variety.
 
-    std::cout << "\n--- Frame " << std::setw(2) << frame
-              << " : c=(" << std::fixed << std::setprecision(4)
-              << levelSet.cx << ", " << levelSet.cy << ")"
+    std::cout << "\n--- Frame " << std::setw(2) << frame << " : c=(" << std::fixed
+              << std::setprecision(4) << levelSet.cx << ", " << levelSet.cy << ")"
               << "  phase=" << std::setprecision(3) << angle << " rad\n";
 
     // Reset attributes so the new classification owns them.
@@ -656,12 +669,10 @@ int main(int argc, char** argv)
 
     // Re-tag static boundary (clearXDMFRegionAttributes wipes it too).
     for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                        boundaryAttribute);
+      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
     auto stageClock = std::chrono::steady_clock::now();
-    auto stageLap = [&stageClock](const char* name)
-    {
+    auto stageLap = [&stageClock](const char* name) {
       const auto now = std::chrono::steady_clock::now();
       const double s = std::chrono::duration<double>(now - stageClock).count();
       stageClock = now;
@@ -672,25 +683,23 @@ int main(int argc, char** argv)
     if (frame > 0)
     {
       AnalyticVectorFunction velocity(
-          [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
+        [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+          const auto& X = p.getCoordinates();
+          switch (velocityField)
           {
-            const auto& X = p.getCoordinates();
-            switch (velocityField)
+            case VelocityField::Rotation:
             {
-              case VelocityField::Rotation:
-              {
-                const Real omega = Real(2) * Real(M_PI);
-                return vec2(-omega * (X(1) - Real(0.5)),
-                             omega * (X(0) - Real(0.5)));
-              }
-              case VelocityField::None:
-              default:
-                return vec2(Real(0), Real(0));
+              const Real omega = Real(2) * Real(M_PI);
+              return vec2(-omega * (X(1) - Real(0.5)), omega * (X(0) - Real(0.5)));
             }
-          },
-          /*dimension=*/2);
+            case VelocityField::None:
+            default:
+              return vec2(Real(0), Real(0));
+          }
+        },
+        /*dimension=*/2);
       TrialFunction advect(p1Fes);
-      TestFunction  advectTest(p1Fes);
+      TestFunction advectTest(p1Fes);
       Advection::Lagrangian adv(advect, advectTest, phiH, velocity);
       adv.step(kAdvectionDt);
       phiH.getData() = advect.getSolution().getData();
@@ -707,51 +716,45 @@ int main(int argc, char** argv)
     // The interface skeleton produced here is consumed directly by WNGIR
     // and, when requested, by phi_h initialization/redistance.
     const bool useAnalyticForMoments = (frame == 0);
-    const auto cellMoments =
-      useAnalyticForMoments
-        ? collectCellMomentInfo(
-              mesh,
-              [&](const Vec2& p) { return levelSet.phi(p); },
-              epsilon)
-        : [&]()
+    const auto cellMoments = useAnalyticForMoments
+      ? collectCellMomentInfo(
+          mesh, [&](const Vec2& p) { return levelSet.phi(p); }, epsilon)
+      : [&]() {
+          // Evaluate phi_h at quadrature points by walking cells and
+          // calling GridFunction::getValue at the reference coord.
+          std::vector<CellMomentInfo> cells;
+          cells.reserve(mesh.getCellCount());
+          for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
           {
-            // Evaluate phi_h at quadrature points by walking cells and
-            // calling GridFunction::getValue at the reference coord.
-            std::vector<CellMomentInfo> cells;
-            cells.reserve(mesh.getCellCount());
-            for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
+            const auto& cellPolytope = *cellIt;
+            const auto& vertices = cellPolytope.getVertices();
+            if (vertices.size() != 3)
+              throw std::runtime_error("expects triangular cells.");
+            CellMomentInfo info;
+            info.index = cellPolytope.getIndex();
+            for (size_t i = 0; i < 3; ++i)
             {
-              const auto& cellPolytope = *cellIt;
-              const auto& vertices = cellPolytope.getVertices();
-              if (vertices.size() != 3)
-                throw std::runtime_error(
-                    "expects triangular cells.");
-              CellMomentInfo info;
-              info.index = cellPolytope.getIndex();
-              for (size_t i = 0; i < 3; ++i)
-              {
-                info.vertices[i] = vertices[i];
-                info.x[i] = mesh.getVertexCoordinates(vertices[i]);
-              }
-              const Vec2 e1 = info.x[1] - info.x[0];
-              const Vec2 e2 = info.x[2] - info.x[0];
-              info.area =
-                std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
-              Real moment = 0;
-              for (const auto& bary : TriangleBarycentricQuadrature)
-              {
-                Math::SpatialPoint rc(2);
-                rc(0) = bary[1];
-                rc(1) = bary[2];
-                const Geometry::Point pt(cellPolytope, rc);
-                const Real phiq = phiH.getValue(pt);
-                moment += applyPhaseMomentMap(phiq, epsilon);
-              }
-              info.moment = moment / TriangleBarycentricQuadrature.size();
-              cells.push_back(std::move(info));
+              info.vertices[i] = vertices[i];
+              info.x[i] = mesh.getVertexCoordinates(vertices[i]);
             }
-            return cells;
-          }();
+            const Vec2 e1 = info.x[1] - info.x[0];
+            const Vec2 e2 = info.x[2] - info.x[0];
+            info.area = std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
+            Real moment = 0;
+            for (const auto& bary : TriangleBarycentricQuadrature)
+            {
+              Math::SpatialPoint rc(2);
+              rc(0) = bary[1];
+              rc(1) = bary[2];
+              const Geometry::Point pt(cellPolytope, rc);
+              const Real phiq = phiH.getValue(pt);
+              moment += applyPhaseMomentMap(phiq, epsilon);
+            }
+            info.moment = moment / TriangleBarycentricQuadrature.size();
+            cells.push_back(std::move(info));
+          }
+          return cells;
+        }();
 
     std::unordered_map<Index, std::size_t> cellToLocal;
     std::vector<Index> localToCell;
@@ -782,16 +785,12 @@ int main(int argc, char** argv)
       const auto itB = cellToLocal.find(incident[1]);
       if (itA == cellToLocal.end() || itB == cellToLocal.end())
         continue;
-      graphEdges.push_back({
-          static_cast<Index>(itA->second),
-          static_cast<Index>(itB->second),
-          lambdaC * facetLength(mesh, facet),
-          facet});
+      graphEdges.push_back({static_cast<Index>(itA->second),
+        static_cast<Index>(itB->second), lambdaC * facetLength(mesh, facet), facet});
     }
 
     const MinSTCut cut;
-    const MinSTCut::Result classified =
-      cut.classify(volumes, moments, graphEdges);
+    const MinSTCut::Result classified = cut.classify(volumes, moments, graphEdges);
 
     std::vector<Index> interfaceFacets;
     interfaceFacets.reserve(classified.cutEdges.size());
@@ -802,40 +801,31 @@ int main(int argc, char** argv)
     for (std::size_t local = 0; local < classified.labels.size(); ++local)
     {
       const Index cellIdx = localToCell[local];
-      mesh.setAttribute(
-          {mesh.getDimension(), cellIdx},
-          classified.labels[local] == MinSTCut::Inside
-            ? interiorAttribute
-            : exteriorAttribute);
+      mesh.setAttribute({mesh.getDimension(), cellIdx},
+        classified.labels[local] == MinSTCut::Inside ? interiorAttribute
+                                                     : exteriorAttribute);
     }
     for (const Index facet : interfaceFacets)
       mesh.setAttribute({mesh.getDimension() - 1, facet}, interfaceAttribute);
 
-    if (frame == 0
-        && phiInitialRepresentative == PhiInitialRepresentative::Screened)
+    if (frame == 0 && phiInitialRepresentative == PhiInitialRepresentative::Screened)
     {
       TrialFunction phiTrial(p1Fes);
-      TestFunction  phiTest(p1Fes);
-      RealFunction phiSource(
-          [&](const Geometry::Point& p) -> Real
-          {
-            const auto attr = p.getPolytope().getAttribute();
-            if (attr && *attr == interiorAttribute)
-              return -kPsiSourceMagnitude;
-            return kPsiSourceMagnitude;
-          });
+      TestFunction phiTest(p1Fes);
+      RealFunction phiSource([&](const Geometry::Point& p) -> Real {
+        const auto attr = p.getPolytope().getAttribute();
+        if (attr && *attr == interiorAttribute)
+          return -kPsiSourceMagnitude;
+        return kPsiSourceMagnitude;
+      });
       Problem phiProblem(phiTrial, phiTest);
-      phiProblem =
-          Integral((kPsiEll * kPsiEll) * Grad(phiTrial), Grad(phiTest))
-        + Integral(phiTrial, phiTest)
-        - Integral(phiSource, phiTest)
-        + DirichletBC(phiTrial, RealFunction(Real(0)))
-            .on(interfaceAttribute);
+      phiProblem = Integral((kPsiEll * kPsiEll) * Grad(phiTrial), Grad(phiTest)) +
+        Integral(phiTrial, phiTest) - Integral(phiSource, phiTest) +
+        DirichletBC(phiTrial, RealFunction(Real(0))).on(interfaceAttribute);
       Solver::SparseLU(phiProblem).solve();
       phiH.getData() = phiTrial.getSolution().getData();
     }
-    if (frame == 0
-        && phiInitialRepresentative == PhiInitialRepresentative::Fmm)
+    if (frame == 0 && phiInitialRepresentative == PhiInitialRepresentative::Fmm)
     {
       phiH = Real(0);
       Distance::Eikonal<ScalarP1, Math::Vector<Real>>(phiH)
@@ -851,10 +841,10 @@ int main(int argc, char** argv)
       std::size_t insideCells = 0;
       for (std::size_t local = 0; local < classified.labels.size(); ++local)
       {
-        if (classified.labels[local] != MinSTCut::Inside) continue;
+        if (classified.labels[local] != MinSTCut::Inside)
+          continue;
         const auto& info = cellMoments[local];
-        const Vec2 ctr =
-          (info.x[0] + info.x[1] + info.x[2]) / Real(3);
+        const Vec2 ctr = (info.x[0] + info.x[1] + info.x[2]) / Real(3);
         wx += info.area * ctr(0);
         wy += info.area * ctr(1);
         wA += info.area;
@@ -866,12 +856,10 @@ int main(int argc, char** argv)
       const Real dyClass = cyClass - levelSet.cy;
       const Real lag = std::sqrt(dxClass * dxClass + dyClass * dyClass);
       std::cout << "    classifier interior: cells=" << insideCells
-                << "  area=" << std::fixed << std::setprecision(4) << wA
-                << "  centroid=(" << cxClass << ", " << cyClass << ")"
-                << "  vs c_analytic=(" << levelSet.cx << ", " << levelSet.cy
-                << ")"
-                << "  lag=" << std::scientific << std::setprecision(3)
-                << lag << '\n';
+                << "  area=" << std::fixed << std::setprecision(4) << wA << "  centroid=("
+                << cxClass << ", " << cyClass << ")"
+                << "  vs c_analytic=(" << levelSet.cx << ", " << levelSet.cy << ")"
+                << "  lag=" << std::scientific << std::setprecision(3) << lag << '\n';
     }
 
     stageLap("phi-init");
@@ -879,11 +867,9 @@ int main(int argc, char** argv)
 
     auto& cellCache = cellCacheBg;
 
-    if (frame == 0
-        && phiInitialRepresentative == PhiInitialRepresentative::Analytic)
+    if (frame == 0 && phiInitialRepresentative == PhiInitialRepresentative::Analytic)
     {
-      phiH = [&](const Geometry::Point& p) -> Real
-      {
+      phiH = [&](const Geometry::Point& p) -> Real {
         const auto& X = p.getCoordinates();
         return levelSet.phi(vec2(X(0), X(1)));
       };
@@ -892,59 +878,51 @@ int main(int argc, char** argv)
     auto gradPhiDiscrete = Grad(phiH);
     {
       TrialFunction gtrial(gradPhiFes);
-      TestFunction  gtest(gradPhiFes);
+      TestFunction gtest(gradPhiFes);
       Problem gpb(gtrial, gtest);
-      gpb = Integral(gtrial, gtest)
-          - Integral(gradPhiDiscrete, gtest);
+      gpb = Integral(gtrial, gtest) - Integral(gradPhiDiscrete, gtest);
       Solver::SparseLU(gpb).solve();
       gradPhiSmoothed.getData() = gtrial.getSolution().getData();
     }
     auto hessFromSmoothedGrad = Jacobian(gradPhiSmoothed);
 
-    RealFunction phi(
-        [&](const Geometry::Point& p) -> Real
-        {
-          return phiH.getValue(p);
-        });
+    RealFunction phi([&](const Geometry::Point& p) -> Real { return phiH.getValue(p); });
     AnalyticVectorFunction gradPhi(
-        [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-        {
-          return gradPhiSmoothed.getValue(p);
-        },
-        /*dimension=*/2);
+      [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+        return gradPhiSmoothed.getValue(p);
+      },
+      /*dimension=*/2);
     AnalyticMatrixFunction hessPhi(
-        [&](const Geometry::Point& p) -> Math::SpatialMatrix<Real>
-        {
-          return hessFromSmoothedGrad.getValue(p);
-        },
-        /*rows=*/2, /*cols=*/2);
+      [&](const Geometry::Point& p) -> Math::SpatialMatrix<Real> {
+        return hessFromSmoothedGrad.getValue(p);
+      },
+      /*rows=*/2, /*cols=*/2);
 
     const bool kVerbose = hasFlag(argc, argv, "verbose");
 
     // Evaluate phi_h at a moved physical point (a + ua) by walking the
     // mesh and using its inverse polytope map. Simple O(N_cells) fallback
     // — fine here because we only sample ~|skeleton| points.
-    auto phiHAtMovedVertex = [&](const Vec2& y) -> Real
-    {
+    auto phiHAtMovedVertex = [&](const Vec2& y) -> Real {
       for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
       {
         const auto& cell = *cellIt;
         Math::SpatialPoint rc(2);
         const auto& trf = cell.getTransformation();
         Math::SpatialPoint Y(2);
-        Y(0) = y(0); Y(1) = y(1);
+        Y(0) = y(0);
+        Y(1) = y(1);
         trf.inverse(rc, Y);
         // Inside-triangle test in reference (xi, eta in [0,1], xi+eta<=1).
-        const Real xi  = rc(0), eta = rc(1);
+        const Real xi = rc(0), eta = rc(1);
         const Real tol = Real(1e-9);
         if (xi >= -tol && eta >= -tol && xi + eta <= Real(1) + tol)
           return phiH.getValue(Geometry::Point(cell, rc, Y));
       }
-      return Real(0);  // outside the mesh — should not happen for moved vertices
+      return Real(0); // outside the mesh — should not happen for moved vertices
     };
 
-    auto computeInterfaceFit = [&](bool discrete) -> Real
-    {
+    auto computeInterfaceFit = [&](bool discrete) -> Real {
       Real interfacePhi = 0;
       Real interfaceLen = 0;
       for (const Index facet : interfaceFacets)
@@ -979,9 +957,9 @@ int main(int argc, char** argv)
 
     Real residualBest = std::numeric_limits<Real>::infinity();
     std::size_t itCount = 0;
-    Real        interfaceFit = 0;
-    bool        convergedFlag    = false;
-    const char* convergedReason  = "no";
+    Real interfaceFit = 0;
+    bool convergedFlag = false;
+    const char* convergedReason = "no";
 
     {
       // Robust WNGIR (Rodin/Adaptation/WNGIR.h). The
@@ -992,21 +970,16 @@ int main(int argc, char** argv)
       Rodin::Examples::WNGIRExampleDefaults wngirDefaults;
       wngirDefaults.maxIterations = 200;
       wngirDefaults.parseLegacyMaxIterations = true;
-      const auto wngir =
-        Rodin::Examples::makeWNGIRParameters(
-            argc, argv, h, interfaceAttribute, wngirDefaults);
+      const auto wngir = Rodin::Examples::makeWNGIRParameters(
+        argc, argv, h, interfaceAttribute, wngirDefaults);
       Rodin::Adaptation::WNGIR wngirSolver(wngirTrial, wngirTest);
       wngirSolver.setParameters(wngir);
-      const auto wngirRep =
-        wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
-      std::cout << "    wngir timing: it=" << wngirRep.iterations
-                << std::scientific << std::setprecision(2)
-                << "  assembly=" << wngirRep.tAssembly
-                << "  setup=" << wngirRep.tFactor
-                << "  solve=" << wngirRep.tSolve
+      const auto wngirRep = wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
+      std::cout << "    wngir timing: it=" << wngirRep.iterations << std::scientific
+                << std::setprecision(2) << "  assembly=" << wngirRep.tAssembly
+                << "  setup=" << wngirRep.tFactor << "  solve=" << wngirRep.tSolve
                 << "  cgIt=" << wngirRep.linearIterations
-                << "  cgErr=" << wngirRep.linearError
-                << "  ls=" << wngirRep.tLineSearch
+                << "  cgErr=" << wngirRep.linearError << "  ls=" << wngirRep.tLineSearch
                 << "  exit=" << wngirRep.exitReason << '\n';
       itCount = wngirRep.iterations;
       residualBest = wngirRep.activeRMS;
@@ -1017,8 +990,7 @@ int main(int argc, char** argv)
       interfaceFit = computeInterfaceFit(/*discrete=*/true);
     const Real interfaceFitAnalytic = computeInterfaceFit(/*discrete=*/false);
 
-    const bool residualOK =
-         residualBest < kResidualAbsTol;
+    const bool residualOK = residualBest < kResidualAbsTol;
     const bool geometryOK = interfaceFit < kInterfaceFitTol;
     switch (kConvergenceMode)
     {
@@ -1032,34 +1004,26 @@ int main(int argc, char** argv)
         break;
       case ConvergenceMode::Either:
         convergedFlag = geometryOK || residualOK;
-        convergedReason =
-            geometryOK && residualOK ? "yes (both)"
-          : geometryOK               ? "yes (geometry)"
-          : residualOK               ? "yes (residual)"
-                                     : "no";
+        convergedReason = geometryOK && residualOK ? "yes (both)"
+          : geometryOK                             ? "yes (geometry)"
+          : residualOK                             ? "yes (residual)"
+                                                   : "no";
         break;
     }
 
     if (kVerbose)
       std::cout << "      WNGIR:"
-                << " it=" << itCount
-                << "  activeRMS=" << std::scientific << std::setprecision(3)
-                << residualBest
-                << '\n';
+                << " it=" << itCount << "  activeRMS=" << std::scientific
+                << std::setprecision(3) << residualBest << '\n';
     finalFitPerFrame.push_back(interfaceFit);
 
     struct AggregateReport
     {
-      std::size_t iterations;
-      Real        final_residual;
-      Real        interface_fit;
-      bool        converged;
-    } report{
-      itCount,
-      residualBest,
-      interfaceFit,
-      convergedFlag
-    };
+        std::size_t iterations;
+        Real final_residual;
+        Real interface_fit;
+        bool converged;
+    } report{itCount, residualBest, interfaceFit, convergedFlag};
 
     stageLap("solve");
     // ---- Stage 5a: background cell-P0 fields + nodal phi ----
@@ -1070,22 +1034,18 @@ int main(int argc, char** argv)
         const Index cellIdx = cellIt->getIndex();
         const std::size_t local = cellToLocal.at(cellIdx);
         const Index dof = p0Fes.getGlobalIndex({d, cellIdx}, 0);
-        cellLabel.getData()(dof)   =
-          static_cast<Real>(classified.labels[local]);
+        cellLabel.getData()(dof) = static_cast<Real>(classified.labels[local]);
         phaseMoment.getData()(dof) = cellMoments[local].moment;
-        sigmaKgf.getData()(dof)    =
-          static_cast<Real>(cellCache[local].sigmaK);
+        sigmaKgf.getData()(dof) = static_cast<Real>(cellCache[local].sigmaK);
       }
     }
-    phiGf = [&](const Geometry::Point& p) -> Real
-    {
+    phiGf = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
     // phiHError = phi_h - phi_analytic at vertices (diagnostic of
     // accumulated advection error).
-    phiHError = [&](const Geometry::Point& p) -> Real
-    {
+    phiHError = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       const Real ana = levelSet.phi(vec2(X(0), X(1)));
       const Real dis = phiH.getValue(p);
@@ -1139,18 +1099,14 @@ int main(int argc, char** argv)
         jKgf.getData()(dof) = jKval;
         const Real dExp = Real(2) / Real(d);
         qAbs.getData()(dof) =
-          dst.A.squaredNorm()
-            / (static_cast<Real>(d) * std::pow(sigDetAu, dExp));
+          dst.A.squaredNorm() / (static_cast<Real>(d) * std::pow(sigDetAu, dExp));
         const Math::SpatialMatrix<Real> F = dst.A * src.A.inverse();
         qRel.getData()(dof) =
-          F.squaredNorm()
-            / (static_cast<Real>(d) * std::pow(jKval, dExp));
-        cellLabelPhi.getData()(dof) =
-          static_cast<Real>(classified.labels[local]);
+          F.squaredNorm() / (static_cast<Real>(d) * std::pow(jKval, dExp));
+        cellLabelPhi.getData()(dof) = static_cast<Real>(classified.labels[local]);
       }
     }
-    phiMoved = [&](const Geometry::Point& p) -> Real
-    {
+    phiMoved = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
@@ -1170,13 +1126,12 @@ int main(int argc, char** argv)
         const Real uy = uData(dofs[1]);
         maxUoverH = std::max(maxUoverH, std::sqrt(ux * ux + uy * uy) / h);
       }
-      std::cout << "    max|u|/h=" << std::scientific << std::setprecision(3)
-                << maxUoverH << '\n';
+      std::cout << "    max|u|/h=" << std::scientific << std::setprecision(3) << maxUoverH
+                << '\n';
     }
 
-    std::cout << "    WNGIR it=" << report.iterations
-              << "  activeRMS=" << std::scientific << std::setprecision(3)
-              << report.final_residual
+    std::cout << "    WNGIR it=" << report.iterations << "  activeRMS=" << std::scientific
+              << std::setprecision(3) << report.final_residual
               << "  fit_h=" << std::setprecision(3) << interfaceFit
               << "  fit_an=" << std::setprecision(3) << interfaceFitAnalytic
               << "  init=cold"
@@ -1203,22 +1158,17 @@ int main(int argc, char** argv)
     if (phiRedistance == PhiRedistance::ScreenedMoved)
     {
       TrialFunction phiTrial(p1FesMoved);
-      TestFunction  phiTest(p1FesMoved);
-      RealFunction phiSource(
-          [&](const Geometry::Point& p) -> Real
-          {
-            const auto attr = p.getPolytope().getAttribute();
-            if (attr && *attr == interiorAttribute)
-              return -kPsiSourceMagnitude;
-            return kPsiSourceMagnitude;
-          });
+      TestFunction phiTest(p1FesMoved);
+      RealFunction phiSource([&](const Geometry::Point& p) -> Real {
+        const auto attr = p.getPolytope().getAttribute();
+        if (attr && *attr == interiorAttribute)
+          return -kPsiSourceMagnitude;
+        return kPsiSourceMagnitude;
+      });
       Problem phiProblem(phiTrial, phiTest);
-      phiProblem =
-          Integral((kPsiEll * kPsiEll) * Grad(phiTrial), Grad(phiTest))
-        + Integral(phiTrial, phiTest)
-        - Integral(phiSource, phiTest)
-        + DirichletBC(phiTrial, RealFunction(Real(0)))
-            .on(interfaceAttribute);
+      phiProblem = Integral((kPsiEll * kPsiEll) * Grad(phiTrial), Grad(phiTest)) +
+        Integral(phiTrial, phiTest) - Integral(phiSource, phiTest) +
+        DirichletBC(phiTrial, RealFunction(Real(0))).on(interfaceAttribute);
       Solver::SparseLU(phiProblem).solve();
       phiRedist.getData() = phiTrial.getSolution().getData();
 
@@ -1227,7 +1177,8 @@ int main(int argc, char** argv)
       {
         const auto& cell = *cellIt;
         const auto& vertices = cell.getVertices();
-        if (vertices.size() != 3) continue;
+        if (vertices.size() != 3)
+          continue;
         std::array<Vec2, 3> x;
         std::array<Real, 3> phiNode;
         for (std::size_t a = 0; a < 3; ++a)
@@ -1235,8 +1186,10 @@ int main(int argc, char** argv)
           x[a] = moved.getVertexCoordinates(vertices[a]);
           Math::SpatialPoint rc(2);
           rc.setZero();
-          if (a == 1) rc(0) = 1;
-          if (a == 2) rc(1) = 1;
+          if (a == 1)
+            rc(0) = 1;
+          if (a == 2)
+            rc(1) = 1;
           phiNode[a] = phiRedist.getValue(Geometry::Point(cell, rc));
         }
         Math::SpatialMatrix<Real> M(2, 2);
@@ -1247,23 +1200,20 @@ int main(int argc, char** argv)
         const Real detM = M(0, 0) * M(1, 1) - M(0, 1) * M(1, 0);
         Vec2 rhs = vec2(phiNode[1] - phiNode[0], phiNode[2] - phiNode[0]);
         Vec2 gradCell(2);
-        gradCell(0) = ( M(1, 1) * rhs(0) - M(0, 1) * rhs(1)) / detM;
+        gradCell(0) = (M(1, 1) * rhs(0) - M(0, 1) * rhs(1)) / detM;
         gradCell(1) = (-M(1, 0) * rhs(0) + M(0, 0) * rhs(1)) / detM;
         const Real gradNorm = gradCell.norm();
         const Vec2 e1 = x[1] - x[0];
         const Vec2 e2 = x[2] - x[0];
-        const Real triangleArea =
-          Real(0.5) * std::abs(e1(0) * e2(1) - e1(1) * e2(0));
+        const Real triangleArea = Real(0.5) * std::abs(e1(0) * e2(1) - e1(1) * e2(0));
         for (const auto& bary : TriangleBarycentricQuadrature)
         {
           const Real phiq =
-            bary[0] * phiNode[0] + bary[1] * phiNode[1]
-          + bary[2] * phiNode[2];
-          const Real wBand =
-            std::exp(-phiq * phiq / (Real(2) * deltaW * deltaW));
+            bary[0] * phiNode[0] + bary[1] * phiNode[1] + bary[2] * phiNode[2];
+          const Real wBand = std::exp(-phiq * phiq / (Real(2) * deltaW * deltaW));
           const Real qw =
             triangleArea / static_cast<Real>(TriangleBarycentricQuadrature.size());
-          gradAcc   += wBand * gradNorm * qw;
+          gradAcc += wBand * gradNorm * qw;
           weightAcc += wBand * qw;
         }
       }
@@ -1281,56 +1231,41 @@ int main(int argc, char** argv)
     if (phiRedistance == PhiRedistance::ProjectedPhiH1Moved)
     {
       auto gradPhiHCurrent = Grad(phiH);
-      auto localizedOnBackground =
-        [&](const Geometry::Point& p, const auto& callback)
+      auto localizedOnBackground = [&](const Geometry::Point& p, const auto& callback) {
+        const auto& Yphys = p.getPhysicalCoordinates();
+        for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
         {
-          const auto& Yphys = p.getPhysicalCoordinates();
-          for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
-          {
-            const auto& cell = *cellIt;
-            Math::SpatialPoint rc(2);
-            cell.getTransformation().inverse(rc, Yphys);
-            const Real xi = rc(0), eta = rc(1);
-            const Real tol = Real(1e-9);
-            if (xi >= -tol && eta >= -tol
-                && xi + eta <= Real(1) + tol)
-              return callback(Geometry::Point(cell, rc, Yphys));
-          }
-          return callback(p);
-        };
-      RealFunction phiDataMoved(
-          [&](const Geometry::Point& p) -> Real
-          {
-            return localizedOnBackground(
-                p,
-                [&](const Geometry::Point& q) -> Real
-                {
-                  return phiH.getValue(q);
-                });
-          });
+          const auto& cell = *cellIt;
+          Math::SpatialPoint rc(2);
+          cell.getTransformation().inverse(rc, Yphys);
+          const Real xi = rc(0), eta = rc(1);
+          const Real tol = Real(1e-9);
+          if (xi >= -tol && eta >= -tol && xi + eta <= Real(1) + tol)
+            return callback(Geometry::Point(cell, rc, Yphys));
+        }
+        return callback(p);
+      };
+      RealFunction phiDataMoved([&](const Geometry::Point& p) -> Real {
+        return localizedOnBackground(
+          p, [&](const Geometry::Point& q) -> Real { return phiH.getValue(q); });
+      });
       AnalyticVectorFunction gradPhiDataMoved(
-          [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-          {
-            return localizedOnBackground(
-                p,
-                [&](const Geometry::Point& q) -> Math::SpatialVector<Real>
-                {
-                  return gradPhiHCurrent.getValue(q);
-                });
-          },
-          /*dimension=*/2);
+        [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+          return localizedOnBackground(
+            p, [&](const Geometry::Point& q) -> Math::SpatialVector<Real> {
+              return gradPhiHCurrent.getValue(q);
+            });
+        },
+        /*dimension=*/2);
 
       TrialFunction phiTrial(p1FesMoved);
-      TestFunction  phiTest(p1FesMoved);
+      TestFunction phiTest(p1FesMoved);
       RealFunction<Real> ell2(kPsiEll * kPsiEll);
       Problem phiProblem(phiTrial, phiTest);
-      phiProblem =
-          Integral(phiTrial, phiTest)
-        + Integral(ell2 * Grad(phiTrial), Grad(phiTest))
-        - Integral(phiDataMoved, phiTest)
-        - Integral(ell2 * gradPhiDataMoved, Grad(phiTest))
-        + DirichletBC(phiTrial, RealFunction(Real(0)))
-            .on(interfaceAttribute);
+      phiProblem = Integral(phiTrial, phiTest) +
+        Integral(ell2 * Grad(phiTrial), Grad(phiTest)) - Integral(phiDataMoved, phiTest) -
+        Integral(ell2 * gradPhiDataMoved, Grad(phiTest)) +
+        DirichletBC(phiTrial, RealFunction(Real(0))).on(interfaceAttribute);
       Solver::SparseLU(phiProblem).solve();
       phiRedist.getData() = phiTrial.getSolution().getData();
       phiRedistBg.getData() = phiRedist.getData();
@@ -1367,7 +1302,6 @@ int main(int argc, char** argv)
     // history rather than restarting from a reconstructed surrogate.
     xdmf.write(t).flush();
     stageLap("xdmf");
-
   }
 
   xdmf.close();
@@ -1376,8 +1310,7 @@ int main(int argc, char** argv)
   // Summary.
   // -------------------------------------------------------------------------
   std::cout << "\nSummary\n";
-  std::cout << "  frames converged: " << framesConverged
-            << " / " << nFrames << '\n';
+  std::cout << "  frames converged: " << framesConverged << " / " << nFrames << '\n';
   if (!finalFitPerFrame.empty())
   {
     const Real fitMin =
@@ -1385,12 +1318,11 @@ int main(int argc, char** argv)
     const Real fitMax =
       *std::max_element(finalFitPerFrame.begin(), finalFitPerFrame.end());
     Real fitMean = 0;
-    for (Real x : finalFitPerFrame) fitMean += x;
+    for (Real x : finalFitPerFrame)
+      fitMean += x;
     fitMean /= static_cast<Real>(finalFitPerFrame.size());
-    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific
-              << std::setprecision(3) << fitMin
-              << "  mean=" << fitMean
-              << "  max=" << fitMax << '\n';
+    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific << std::setprecision(3)
+              << fitMin << "  mean=" << fitMean << "  max=" << fitMax << '\n';
   }
 
   return framesConverged == nFrames ? 0 : 1;

--- a/examples/Geometry/LevelSetWNGIRReconstruction.cpp
+++ b/examples/Geometry/LevelSetWNGIRReconstruction.cpp
@@ -73,19 +73,16 @@ namespace
         pm(0, a) = X(0);
         pm(1, a) = X(1);
       }
-      mesh.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      mesh.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
   }
 #endif
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const LocalMesh& mesh,
-      LocalMesh& moved,
-      const Displacement& u)
+    const LocalMesh& mesh, LocalMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -95,8 +92,7 @@ namespace
       const Vec2 x = mesh.getVertexCoordinates(vertex);
       const auto& dofs = uFes.getDOFs(0, vertex);
       moved.setVertexCoordinates(
-          vertex,
-          vec2(x(0) + uData(dofs[0]), x(1) + uData(dofs[1])));
+        vertex, vec2(x(0) + uData(dofs[0]), x(1) + uData(dofs[1])));
     }
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -111,31 +107,28 @@ namespace
       {
         const auto& rc = geomFe.getNode(a);
         cell.getTransformation().transform(X, rc);
-        const Real ux =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2));
-        const Real uy =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2 + 1));
+        const Real ux = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2));
+        const Real uy = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2 + 1));
         pm(0, a) = X(0) + ux;
         pm(1, a) = X(1) + uy;
       }
-      moved.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      moved.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
 #endif
   }
 
   struct AdmissibilityDistribution
   {
-    Real minJ = std::numeric_limits<Real>::infinity();
-    Real p10J = 0, p50J = 0, p90J = 0;
-    Real maxQ = 0;
-    Real p10Q = 0, p50Q = 0, p90Q = 0;
-    std::size_t numQuadPoints = 0;
-    std::size_t numNearJSafe = 0;   // j_K < 1.5·j_safe
-    std::size_t numNearQMax = 0;    // Q_rel > 0.7·Q_max
-    std::size_t numInadmissible = 0;
+      Real minJ = std::numeric_limits<Real>::infinity();
+      Real p10J = 0, p50J = 0, p90J = 0;
+      Real maxQ = 0;
+      Real p10Q = 0, p50Q = 0, p90Q = 0;
+      std::size_t numQuadPoints = 0;
+      std::size_t numNearJSafe = 0;   // j_K < 1.5·j_safe
+      std::size_t numNearQMax = 0;    // Q_rel > 0.7·Q_max
+      std::size_t numInadmissible = 0;
   };
 
   /// Sampled per-cell admissibility distribution (j, Q_rel) at all
@@ -145,12 +138,8 @@ namespace
   /// only conceptually — same dominant cost (cell-loop gradU eval),
   /// but accumulates a distribution rather than min/max.
   template <class Displacement>
-  AdmissibilityDistribution
-  evaluateAdmissibilityDistribution(
-      Displacement& u,
-      Real jSafe,
-      Real qMax,
-      std::size_t qOrder = 2)
+  AdmissibilityDistribution evaluateAdmissibilityDistribution(
+    Displacement& u, Real jSafe, Real qMax, std::size_t qOrder = 2)
   {
     using Variational::IntegrationPoint;
     using Variational::Jacobian;
@@ -169,40 +158,39 @@ namespace
     for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
     {
       const auto& cell = *cellIt;
-      const auto& fe =
-        fes.getFiniteElement(cell.getDimension(), cell.getIndex());
-      const auto& qf =
-        QF::PolytopeQuadratureFormula::get(
-            qOrder, cell.getGeometry());
+      const auto& fe = fes.getFiniteElement(cell.getDimension(), cell.getIndex());
+      const auto& qf = QF::PolytopeQuadratureFormula::get(qOrder, cell.getGeometry());
       const auto& quadrature = cell.getQuadrature(qf);
       for (std::size_t q = 0; q < quadrature.getSize(); ++q)
       {
         const auto& pt = quadrature.getPoint(q);
         const IntegrationPoint ip(pt, &qf, q);
         Math::SpatialMatrix<Real> F =
-          Math::SpatialMatrix<Real>::Identity(dim, dim)
-          + gradU.getValue(ip);
+          Math::SpatialMatrix<Real>::Identity(dim, dim) + gradU.getValue(ip);
         const Real j = F.determinant();
         Real qRel = std::numeric_limits<Real>::infinity();
         if (j > Real(0))
-          qRel = F.squaredNorm()
-            / (static_cast<Real>(dim)
-               * std::pow(j, Real(2) / static_cast<Real>(dim)));
+          qRel = F.squaredNorm() /
+            (static_cast<Real>(dim) * std::pow(j, Real(2) / static_cast<Real>(dim)));
         jSamples.push_back(j);
         qSamples.push_back(qRel);
-        if (j < dist.minJ) dist.minJ = j;
-        if (qRel > dist.maxQ) dist.maxQ = qRel;
-        if (j <= jSafe) ++dist.numInadmissible;
-        if (j < Real(1.5) * jSafe) ++dist.numNearJSafe;
-        if (qRel > Real(0.7) * qMax) ++dist.numNearQMax;
+        if (j < dist.minJ)
+          dist.minJ = j;
+        if (qRel > dist.maxQ)
+          dist.maxQ = qRel;
+        if (j <= jSafe)
+          ++dist.numInadmissible;
+        if (j < Real(1.5) * jSafe)
+          ++dist.numNearJSafe;
+        if (qRel > Real(0.7) * qMax)
+          ++dist.numNearQMax;
       }
     }
     dist.numQuadPoints = jSamples.size();
     if (!jSamples.empty())
     {
       auto pct = [](std::vector<Real>& v, double p) -> Real {
-        const std::size_t k = static_cast<std::size_t>(
-            p * static_cast<double>(v.size()));
+        const std::size_t k = static_cast<std::size_t>(p * static_cast<double>(v.size()));
         std::nth_element(v.begin(), v.begin() + k, v.end());
         return v[k];
       };
@@ -218,66 +206,61 @@ namespace
 
   struct WavyCircleLevelSet
   {
-    Real cx = Real(0.5);
-    Real cy = Real(0.5);
-    Real R0 = Real(0.20);
-    Real amp = Real(0.05);
-    Real k = Real(6);
-    Real phase = Real(0);
+      Real cx = Real(0.5);
+      Real cy = Real(0.5);
+      Real R0 = Real(0.20);
+      Real amp = Real(0.05);
+      Real k = Real(6);
+      Real phase = Real(0);
 
-    Real phi(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r = std::sqrt(dx * dx + dy * dy);
-      const Real theta = std::atan2(dy, dx);
-      return r - (R0 + amp * std::cos(k * theta + phase));
-    }
+      Real phi(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r = std::sqrt(dx * dx + dy * dy);
+        const Real theta = std::atan2(dy, dx);
+        return r - (R0 + amp * std::cos(k * theta + phase));
+      }
 
-    Vec2 grad(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r2 = dx * dx + dy * dy;
-      const Real r = std::max(std::sqrt(r2), Real(1e-14));
-      const Real theta = std::atan2(dy, dx);
-      const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
-      const Real r2safe = std::max(r2, Real(1e-28));
-      return vec2(
-          dx / r - dRdtheta * (-dy / r2safe),
-          dy / r - dRdtheta * ( dx / r2safe));
-    }
+      Vec2 grad(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r2 = dx * dx + dy * dy;
+        const Real r = std::max(std::sqrt(r2), Real(1e-14));
+        const Real theta = std::atan2(dy, dx);
+        const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
+        const Real r2safe = std::max(r2, Real(1e-28));
+        return vec2(
+          dx / r - dRdtheta * (-dy / r2safe), dy / r - dRdtheta * (dx / r2safe));
+      }
   };
 
-  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {{
-    {{ Real(2) / 3, Real(1) / 6, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(2) / 3, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(1) / 6, Real(2) / 3 }}
-  }};
+  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {
+    {{{Real(2) / 3, Real(1) / 6, Real(1) / 6}}, {{Real(1) / 6, Real(2) / 3, Real(1) / 6}},
+      {{Real(1) / 6, Real(1) / 6, Real(2) / 3}}}};
 
   Real applyPhaseMomentMap(Real phi, Real epsilon)
   {
     return std::tanh(phi / epsilon);
   }
 
-  Vec2 interpolateVec(
-      const std::array<Vec2, 3>& values,
-      const std::array<Real, 3>& bary)
+  Vec2 interpolateVec(const std::array<Vec2, 3>& values, const std::array<Real, 3>& bary)
   {
     return bary[0] * values[0] + bary[1] * values[1] + bary[2] * values[2];
   }
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real area = 0;
-    Real moment = 0;
-    std::array<Vec2, 3> x;
+      Index index = 0;
+      Real area = 0;
+      Real moment = 0;
+      std::array<Vec2, 3> x;
   };
 
   template <class PhiFn>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
+    const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -286,8 +269,7 @@ namespace
       const auto& cell = *cellIt;
       const auto& vertices = cell.getVertices();
       if (vertices.size() != 3)
-        throw std::runtime_error(
-            "LevelSetWNGIRReconstruction expects triangular cells.");
+        throw std::runtime_error("LevelSetWNGIRReconstruction expects triangular cells.");
 
       CellMomentInfo info;
       info.index = cell.getIndex();
@@ -296,8 +278,7 @@ namespace
 
       const Vec2 e1 = info.x[1] - info.x[0];
       const Vec2 e2 = info.x[2] - info.x[0];
-      info.area =
-        std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
+      info.area = std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
 
       Real moment = 0;
       for (const auto& bary : TriangleBarycentricQuadrature)
@@ -327,7 +308,7 @@ namespace
   }
 
   std::size_t parseSizeTOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -339,8 +320,7 @@ namespace
     return fallback;
   }
 
-  Real parseRealOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -365,8 +345,7 @@ namespace
 
 int main(int argc, char** argv)
 {
-  const std::size_t n =
-    parseSizeTOption(argc, argv, "n", 50);
+  const std::size_t n = parseSizeTOption(argc, argv, "n", 50);
   constexpr std::size_t nFrames = 1;
   const Real cx = parseRealOption(argc, argv, "cx", Real(0.5));
   const Real cy = parseRealOption(argc, argv, "cy", Real(0.5));
@@ -392,15 +371,13 @@ int main(int argc, char** argv)
   constexpr Attribute interfaceAttribute = 10;
   constexpr Attribute boundaryAttribute = 20;
 
-  const auto wngirParams =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, interfaceAttribute, wngirDefaults);
-  const Real fitTol =
-    parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
+  const auto wngirParams = Rodin::Examples::makeWNGIRParameters(
+    argc, argv, h, interfaceAttribute, wngirDefaults);
+  const Real fitTol = parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
   const std::size_t qOrder = wngirParams.quadratureOrder;
   const bool trace = wngirParams.trace;
 
-  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { n, n });
+  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {n, n});
   mesh.scale(h);
   mesh.getConnectivity().compute(2, 1);
   mesh.getConnectivity().compute(1, 2);
@@ -411,8 +388,7 @@ int main(int argc, char** argv)
 #endif
 
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   using ScalarFES = H1<2, Real, LocalMesh>;
@@ -429,9 +405,9 @@ int main(int argc, char** argv)
 
   ScalarFES scalarFes(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      mesh);
+    mesh);
   ScalarP0 p0Fes(mesh);
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   VectorFES vectorFes(std::integral_constant<std::size_t, 2>{}, mesh, 2);
@@ -446,7 +422,7 @@ int main(int argc, char** argv)
   GridFunction phaseMoment(p0Fes);
   phaseMoment.setName("phase_moment");
   TrialFunction wngirTrial(vectorFes);
-  TestFunction  wngirTest(vectorFes);
+  TestFunction wngirTest(vectorFes);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");
   GridFunction du(vectorFes);
@@ -456,9 +432,9 @@ int main(int argc, char** argv)
   ScalarP0 p0FesMoved(moved);
   ScalarFES scalarFesMoved(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      moved);
+    moved);
   GridFunction movedLabel(p0FesMoved);
   movedLabel.setName("cell_label");
   GridFunction phiMoved(scalarFesMoved);
@@ -486,10 +462,9 @@ int main(int argc, char** argv)
 
   std::cout << "Wavy-circle WNGIR reconstruction on " << n << "x" << n
             << " unit-square mesh\n";
-  std::cout << "  R0=" << R0 << "  amp=" << amp << "  k=" << kLobes
-            << "  center=(" << cx << ", " << cy << ")"
-            << "  phase=" << phase
-            << "  wngirEll=" << wngirParams.ellM
+  std::cout << "  R0=" << R0 << "  amp=" << amp << "  k=" << kLobes << "  center=(" << cx
+            << ", " << cy << ")"
+            << "  phase=" << phase << "  wngirEll=" << wngirParams.ellM
             << "  betaMax=" << wngirParams.betaMax << '\n';
 
   std::size_t framesConverged = 0;
@@ -509,19 +484,16 @@ int main(int argc, char** argv)
     levelSet.phase = phase;
 
     std::cout << "\n--- Reconstruction"
-              << " : c=(" << std::fixed << std::setprecision(4)
-              << levelSet.cx << ", " << levelSet.cy << ")"
+              << " : c=(" << std::fixed << std::setprecision(4) << levelSet.cx << ", "
+              << levelSet.cy << ")"
               << "  phase=" << std::setprecision(3) << phase << " rad\n";
 
     clearXDMFRegionAttributes(mesh);
     for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                        boundaryAttribute);
+      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
-    const auto cellMoments =
-      collectCellMomentInfo(mesh,
-                            [&](const Vec2& p) { return levelSet.phi(p); },
-                            epsilon);
+    const auto cellMoments = collectCellMomentInfo(
+      mesh, [&](const Vec2& p) { return levelSet.phi(p); }, epsilon);
 
     std::unordered_map<Index, std::size_t> cellToLocal;
     std::vector<Index> localToCell;
@@ -545,24 +517,19 @@ int main(int argc, char** argv)
     for (auto faceIt = mesh.getFace(); faceIt; ++faceIt)
     {
       const Index facet = faceIt->getIndex();
-      const auto& incident =
-        mesh.getConnectivity().getIncidence({1, 2}, facet);
+      const auto& incident = mesh.getConnectivity().getIncidence({1, 2}, facet);
       if (incident.size() != 2)
         continue;
       const auto itA = cellToLocal.find(incident[0]);
       const auto itB = cellToLocal.find(incident[1]);
       if (itA == cellToLocal.end() || itB == cellToLocal.end())
         continue;
-      graphEdges.push_back({
-          static_cast<Index>(itA->second),
-          static_cast<Index>(itB->second),
-          lambdaC * facetLength(mesh, facet),
-          facet});
+      graphEdges.push_back({static_cast<Index>(itA->second),
+        static_cast<Index>(itB->second), lambdaC * facetLength(mesh, facet), facet});
     }
 
     const MinSTCut cut;
-    const MinSTCut::Result classified =
-      cut.classify(volumes, moments, graphEdges);
+    const MinSTCut::Result classified = cut.classify(volumes, moments, graphEdges);
 
     std::vector<Index> interfaceFacets;
     interfaceFacets.reserve(classified.cutEdges.size());
@@ -573,40 +540,33 @@ int main(int argc, char** argv)
     for (std::size_t local = 0; local < classified.labels.size(); ++local)
     {
       const Index cellIdx = localToCell[local];
-      mesh.setAttribute(
-          {mesh.getDimension(), cellIdx},
-          classified.labels[local] == MinSTCut::Inside
-            ? interiorAttribute
-            : exteriorAttribute);
+      mesh.setAttribute({mesh.getDimension(), cellIdx},
+        classified.labels[local] == MinSTCut::Inside ? interiorAttribute
+                                                     : exteriorAttribute);
     }
     for (const Index facet : interfaceFacets)
       mesh.setAttribute({mesh.getDimension() - 1, facet}, interfaceAttribute);
 
-    phiGf = [&](const Geometry::Point& p) -> Real
-    {
+    phiGf = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
 
-    RealFunction phi(
-        [&](const Geometry::Point& p) -> Real
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.phi(vec2(X(0), X(1)));
-        });
+    RealFunction phi([&](const Geometry::Point& p) -> Real {
+      const auto& X = p.getPhysicalCoordinates();
+      return levelSet.phi(vec2(X(0), X(1)));
+    });
     AnalyticVectorFunction gradPhi(
-        [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.grad(vec2(X(0), X(1)));
-        },
-        /*dimension=*/2);
+      [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+        const auto& X = p.getPhysicalCoordinates();
+        return levelSet.grad(vec2(X(0), X(1)));
+      },
+      /*dimension=*/2);
 
     u.getData().setZero();
     du.getData().setZero();
 
-    auto computeInterfaceFit = [&]() -> Real
-    {
+    auto computeInterfaceFit = [&]() -> Real {
       Real interfacePhi = 0;
       Real interfaceLen = 0;
       const auto& fes = u.getFiniteElementSpace();
@@ -649,7 +609,9 @@ int main(int argc, char** argv)
     if (verbose)
     {
       std::size_t insideCount = 0;
-      for (int lbl : classified.labels) if (lbl == MinSTCut::Inside) ++insideCount;
+      for (int lbl : classified.labels)
+        if (lbl == MinSTCut::Inside)
+          ++insideCount;
       std::cout << "    debug: facets=" << interfaceFacets.size()
                 << "  inside=" << insideCount
                 << "  outside=" << (classified.labels.size() - insideCount)
@@ -670,16 +632,12 @@ int main(int argc, char** argv)
       wngir.activeRMSTol = fitTol;
       Rodin::Adaptation::WNGIR wngirSolver(wngirTrial, wngirTest);
       wngirSolver.setParameters(wngir);
-      const auto wngirRep = wngirSolver.solve(
-          mesh, interfaceFacets, phi, gradPhi);
-      std::cout << "    wngir timing: it=" << wngirRep.iterations
-                << std::scientific << std::setprecision(2)
-                << "  assembly=" << wngirRep.tAssembly
-                << "  setup=" << wngirRep.tFactor
-                << "  solve=" << wngirRep.tSolve
+      const auto wngirRep = wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
+      std::cout << "    wngir timing: it=" << wngirRep.iterations << std::scientific
+                << std::setprecision(2) << "  assembly=" << wngirRep.tAssembly
+                << "  setup=" << wngirRep.tFactor << "  solve=" << wngirRep.tSolve
                 << "  cgIt=" << wngirRep.linearIterations
-                << "  cgErr=" << wngirRep.linearError
-                << "  ls=" << wngirRep.tLineSearch
+                << "  cgErr=" << wngirRep.linearError << "  ls=" << wngirRep.tLineSearch
                 << "  exit=" << wngirRep.exitReason << '\n';
       iterations = wngirRep.iterations;
       lastAlpha = wngirRep.lastAlpha;
@@ -694,15 +652,14 @@ int main(int argc, char** argv)
         bestU = u.getData();
       }
       if (trace)
-        std::cout << "      wngir sigma=" << wngirRep.sigma
-                  << "  (3h=" << Real(3) * h << ")\n";
+        std::cout << "      wngir sigma=" << wngirRep.sigma << "  (3h=" << Real(3) * h
+                  << ")\n";
     }
-
 
     u.getData() = bestU;
     interfaceFit = bestFit;
-    const auto bestAdm = evaluateWNGIRAdmissibilitySampled(
-        u, u.getData(), wngirParams.jMinRatio, qOrder);
+    const auto bestAdm =
+      evaluateWNGIRAdmissibilitySampled(u, u.getData(), wngirParams.jMinRatio, qOrder);
     minJ = bestAdm.minJ;
     maxQRel = bestAdm.maxQRel;
 
@@ -717,8 +674,7 @@ int main(int argc, char** argv)
       const Index cellIdx = cellIt->getIndex();
       const std::size_t local = cellToLocal.at(cellIdx);
       const Index dof = p0Fes.getGlobalIndex({D, cellIdx}, 0);
-      cellLabel.getData()(dof) =
-        static_cast<Real>(classified.labels[local]);
+      cellLabel.getData()(dof) = static_cast<Real>(classified.labels[local]);
       phaseMoment.getData()(dof) = cellMoments[local].moment;
     }
 
@@ -753,28 +709,22 @@ int main(int argc, char** argv)
       const Real jK = sigDetAu / src.Jscale;
       jMoved.getData()(dof) = jK;
       const Math::SpatialMatrix<Real> F = dst.A * src.A.inverse();
-      qRelMoved.getData()(dof) =
-        F.squaredNorm() / (Real(2) * std::max(jK, Real(1e-30)));
+      qRelMoved.getData()(dof) = F.squaredNorm() / (Real(2) * std::max(jK, Real(1e-30)));
       movedLabel.getData()(dof) =
         static_cast<Real>(classified.labels[cellToLocal.at(cellIdx)]);
     }
 
-    phiMoved = [&](const Geometry::Point& p) -> Real
-    {
+    phiMoved = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
 
-    std::cout << "    WNGIR it=" << iterations
-              << "  fit=" << std::scientific << std::setprecision(3)
-              << interfaceFit
-              << "  alpha=" << lastAlpha
-              << "  step=" << acceptedStep
-              << "  min_j=" << minJ
+    std::cout << "    WNGIR it=" << iterations << "  fit=" << std::scientific
+              << std::setprecision(3) << interfaceFit << "  alpha=" << lastAlpha
+              << "  step=" << acceptedStep << "  min_j=" << minJ
               << "  max_qrel=" << maxQRel
               << "  converged=" << (converged ? "yes" : "best-effort")
-              << "  exit=" << exitReason
-              << '\n';
+              << "  exit=" << exitReason << '\n';
 
     xdmf.write(t).flush();
   }
@@ -782,8 +732,7 @@ int main(int argc, char** argv)
   xdmf.close();
 
   std::cout << "\nSummary\n";
-  std::cout << "  cases converged: " << framesConverged
-            << " / " << nFrames << '\n';
+  std::cout << "  cases converged: " << framesConverged << " / " << nFrames << '\n';
   if (!finalFitPerFrame.empty())
   {
     const Real fitMin =
@@ -794,10 +743,8 @@ int main(int argc, char** argv)
     for (Real x : finalFitPerFrame)
       fitMean += x;
     fitMean /= static_cast<Real>(finalFitPerFrame.size());
-    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific
-              << std::setprecision(3) << fitMin
-              << "  mean=" << fitMean
-              << "  max=" << fitMax << '\n';
+    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific << std::setprecision(3)
+              << fitMin << "  mean=" << fitMean << "  max=" << fitMax << '\n';
   }
 
   return 0;

--- a/examples/Geometry/LevelSetWNGIRReconstruction3D.cpp
+++ b/examples/Geometry/LevelSetWNGIRReconstruction3D.cpp
@@ -57,18 +57,14 @@ namespace
 
   Real det3(const Vec3& a, const Vec3& b, const Vec3& c)
   {
-    return
-      a(0) * (b(1) * c(2) - b(2) * c(1))
-      - a(1) * (b(0) * c(2) - b(2) * c(0))
-      + a(2) * (b(0) * c(1) - b(1) * c(0));
+    return a(0) * (b(1) * c(2) - b(2) * c(1)) - a(1) * (b(0) * c(2) - b(2) * c(0)) +
+      a(2) * (b(0) * c(1) - b(1) * c(0));
   }
 
   Vec3 cross3(const Vec3& a, const Vec3& b)
   {
     return vec3(
-        a(1) * b(2) - a(2) * b(1),
-        a(2) * b(0) - a(0) * b(2),
-        a(0) * b(1) - a(1) * b(0));
+      a(1) * b(2) - a(2) * b(1), a(2) * b(0) - a(0) * b(2), a(0) * b(1) - a(1) * b(0));
   }
 
   Mat3 edgeMatrix(const std::array<Vec3, 4>& x)
@@ -88,77 +84,71 @@ namespace
 
   struct LobedSphereLevelSet
   {
-    Vec3 c = vec3(Real(0.5), Real(0.5), Real(0.5));
-    Real R0 = Real(0.25);
-    Real amp = Real(0.05);
-    Real lobes = Real(6);
-    Real phase = Real(0);
+      Vec3 c = vec3(Real(0.5), Real(0.5), Real(0.5));
+      Real R0 = Real(0.25);
+      Real amp = Real(0.05);
+      Real lobes = Real(6);
+      Real phase = Real(0);
 
-    Real radius(const Vec3& p) const
-    {
-      const Vec3 d = p - c;
-      const Real r = std::max(d.norm(), Real(1e-14));
-      const Real theta = std::atan2(d(1), d(0));
-      const Real mu = d(2) / r;
-      return R0 + amp * std::cos(lobes * theta + phase)
-        * (Real(1) - mu * mu);
-    }
+      Real radius(const Vec3& p) const
+      {
+        const Vec3 d = p - c;
+        const Real r = std::max(d.norm(), Real(1e-14));
+        const Real theta = std::atan2(d(1), d(0));
+        const Real mu = d(2) / r;
+        return R0 + amp * std::cos(lobes * theta + phase) * (Real(1) - mu * mu);
+      }
 
-    Real phi(const Vec3& p) const
-    {
-      return (p - c).norm() - radius(p);
-    }
+      Real phi(const Vec3& p) const
+      {
+        return (p - c).norm() - radius(p);
+      }
 
-    Vec3 grad(const Vec3& p) const
-    {
-      const Vec3 x = p - c;
-      const Real x0 = x(0);
-      const Real x1 = x(1);
-      const Real x2 = x(2);
-      const Real r2 = x.squaredNorm();
-      const Real r = std::sqrt(r2);
-      if (r <= Real(1e-14))
-        return vec3(0, 0, 0);
+      Vec3 grad(const Vec3& p) const
+      {
+        const Vec3 x = p - c;
+        const Real x0 = x(0);
+        const Real x1 = x(1);
+        const Real x2 = x(2);
+        const Real r2 = x.squaredNorm();
+        const Real r = std::sqrt(r2);
+        if (r <= Real(1e-14))
+          return vec3(0, 0, 0);
 
-      const Real rho2 = x0 * x0 + x1 * x1;
-      const Real theta = std::atan2(x1, x0);
-      const Real angle = lobes * theta + phase;
-      const Real cosA = std::cos(angle);
-      const Real sinA = std::sin(angle);
+        const Real rho2 = x0 * x0 + x1 * x1;
+        const Real theta = std::atan2(x1, x0);
+        const Real angle = lobes * theta + phase;
+        const Real cosA = std::cos(angle);
+        const Real sinA = std::sin(angle);
 
-      const Real invR2 = Real(1) / r2;
-      const Real invR4 = invR2 * invR2;
-      const Vec3 gradR =
-        amp * (
-            -sinA * lobes * vec3(-x1 * invR2, x0 * invR2, 0)
-            + cosA * vec3(
-              Real(2) * x0 * x2 * x2 * invR4,
-              Real(2) * x1 * x2 * x2 * invR4,
-             -Real(2) * x2 * rho2 * invR4));
+        const Real invR2 = Real(1) / r2;
+        const Real invR4 = invR2 * invR2;
+        const Vec3 gradR = amp *
+          (-sinA * lobes * vec3(-x1 * invR2, x0 * invR2, 0) +
+            cosA *
+              vec3(Real(2) * x0 * x2 * x2 * invR4, Real(2) * x1 * x2 * x2 * invR4,
+                -Real(2) * x2 * rho2 * invR4));
 
-      return x / r - gradR;
-    }
+        return x / r - gradR;
+      }
   };
 
-  constexpr std::array<std::array<Real, 4>, 4> TetraBarycentricQuadrature = {{
-    {{ Real(0.5854101966249685), Real(0.1381966011250105),
-       Real(0.1381966011250105), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.5854101966249685),
-       Real(0.1381966011250105), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.1381966011250105),
-       Real(0.5854101966249685), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.1381966011250105),
-       Real(0.1381966011250105), Real(0.5854101966249685) }}
-  }};
+  constexpr std::array<std::array<Real, 4>, 4> TetraBarycentricQuadrature = {
+    {{{Real(0.5854101966249685), Real(0.1381966011250105), Real(0.1381966011250105),
+       Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.5854101966249685), Real(0.1381966011250105),
+        Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.1381966011250105), Real(0.5854101966249685),
+        Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.1381966011250105), Real(0.1381966011250105),
+        Real(0.5854101966249685)}}}};
 
   Real applyPhaseMomentMap(Real phi, Real epsilon)
   {
     return std::tanh(phi / epsilon);
   }
 
-  Vec3 interpolateVec(
-      const std::array<Vec3, 4>& values,
-      const std::array<Real, 4>& bary)
+  Vec3 interpolateVec(const std::array<Vec3, 4>& values, const std::array<Real, 4>& bary)
   {
     Vec3 out = vec3(0, 0, 0);
     for (std::size_t i = 0; i < 4; ++i)
@@ -168,15 +158,15 @@ namespace
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real volume = 0;
-    Real moment = 0;
-    std::array<Vec3, 4> x;
+      Index index = 0;
+      Real volume = 0;
+      Real moment = 0;
+      std::array<Vec3, 4> x;
   };
 
   template <class PhiFn>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
+    const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -186,17 +176,16 @@ namespace
       const auto& vertices = cell.getVertices();
       if (vertices.size() != 4)
         throw std::runtime_error(
-            "LevelSetWNGIRReconstruction3D expects tetrahedral cells.");
+          "LevelSetWNGIRReconstruction3D expects tetrahedral cells.");
 
       CellMomentInfo info;
       info.index = cell.getIndex();
       for (std::size_t i = 0; i < 4; ++i)
         info.x[i] = mesh.getVertexCoordinates(vertices[i]);
 
-      info.volume = std::abs(det3(
-            info.x[1] - info.x[0],
-            info.x[2] - info.x[0],
-            info.x[3] - info.x[0])) / Real(6);
+      info.volume = std::abs(det3(info.x[1] - info.x[0], info.x[2] - info.x[0],
+                      info.x[3] - info.x[0])) /
+        Real(6);
 
       Real moment = 0;
       for (const auto& bary : TetraBarycentricQuadrature)
@@ -248,19 +237,16 @@ namespace
         pm(1, a) = X(1);
         pm(2, a) = X(2);
       }
-      mesh.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      mesh.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
   }
 #endif
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const LocalMesh& mesh,
-      LocalMesh& moved,
-      const Displacement& u)
+    const LocalMesh& mesh, LocalMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -269,11 +255,8 @@ namespace
     {
       const Vec3 x = mesh.getVertexCoordinates(vertex);
       const auto& dofs = uFes.getDOFs(0, vertex);
-      moved.setVertexCoordinates(
-          vertex,
-          vec3(x(0) + uData(dofs[0]),
-               x(1) + uData(dofs[1]),
-               x(2) + uData(dofs[2])));
+      moved.setVertexCoordinates(vertex,
+        vec3(x(0) + uData(dofs[0]), x(1) + uData(dofs[1]), x(2) + uData(dofs[2])));
     }
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -291,26 +274,22 @@ namespace
       {
         const auto& rc = geomFe.getNode(a);
         cell.getTransformation().transform(X, rc);
-        const Real ux =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3));
-        const Real uy =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 1));
-        const Real uz =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 2));
+        const Real ux = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3));
+        const Real uy = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 1));
+        const Real uz = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 2));
         pm(0, a) = X(0) + ux;
         pm(1, a) = X(1) + uy;
         pm(2, a) = X(2) + uz;
       }
-      moved.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      moved.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
 #endif
   }
 
   std::size_t parseSizeTOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -322,8 +301,7 @@ namespace
     return fallback;
   }
 
-  Real parseRealOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -357,10 +335,8 @@ int main(int argc, char** argv)
   const Real kLobes = parseRealOption(argc, argv, "lobes", Real(6));
 
   const Real h = Real(1) / static_cast<Real>(n - 1);
-  const Real epsilon =
-    parseRealOption(argc, argv, "classifier-eps", Real(1.25) * h);
-  const Real lambdaC =
-    parseRealOption(argc, argv, "classifier-lambda", Real(0.004));
+  const Real epsilon = parseRealOption(argc, argv, "classifier-eps", Real(1.25) * h);
+  const Real lambdaC = parseRealOption(argc, argv, "classifier-lambda", Real(0.004));
   Rodin::Examples::WNGIRExampleDefaults wngirDefaults;
   wngirDefaults.maxIterations = 120;
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -375,16 +351,13 @@ int main(int argc, char** argv)
   constexpr Attribute interfaceAttribute = 10;
   constexpr Attribute boundaryAttribute = 20;
 
-  const auto wngirParams =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, interfaceAttribute, wngirDefaults);
-  const Real fitTol =
-    parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
+  const auto wngirParams = Rodin::Examples::makeWNGIRParameters(
+    argc, argv, h, interfaceAttribute, wngirDefaults);
+  const Real fitTol = parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
   const std::size_t qOrder = wngirParams.quadratureOrder;
   const bool trace = wngirParams.trace;
 
-  LocalMesh mesh =
-    LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
   mesh.scale(h);
   mesh.getConnectivity().compute(3, 2);
   mesh.getConnectivity().compute(2, 3);
@@ -398,8 +371,7 @@ int main(int argc, char** argv)
 #endif
 
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   using ScalarFES = H1<2, Real, LocalMesh>;
@@ -412,9 +384,9 @@ int main(int argc, char** argv)
 
   ScalarFES scalarFes(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      mesh);
+    mesh);
   ScalarP0 p0Fes(mesh);
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   VectorFES vectorFes(std::integral_constant<std::size_t, 2>{}, mesh, 3);
@@ -429,7 +401,7 @@ int main(int argc, char** argv)
   GridFunction phaseMoment(p0Fes);
   phaseMoment.setName("phase_moment");
   TrialFunction wngirTrial(vectorFes);
-  TestFunction  wngirTest(vectorFes);
+  TestFunction wngirTest(vectorFes);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");
 
@@ -437,9 +409,9 @@ int main(int argc, char** argv)
   ScalarP0 p0FesMoved(moved);
   ScalarFES scalarFesMoved(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      moved);
+    moved);
   GridFunction movedLabel(p0FesMoved);
   movedLabel.setName("cell_label");
   GridFunction phiMoved(scalarFesMoved);
@@ -471,22 +443,19 @@ int main(int argc, char** argv)
   levelSet.lobes = kLobes;
   levelSet.phase = phase;
 
-  std::cout << "Lobed-sphere WNGIR reconstruction on " << n << "x" << n
-            << "x" << n << " tetrahedral unit-cube mesh\n";
-  std::cout << "  R0=" << R0 << "  amp=" << amp << "  lobes=" << kLobes
-            << "  center=(" << cx << ", " << cy << ", " << cz << ")"
-            << "  phase=" << phase
-            << "  wngirEll=" << wngirParams.ellM
+  std::cout << "Lobed-sphere WNGIR reconstruction on " << n << "x" << n << "x" << n
+            << " tetrahedral unit-cube mesh\n";
+  std::cout << "  R0=" << R0 << "  amp=" << amp << "  lobes=" << kLobes << "  center=("
+            << cx << ", " << cy << ", " << cz << ")"
+            << "  phase=" << phase << "  wngirEll=" << wngirParams.ellM
             << "  betaMax=" << wngirParams.betaMax << '\n';
 
   clearXDMFRegionAttributes(mesh);
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
   const auto cellMoments =
-    collectCellMomentInfo(
-        mesh, [&](const Vec3& p) { return levelSet.phi(p); }, epsilon);
+    collectCellMomentInfo(mesh, [&](const Vec3& p) { return levelSet.phi(p); }, epsilon);
 
   std::unordered_map<Index, std::size_t> cellToLocal;
   std::vector<Index> localToCell;
@@ -517,16 +486,12 @@ int main(int argc, char** argv)
     const auto itB = cellToLocal.find(incident[1]);
     if (itA == cellToLocal.end() || itB == cellToLocal.end())
       continue;
-    graphEdges.push_back({
-        static_cast<Index>(itA->second),
-        static_cast<Index>(itB->second),
-        lambdaC * faceArea(mesh, facet),
-        facet});
+    graphEdges.push_back({static_cast<Index>(itA->second),
+      static_cast<Index>(itB->second), lambdaC * faceArea(mesh, facet), facet});
   }
 
   const MinSTCut cut;
-  const MinSTCut::Result classified =
-    cut.classify(volumes, moments, graphEdges);
+  const MinSTCut::Result classified = cut.classify(volumes, moments, graphEdges);
 
   std::vector<Index> interfaceFacets;
   interfaceFacets.reserve(classified.cutEdges.size());
@@ -537,39 +502,32 @@ int main(int argc, char** argv)
   for (std::size_t local = 0; local < classified.labels.size(); ++local)
   {
     const Index cellIdx = localToCell[local];
-    mesh.setAttribute(
-        {mesh.getDimension(), cellIdx},
-        classified.labels[local] == MinSTCut::Inside
-          ? interiorAttribute
-          : exteriorAttribute);
+    mesh.setAttribute({mesh.getDimension(), cellIdx},
+      classified.labels[local] == MinSTCut::Inside ? interiorAttribute
+                                                   : exteriorAttribute);
   }
   for (const Index facet : interfaceFacets)
     mesh.setAttribute({mesh.getDimension() - 1, facet}, interfaceAttribute);
 
-  phiGf = [&](const Geometry::Point& p) -> Real
-  {
+  phiGf = [&](const Geometry::Point& p) -> Real {
     const auto& X = p.getCoordinates();
     return levelSet.phi(vec3(X(0), X(1), X(2)));
   };
 
-  RealFunction phi(
-      [&](const Geometry::Point& p) -> Real
-      {
-        const auto& X = p.getPhysicalCoordinates();
-        return levelSet.phi(vec3(X(0), X(1), X(2)));
-      });
+  RealFunction phi([&](const Geometry::Point& p) -> Real {
+    const auto& X = p.getPhysicalCoordinates();
+    return levelSet.phi(vec3(X(0), X(1), X(2)));
+  });
   AnalyticVectorFunction gradPhi(
-      [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-      {
-        const auto& X = p.getPhysicalCoordinates();
-        return levelSet.grad(vec3(X(0), X(1), X(2)));
-      },
-      /*dimension=*/3);
+    [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+      const auto& X = p.getPhysicalCoordinates();
+      return levelSet.grad(vec3(X(0), X(1), X(2)));
+    },
+    /*dimension=*/3);
 
   u.getData().setZero();
 
-  auto computeInterfaceFit = [&]() -> Real
-  {
+  auto computeInterfaceFit = [&]() -> Real {
     Real interfacePhi = 0;
     Real interfaceArea = 0;
     const auto& fes = u.getFiniteElementSpace();
@@ -579,10 +537,8 @@ int main(int argc, char** argv)
       const auto face = mesh.getFace(facet);
       const auto& fe = fes.getFiniteElement(meshDim - 1, facet);
       const std::size_t nLocal = fe.getCount();
-      const std::size_t qFitOrder =
-        std::max<std::size_t>(qOrder, 2 * fe.getOrder());
-      const auto& qf =
-        QF::PolytopeQuadratureFormula::get(qFitOrder, face->getGeometry());
+      const std::size_t qFitOrder = std::max<std::size_t>(qOrder, 2 * fe.getOrder());
+      const auto& qf = QF::PolytopeQuadratureFormula::get(qFitOrder, face->getGeometry());
       const auto& quad = face->getQuadrature(qf);
       std::vector<Index> dofs(nLocal);
       for (std::size_t l = 0; l < nLocal; ++l)
@@ -614,7 +570,8 @@ int main(int argc, char** argv)
   {
     std::size_t insideCount = 0;
     for (int lbl : classified.labels)
-      if (lbl == MinSTCut::Inside) ++insideCount;
+      if (lbl == MinSTCut::Inside)
+        ++insideCount;
     std::cout << "    debug: facets=" << interfaceFacets.size()
               << "  inside=" << insideCount
               << "  outside=" << (classified.labels.size() - insideCount)
@@ -634,16 +591,12 @@ int main(int argc, char** argv)
     wngir.activeRMSTol = fitTol;
     Rodin::Adaptation::WNGIR wngirSolver(wngirTrial, wngirTest);
     wngirSolver.setParameters(wngir);
-    const auto wngirRep = wngirSolver.solve(
-        mesh, interfaceFacets, phi, gradPhi);
-    std::cout << "    wngir timing: it=" << wngirRep.iterations
-              << std::scientific << std::setprecision(2)
-              << "  assembly=" << wngirRep.tAssembly
-              << "  setup=" << wngirRep.tFactor
-              << "  solve=" << wngirRep.tSolve
+    const auto wngirRep = wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
+    std::cout << "    wngir timing: it=" << wngirRep.iterations << std::scientific
+              << std::setprecision(2) << "  assembly=" << wngirRep.tAssembly
+              << "  setup=" << wngirRep.tFactor << "  solve=" << wngirRep.tSolve
               << "  cgIt=" << wngirRep.linearIterations
-              << "  cgErr=" << wngirRep.linearError
-              << "  ls=" << wngirRep.tLineSearch
+              << "  cgErr=" << wngirRep.linearError << "  ls=" << wngirRep.tLineSearch
               << "  exit=" << wngirRep.exitReason << '\n';
     iterations = wngirRep.iterations;
     lastAlpha = wngirRep.lastAlpha;
@@ -658,8 +611,8 @@ int main(int argc, char** argv)
       bestU = u.getData();
     }
     if (trace)
-      std::cout << "      wngir sigma=" << wngirRep.sigma
-                << "  (3h=" << Real(3) * h << ")\n";
+      std::cout << "      wngir sigma=" << wngirRep.sigma << "  (3h=" << Real(3) * h
+                << ")\n";
   }
 
   u.getData() = bestU;
@@ -672,8 +625,7 @@ int main(int argc, char** argv)
     const Index cellIdx = cellIt->getIndex();
     const std::size_t local = cellToLocal.at(cellIdx);
     const Index dof = p0Fes.getGlobalIndex({D, cellIdx}, 0);
-    cellLabel.getData()(dof) =
-      static_cast<Real>(classified.labels[local]);
+    cellLabel.getData()(dof) = static_cast<Real>(classified.labels[local]);
     phaseMoment.getData()(dof) = cellMoments[local].moment;
   }
 
@@ -719,16 +671,14 @@ int main(int argc, char** argv)
     const Real j = A1.determinant() / A0.determinant();
     const Mat3 F = A1 * A0.inverse();
     jMoved.getData()(dof) = j;
-    qRelMoved.getData()(dof) =
-      j > Real(0)
-        ? F.squaredNorm() / (Real(3) * std::pow(j, Real(2) / Real(3)))
-        : std::numeric_limits<Real>::infinity();
+    qRelMoved.getData()(dof) = j > Real(0)
+      ? F.squaredNorm() / (Real(3) * std::pow(j, Real(2) / Real(3)))
+      : std::numeric_limits<Real>::infinity();
     movedLabel.getData()(dof) =
       static_cast<Real>(classified.labels[cellToLocal.at(cellIdx)]);
   }
 
-  phiMoved = [&](const Geometry::Point& p) -> Real
-  {
+  phiMoved = [&](const Geometry::Point& p) -> Real {
     const auto& X = p.getCoordinates();
     return levelSet.phi(vec3(X(0), X(1), X(2)));
   };
@@ -738,22 +688,16 @@ int main(int argc, char** argv)
   xdmf.write(0).flush();
   xdmf.close();
 
-  std::cout << "    WNGIR it=" << iterations
-            << "  fit=" << std::scientific << std::setprecision(3)
-            << interfaceFit
-            << "  alpha=" << lastAlpha
-            << "  step=" << acceptedStep
-            << "  min_j=" << minJ
-            << "  max_qrel=" << maxQRel
+  std::cout << "    WNGIR it=" << iterations << "  fit=" << std::scientific
+            << std::setprecision(3) << interfaceFit << "  alpha=" << lastAlpha
+            << "  step=" << acceptedStep << "  min_j=" << minJ << "  max_qrel=" << maxQRel
             << "  converged=" << (converged ? "yes" : "best-effort")
-            << "  exit=" << exitReason
-            << '\n';
+            << "  exit=" << exitReason << '\n';
   std::cout << "\nSummary\n";
   std::cout << "  cases converged: " << (converged ? 1 : 0) << " / 1\n";
-  std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific
-            << std::setprecision(3) << interfaceFit
-            << "  mean=" << interfaceFit
-            << "  max=" << interfaceFit << '\n';
+  std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific << std::setprecision(3)
+            << interfaceFit << "  mean=" << interfaceFit << "  max=" << interfaceFit
+            << '\n';
 
   return 0;
 }

--- a/examples/Geometry/LevelSetWNGIRSweep.cpp
+++ b/examples/Geometry/LevelSetWNGIRSweep.cpp
@@ -73,19 +73,16 @@ namespace
         pm(0, a) = X(0);
         pm(1, a) = X(1);
       }
-      mesh.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      mesh.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
   }
 #endif
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const LocalMesh& mesh,
-      LocalMesh& moved,
-      const Displacement& u)
+    const LocalMesh& mesh, LocalMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -95,8 +92,7 @@ namespace
       const Vec2 x = mesh.getVertexCoordinates(vertex);
       const auto& dofs = uFes.getDOFs(0, vertex);
       moved.setVertexCoordinates(
-          vertex,
-          vec2(x(0) + uData(dofs[0]), x(1) + uData(dofs[1])));
+        vertex, vec2(x(0) + uData(dofs[0]), x(1) + uData(dofs[1])));
     }
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -114,31 +110,28 @@ namespace
       {
         const auto& rc = geomFe.getNode(a);
         cell.getTransformation().transform(X, rc);
-        const Real ux =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2));
-        const Real uy =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2 + 1));
+        const Real ux = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2));
+        const Real uy = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 2 + 1));
         pm(0, a) = X(0) + ux;
         pm(1, a) = X(1) + uy;
       }
-      moved.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      moved.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
 #endif
   }
 
   struct AdmissibilityDistribution
   {
-    Real minJ = std::numeric_limits<Real>::infinity();
-    Real p10J = 0, p50J = 0, p90J = 0;
-    Real maxQ = 0;
-    Real p10Q = 0, p50Q = 0, p90Q = 0;
-    std::size_t numQuadPoints = 0;
-    std::size_t numNearJSafe = 0;   // j_K < 1.5·j_safe
-    std::size_t numNearQMax = 0;    // Q_rel > 0.7·Q_max
-    std::size_t numInadmissible = 0;
+      Real minJ = std::numeric_limits<Real>::infinity();
+      Real p10J = 0, p50J = 0, p90J = 0;
+      Real maxQ = 0;
+      Real p10Q = 0, p50Q = 0, p90Q = 0;
+      std::size_t numQuadPoints = 0;
+      std::size_t numNearJSafe = 0;   // j_K < 1.5·j_safe
+      std::size_t numNearQMax = 0;    // Q_rel > 0.7·Q_max
+      std::size_t numInadmissible = 0;
   };
 
   /// Sampled per-cell admissibility distribution (j, Q_rel) at all
@@ -148,12 +141,8 @@ namespace
   /// only conceptually — same dominant cost (cell-loop gradU eval),
   /// but accumulates a distribution rather than min/max.
   template <class Displacement>
-  AdmissibilityDistribution
-  evaluateAdmissibilityDistribution(
-      Displacement& u,
-      Real jSafe,
-      Real qMax,
-      std::size_t qOrder = 2)
+  AdmissibilityDistribution evaluateAdmissibilityDistribution(
+    Displacement& u, Real jSafe, Real qMax, std::size_t qOrder = 2)
   {
     using Variational::IntegrationPoint;
     using Variational::Jacobian;
@@ -172,40 +161,39 @@ namespace
     for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
     {
       const auto& cell = *cellIt;
-      const auto& fe =
-        fes.getFiniteElement(cell.getDimension(), cell.getIndex());
-      const auto& qf =
-        QF::PolytopeQuadratureFormula::get(
-            qOrder, cell.getGeometry());
+      const auto& fe = fes.getFiniteElement(cell.getDimension(), cell.getIndex());
+      const auto& qf = QF::PolytopeQuadratureFormula::get(qOrder, cell.getGeometry());
       const auto& quadrature = cell.getQuadrature(qf);
       for (std::size_t q = 0; q < quadrature.getSize(); ++q)
       {
         const auto& pt = quadrature.getPoint(q);
         const IntegrationPoint ip(pt, &qf, q);
         Math::SpatialMatrix<Real> F =
-          Math::SpatialMatrix<Real>::Identity(dim, dim)
-          + gradU.getValue(ip);
+          Math::SpatialMatrix<Real>::Identity(dim, dim) + gradU.getValue(ip);
         const Real j = F.determinant();
         Real qRel = std::numeric_limits<Real>::infinity();
         if (j > Real(0))
-          qRel = F.squaredNorm()
-            / (static_cast<Real>(dim)
-               * std::pow(j, Real(2) / static_cast<Real>(dim)));
+          qRel = F.squaredNorm() /
+            (static_cast<Real>(dim) * std::pow(j, Real(2) / static_cast<Real>(dim)));
         jSamples.push_back(j);
         qSamples.push_back(qRel);
-        if (j < dist.minJ) dist.minJ = j;
-        if (qRel > dist.maxQ) dist.maxQ = qRel;
-        if (j <= jSafe) ++dist.numInadmissible;
-        if (j < Real(1.5) * jSafe) ++dist.numNearJSafe;
-        if (qRel > Real(0.7) * qMax) ++dist.numNearQMax;
+        if (j < dist.minJ)
+          dist.minJ = j;
+        if (qRel > dist.maxQ)
+          dist.maxQ = qRel;
+        if (j <= jSafe)
+          ++dist.numInadmissible;
+        if (j < Real(1.5) * jSafe)
+          ++dist.numNearJSafe;
+        if (qRel > Real(0.7) * qMax)
+          ++dist.numNearQMax;
       }
     }
     dist.numQuadPoints = jSamples.size();
     if (!jSamples.empty())
     {
       auto pct = [](std::vector<Real>& v, double p) -> Real {
-        const std::size_t k = static_cast<std::size_t>(
-            p * static_cast<double>(v.size()));
+        const std::size_t k = static_cast<std::size_t>(p * static_cast<double>(v.size()));
         std::nth_element(v.begin(), v.begin() + k, v.end());
         return v[k];
       };
@@ -221,66 +209,61 @@ namespace
 
   struct WavyCircleLevelSet
   {
-    Real cx = Real(0.5);
-    Real cy = Real(0.5);
-    Real R0 = Real(0.20);
-    Real amp = Real(0.05);
-    Real k = Real(6);
-    Real phase = Real(0);
+      Real cx = Real(0.5);
+      Real cy = Real(0.5);
+      Real R0 = Real(0.20);
+      Real amp = Real(0.05);
+      Real k = Real(6);
+      Real phase = Real(0);
 
-    Real phi(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r = std::sqrt(dx * dx + dy * dy);
-      const Real theta = std::atan2(dy, dx);
-      return r - (R0 + amp * std::cos(k * theta + phase));
-    }
+      Real phi(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r = std::sqrt(dx * dx + dy * dy);
+        const Real theta = std::atan2(dy, dx);
+        return r - (R0 + amp * std::cos(k * theta + phase));
+      }
 
-    Vec2 grad(const Vec2& p) const
-    {
-      const Real dx = p(0) - cx;
-      const Real dy = p(1) - cy;
-      const Real r2 = dx * dx + dy * dy;
-      const Real r = std::max(std::sqrt(r2), Real(1e-14));
-      const Real theta = std::atan2(dy, dx);
-      const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
-      const Real r2safe = std::max(r2, Real(1e-28));
-      return vec2(
-          dx / r - dRdtheta * (-dy / r2safe),
-          dy / r - dRdtheta * ( dx / r2safe));
-    }
+      Vec2 grad(const Vec2& p) const
+      {
+        const Real dx = p(0) - cx;
+        const Real dy = p(1) - cy;
+        const Real r2 = dx * dx + dy * dy;
+        const Real r = std::max(std::sqrt(r2), Real(1e-14));
+        const Real theta = std::atan2(dy, dx);
+        const Real dRdtheta = -amp * k * std::sin(k * theta + phase);
+        const Real r2safe = std::max(r2, Real(1e-28));
+        return vec2(
+          dx / r - dRdtheta * (-dy / r2safe), dy / r - dRdtheta * (dx / r2safe));
+      }
   };
 
-  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {{
-    {{ Real(2) / 3, Real(1) / 6, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(2) / 3, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(1) / 6, Real(2) / 3 }}
-  }};
+  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {
+    {{{Real(2) / 3, Real(1) / 6, Real(1) / 6}}, {{Real(1) / 6, Real(2) / 3, Real(1) / 6}},
+      {{Real(1) / 6, Real(1) / 6, Real(2) / 3}}}};
 
   Real applyPhaseMomentMap(Real phi, Real epsilon)
   {
     return std::tanh(phi / epsilon);
   }
 
-  Vec2 interpolateVec(
-      const std::array<Vec2, 3>& values,
-      const std::array<Real, 3>& bary)
+  Vec2 interpolateVec(const std::array<Vec2, 3>& values, const std::array<Real, 3>& bary)
   {
     return bary[0] * values[0] + bary[1] * values[1] + bary[2] * values[2];
   }
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real area = 0;
-    Real moment = 0;
-    std::array<Vec2, 3> x;
+      Index index = 0;
+      Real area = 0;
+      Real moment = 0;
+      std::array<Vec2, 3> x;
   };
 
   template <class PhiFn>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
+    const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -289,8 +272,7 @@ namespace
       const auto& cell = *cellIt;
       const auto& vertices = cell.getVertices();
       if (vertices.size() != 3)
-        throw std::runtime_error(
-            "LevelSetWNGIRSweep expects triangular cells.");
+        throw std::runtime_error("LevelSetWNGIRSweep expects triangular cells.");
 
       CellMomentInfo info;
       info.index = cell.getIndex();
@@ -299,8 +281,7 @@ namespace
 
       const Vec2 e1 = info.x[1] - info.x[0];
       const Vec2 e2 = info.x[2] - info.x[0];
-      info.area =
-        std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
+      info.area = std::abs(Real(0.5) * (e1(0) * e2(1) - e1(1) * e2(0)));
 
       Real moment = 0;
       for (const auto& bary : TriangleBarycentricQuadrature)
@@ -330,7 +311,7 @@ namespace
   }
 
   std::size_t parseSizeTOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -342,8 +323,7 @@ namespace
     return fallback;
   }
 
-  Real parseRealOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -368,10 +348,8 @@ namespace
 
 int main(int argc, char** argv)
 {
-  const std::size_t n =
-    parseSizeTOption(argc, argv, "n", 50);
-  const std::size_t nFrames =
-    parseSizeTOption(argc, argv, "frames", 40);
+  const std::size_t n = parseSizeTOption(argc, argv, "n", 50);
+  const std::size_t nFrames = parseSizeTOption(argc, argv, "frames", 40);
 
   const Real orbitR = parseRealOption(argc, argv, "orbitR", Real(0.10));
   const Real amp = parseRealOption(argc, argv, "amp", Real(0.05));
@@ -393,15 +371,13 @@ int main(int argc, char** argv)
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   wngirDefaults.betaMax = 10;
 #endif
-  const auto wngirParams =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, interfaceAttribute, wngirDefaults);
-  const Real fitTol =
-    parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
+  const auto wngirParams = Rodin::Examples::makeWNGIRParameters(
+    argc, argv, h, interfaceAttribute, wngirDefaults);
+  const Real fitTol = parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
   const std::size_t qOrder = wngirParams.quadratureOrder;
   const bool trace = wngirParams.trace;
 
-  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { n, n });
+  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {n, n});
   mesh.scale(h);
   mesh.getConnectivity().compute(2, 1);
   mesh.getConnectivity().compute(1, 2);
@@ -412,8 +388,7 @@ int main(int argc, char** argv)
 #endif
 
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
   using ScalarP1 = P1<Real, LocalMesh>;
   using ScalarP0 = P0<Real, LocalMesh>;
@@ -438,7 +413,7 @@ int main(int argc, char** argv)
   GridFunction phaseMoment(p0Fes);
   phaseMoment.setName("phase_moment");
   TrialFunction wngirTrial(vectorFes);
-  TestFunction  wngirTest(vectorFes);
+  TestFunction wngirTest(vectorFes);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");
   GridFunction du(vectorFes);
@@ -472,11 +447,10 @@ int main(int argc, char** argv)
   movedGrid.add(qRelMoved, IO::XDMF::Center::Cell);
   movedGrid.add(phiMoved, IO::XDMF::Center::Node);
 
-  std::cout << "Wavy-circle WNGIR sweep on " << n << "x" << n
-            << " unit-square mesh, " << nFrames << " frames\n";
+  std::cout << "Wavy-circle WNGIR sweep on " << n << "x" << n << " unit-square mesh, "
+            << nFrames << " frames\n";
   std::cout << "  R0=" << R0 << "  amp=" << amp << "  k=" << kLobes
-            << "  orbit R=" << orbitR
-            << "  wngirEll=" << wngirParams.ellM << '\n';
+            << "  orbit R=" << orbitR << "  wngirEll=" << wngirParams.ellM << '\n';
 
   std::size_t framesConverged = 0;
   std::vector<Real> finalFitPerFrame;
@@ -495,20 +469,16 @@ int main(int argc, char** argv)
     levelSet.k = kLobes;
     levelSet.phase = angle;
 
-    std::cout << "\n--- Frame " << std::setw(2) << frame
-              << " : c=(" << std::fixed << std::setprecision(4)
-              << levelSet.cx << ", " << levelSet.cy << ")"
+    std::cout << "\n--- Frame " << std::setw(2) << frame << " : c=(" << std::fixed
+              << std::setprecision(4) << levelSet.cx << ", " << levelSet.cy << ")"
               << "  phase=" << std::setprecision(3) << angle << " rad\n";
 
     clearXDMFRegionAttributes(mesh);
     for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                        boundaryAttribute);
+      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
-    const auto cellMoments =
-      collectCellMomentInfo(mesh,
-                            [&](const Vec2& p) { return levelSet.phi(p); },
-                            epsilon);
+    const auto cellMoments = collectCellMomentInfo(
+      mesh, [&](const Vec2& p) { return levelSet.phi(p); }, epsilon);
 
     std::unordered_map<Index, std::size_t> cellToLocal;
     std::vector<Index> localToCell;
@@ -532,24 +502,19 @@ int main(int argc, char** argv)
     for (auto faceIt = mesh.getFace(); faceIt; ++faceIt)
     {
       const Index facet = faceIt->getIndex();
-      const auto& incident =
-        mesh.getConnectivity().getIncidence({1, 2}, facet);
+      const auto& incident = mesh.getConnectivity().getIncidence({1, 2}, facet);
       if (incident.size() != 2)
         continue;
       const auto itA = cellToLocal.find(incident[0]);
       const auto itB = cellToLocal.find(incident[1]);
       if (itA == cellToLocal.end() || itB == cellToLocal.end())
         continue;
-      graphEdges.push_back({
-          static_cast<Index>(itA->second),
-          static_cast<Index>(itB->second),
-          lambdaC * facetLength(mesh, facet),
-          facet});
+      graphEdges.push_back({static_cast<Index>(itA->second),
+        static_cast<Index>(itB->second), lambdaC * facetLength(mesh, facet), facet});
     }
 
     const MinSTCut cut;
-    const MinSTCut::Result classified =
-      cut.classify(volumes, moments, graphEdges);
+    const MinSTCut::Result classified = cut.classify(volumes, moments, graphEdges);
 
     std::vector<Index> interfaceFacets;
     interfaceFacets.reserve(classified.cutEdges.size());
@@ -560,40 +525,33 @@ int main(int argc, char** argv)
     for (std::size_t local = 0; local < classified.labels.size(); ++local)
     {
       const Index cellIdx = localToCell[local];
-      mesh.setAttribute(
-          {mesh.getDimension(), cellIdx},
-          classified.labels[local] == MinSTCut::Inside
-            ? interiorAttribute
-            : exteriorAttribute);
+      mesh.setAttribute({mesh.getDimension(), cellIdx},
+        classified.labels[local] == MinSTCut::Inside ? interiorAttribute
+                                                     : exteriorAttribute);
     }
     for (const Index facet : interfaceFacets)
       mesh.setAttribute({mesh.getDimension() - 1, facet}, interfaceAttribute);
 
-    phiGf = [&](const Geometry::Point& p) -> Real
-    {
+    phiGf = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
 
-    RealFunction phi(
-        [&](const Geometry::Point& p) -> Real
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.phi(vec2(X(0), X(1)));
-        });
+    RealFunction phi([&](const Geometry::Point& p) -> Real {
+      const auto& X = p.getPhysicalCoordinates();
+      return levelSet.phi(vec2(X(0), X(1)));
+    });
     AnalyticVectorFunction gradPhi(
-        [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.grad(vec2(X(0), X(1)));
-        },
-        /*dimension=*/2);
+      [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+        const auto& X = p.getPhysicalCoordinates();
+        return levelSet.grad(vec2(X(0), X(1)));
+      },
+      /*dimension=*/2);
 
     u.getData().setZero();
     du.getData().setZero();
 
-    auto computeInterfaceFit = [&]() -> Real
-    {
+    auto computeInterfaceFit = [&]() -> Real {
       Real interfacePhi = 0;
       Real interfaceLen = 0;
       const auto& fes = u.getFiniteElementSpace();
@@ -636,7 +594,9 @@ int main(int argc, char** argv)
     if (verbose)
     {
       std::size_t insideCount = 0;
-      for (int lbl : classified.labels) if (lbl == MinSTCut::Inside) ++insideCount;
+      for (int lbl : classified.labels)
+        if (lbl == MinSTCut::Inside)
+          ++insideCount;
       std::cout << "    debug: facets=" << interfaceFacets.size()
                 << "  inside=" << insideCount
                 << "  outside=" << (classified.labels.size() - insideCount)
@@ -657,16 +617,12 @@ int main(int argc, char** argv)
       wngir.activeRMSTol = fitTol;
       Rodin::Adaptation::WNGIR wngirSolver(wngirTrial, wngirTest);
       wngirSolver.setParameters(wngir);
-      const auto wngirRep = wngirSolver.solve(
-          mesh, interfaceFacets, phi, gradPhi);
-      std::cout << "    wngir timing: it=" << wngirRep.iterations
-                << std::scientific << std::setprecision(2)
-                << "  assembly=" << wngirRep.tAssembly
-                << "  setup=" << wngirRep.tFactor
-                << "  solve=" << wngirRep.tSolve
+      const auto wngirRep = wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
+      std::cout << "    wngir timing: it=" << wngirRep.iterations << std::scientific
+                << std::setprecision(2) << "  assembly=" << wngirRep.tAssembly
+                << "  setup=" << wngirRep.tFactor << "  solve=" << wngirRep.tSolve
                 << "  cgIt=" << wngirRep.linearIterations
-                << "  cgErr=" << wngirRep.linearError
-                << "  ls=" << wngirRep.tLineSearch
+                << "  cgErr=" << wngirRep.linearError << "  ls=" << wngirRep.tLineSearch
                 << "  exit=" << wngirRep.exitReason << '\n';
       iterations = wngirRep.iterations;
       lastAlpha = wngirRep.lastAlpha;
@@ -681,15 +637,14 @@ int main(int argc, char** argv)
         bestU = u.getData();
       }
       if (trace)
-        std::cout << "      wngir sigma=" << wngirRep.sigma
-                  << "  (3h=" << Real(3) * h << ")\n";
+        std::cout << "      wngir sigma=" << wngirRep.sigma << "  (3h=" << Real(3) * h
+                  << ")\n";
     }
-
 
     u.getData() = bestU;
     interfaceFit = bestFit;
-    const auto bestAdm = evaluateWNGIRAdmissibilitySampled(
-        u, u.getData(), wngirParams.jMinRatio, qOrder);
+    const auto bestAdm =
+      evaluateWNGIRAdmissibilitySampled(u, u.getData(), wngirParams.jMinRatio, qOrder);
     minJ = bestAdm.minJ;
     maxQRel = bestAdm.maxQRel;
 
@@ -704,8 +659,7 @@ int main(int argc, char** argv)
       const Index cellIdx = cellIt->getIndex();
       const std::size_t local = cellToLocal.at(cellIdx);
       const Index dof = p0Fes.getGlobalIndex({D, cellIdx}, 0);
-      cellLabel.getData()(dof) =
-        static_cast<Real>(classified.labels[local]);
+      cellLabel.getData()(dof) = static_cast<Real>(classified.labels[local]);
       phaseMoment.getData()(dof) = cellMoments[local].moment;
     }
 
@@ -740,28 +694,22 @@ int main(int argc, char** argv)
       const Real jK = sigDetAu / src.Jscale;
       jMoved.getData()(dof) = jK;
       const Math::SpatialMatrix<Real> F = dst.A * src.A.inverse();
-      qRelMoved.getData()(dof) =
-        F.squaredNorm() / (Real(2) * std::max(jK, Real(1e-30)));
+      qRelMoved.getData()(dof) = F.squaredNorm() / (Real(2) * std::max(jK, Real(1e-30)));
       movedLabel.getData()(dof) =
         static_cast<Real>(classified.labels[cellToLocal.at(cellIdx)]);
     }
 
-    phiMoved = [&](const Geometry::Point& p) -> Real
-    {
+    phiMoved = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec2(X(0), X(1)));
     };
 
-    std::cout << "    WNGIR it=" << iterations
-              << "  fit=" << std::scientific << std::setprecision(3)
-              << interfaceFit
-              << "  alpha=" << lastAlpha
-              << "  step=" << acceptedStep
-              << "  min_j=" << minJ
+    std::cout << "    WNGIR it=" << iterations << "  fit=" << std::scientific
+              << std::setprecision(3) << interfaceFit << "  alpha=" << lastAlpha
+              << "  step=" << acceptedStep << "  min_j=" << minJ
               << "  max_qrel=" << maxQRel
               << "  converged=" << (converged ? "yes" : "best-effort")
-              << "  exit=" << exitReason
-              << '\n';
+              << "  exit=" << exitReason << '\n';
 
     xdmf.write(t).flush();
   }
@@ -769,8 +717,7 @@ int main(int argc, char** argv)
   xdmf.close();
 
   std::cout << "\nSummary\n";
-  std::cout << "  frames converged: " << framesConverged
-            << " / " << nFrames << '\n';
+  std::cout << "  frames converged: " << framesConverged << " / " << nFrames << '\n';
   if (!finalFitPerFrame.empty())
   {
     const Real fitMin =
@@ -781,10 +728,8 @@ int main(int argc, char** argv)
     for (Real x : finalFitPerFrame)
       fitMean += x;
     fitMean /= static_cast<Real>(finalFitPerFrame.size());
-    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific
-              << std::setprecision(3) << fitMin
-              << "  mean=" << fitMean
-              << "  max=" << fitMax << '\n';
+    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific << std::setprecision(3)
+              << fitMin << "  mean=" << fitMean << "  max=" << fitMax << '\n';
   }
 
   return 0;

--- a/examples/Geometry/LevelSetWNGIRSweep3D.cpp
+++ b/examples/Geometry/LevelSetWNGIRSweep3D.cpp
@@ -59,18 +59,14 @@ namespace
 
   Real det3(const Vec3& a, const Vec3& b, const Vec3& c)
   {
-    return
-      a(0) * (b(1) * c(2) - b(2) * c(1))
-      - a(1) * (b(0) * c(2) - b(2) * c(0))
-      + a(2) * (b(0) * c(1) - b(1) * c(0));
+    return a(0) * (b(1) * c(2) - b(2) * c(1)) - a(1) * (b(0) * c(2) - b(2) * c(0)) +
+      a(2) * (b(0) * c(1) - b(1) * c(0));
   }
 
   Vec3 cross3(const Vec3& a, const Vec3& b)
   {
     return vec3(
-        a(1) * b(2) - a(2) * b(1),
-        a(2) * b(0) - a(0) * b(2),
-        a(0) * b(1) - a(1) * b(0));
+      a(1) * b(2) - a(2) * b(1), a(2) * b(0) - a(0) * b(2), a(0) * b(1) - a(1) * b(0));
   }
 
   Mat3 edgeMatrix(const std::array<Vec3, 4>& x)
@@ -90,77 +86,71 @@ namespace
 
   struct LobedSphereLevelSet
   {
-    Vec3 c = vec3(Real(0.5), Real(0.5), Real(0.5));
-    Real R0 = Real(0.25);
-    Real amp = Real(0.05);
-    Real lobes = Real(6);
-    Real phase = Real(0);
+      Vec3 c = vec3(Real(0.5), Real(0.5), Real(0.5));
+      Real R0 = Real(0.25);
+      Real amp = Real(0.05);
+      Real lobes = Real(6);
+      Real phase = Real(0);
 
-    Real radius(const Vec3& p) const
-    {
-      const Vec3 d = p - c;
-      const Real r = std::max(d.norm(), Real(1e-14));
-      const Real theta = std::atan2(d(1), d(0));
-      const Real mu = d(2) / r;
-      return R0 + amp * std::cos(lobes * theta + phase)
-        * (Real(1) - mu * mu);
-    }
+      Real radius(const Vec3& p) const
+      {
+        const Vec3 d = p - c;
+        const Real r = std::max(d.norm(), Real(1e-14));
+        const Real theta = std::atan2(d(1), d(0));
+        const Real mu = d(2) / r;
+        return R0 + amp * std::cos(lobes * theta + phase) * (Real(1) - mu * mu);
+      }
 
-    Real phi(const Vec3& p) const
-    {
-      return (p - c).norm() - radius(p);
-    }
+      Real phi(const Vec3& p) const
+      {
+        return (p - c).norm() - radius(p);
+      }
 
-    Vec3 grad(const Vec3& p) const
-    {
-      const Vec3 x = p - c;
-      const Real x0 = x(0);
-      const Real x1 = x(1);
-      const Real x2 = x(2);
-      const Real r2 = x.squaredNorm();
-      const Real r = std::sqrt(r2);
-      if (r <= Real(1e-14))
-        return vec3(0, 0, 0);
+      Vec3 grad(const Vec3& p) const
+      {
+        const Vec3 x = p - c;
+        const Real x0 = x(0);
+        const Real x1 = x(1);
+        const Real x2 = x(2);
+        const Real r2 = x.squaredNorm();
+        const Real r = std::sqrt(r2);
+        if (r <= Real(1e-14))
+          return vec3(0, 0, 0);
 
-      const Real rho2 = x0 * x0 + x1 * x1;
-      const Real theta = std::atan2(x1, x0);
-      const Real angle = lobes * theta + phase;
-      const Real cosA = std::cos(angle);
-      const Real sinA = std::sin(angle);
+        const Real rho2 = x0 * x0 + x1 * x1;
+        const Real theta = std::atan2(x1, x0);
+        const Real angle = lobes * theta + phase;
+        const Real cosA = std::cos(angle);
+        const Real sinA = std::sin(angle);
 
-      const Real invR2 = Real(1) / r2;
-      const Real invR4 = invR2 * invR2;
-      const Vec3 gradR =
-        amp * (
-            -sinA * lobes * vec3(-x1 * invR2, x0 * invR2, 0)
-            + cosA * vec3(
-              Real(2) * x0 * x2 * x2 * invR4,
-              Real(2) * x1 * x2 * x2 * invR4,
-             -Real(2) * x2 * rho2 * invR4));
+        const Real invR2 = Real(1) / r2;
+        const Real invR4 = invR2 * invR2;
+        const Vec3 gradR = amp *
+          (-sinA * lobes * vec3(-x1 * invR2, x0 * invR2, 0) +
+            cosA *
+              vec3(Real(2) * x0 * x2 * x2 * invR4, Real(2) * x1 * x2 * x2 * invR4,
+                -Real(2) * x2 * rho2 * invR4));
 
-      return x / r - gradR;
-    }
+        return x / r - gradR;
+      }
   };
 
-  constexpr std::array<std::array<Real, 4>, 4> TetraBarycentricQuadrature = {{
-    {{ Real(0.5854101966249685), Real(0.1381966011250105),
-       Real(0.1381966011250105), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.5854101966249685),
-       Real(0.1381966011250105), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.1381966011250105),
-       Real(0.5854101966249685), Real(0.1381966011250105) }},
-    {{ Real(0.1381966011250105), Real(0.1381966011250105),
-       Real(0.1381966011250105), Real(0.5854101966249685) }}
-  }};
+  constexpr std::array<std::array<Real, 4>, 4> TetraBarycentricQuadrature = {
+    {{{Real(0.5854101966249685), Real(0.1381966011250105), Real(0.1381966011250105),
+       Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.5854101966249685), Real(0.1381966011250105),
+        Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.1381966011250105), Real(0.5854101966249685),
+        Real(0.1381966011250105)}},
+      {{Real(0.1381966011250105), Real(0.1381966011250105), Real(0.1381966011250105),
+        Real(0.5854101966249685)}}}};
 
   Real applyPhaseMomentMap(Real phi, Real epsilon)
   {
     return std::tanh(phi / epsilon);
   }
 
-  Vec3 interpolateVec(
-      const std::array<Vec3, 4>& values,
-      const std::array<Real, 4>& bary)
+  Vec3 interpolateVec(const std::array<Vec3, 4>& values, const std::array<Real, 4>& bary)
   {
     Vec3 out = vec3(0, 0, 0);
     for (std::size_t i = 0; i < 4; ++i)
@@ -170,15 +160,15 @@ namespace
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real volume = 0;
-    Real moment = 0;
-    std::array<Vec3, 4> x;
+      Index index = 0;
+      Real volume = 0;
+      Real moment = 0;
+      std::array<Vec3, 4> x;
   };
 
   template <class PhiFn>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
+    const LocalMesh& mesh, PhiFn&& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -187,18 +177,16 @@ namespace
       const auto& cell = *cellIt;
       const auto& vertices = cell.getVertices();
       if (vertices.size() != 4)
-        throw std::runtime_error(
-            "LevelSetWNGIRSweep3D expects tetrahedral cells.");
+        throw std::runtime_error("LevelSetWNGIRSweep3D expects tetrahedral cells.");
 
       CellMomentInfo info;
       info.index = cell.getIndex();
       for (std::size_t i = 0; i < 4; ++i)
         info.x[i] = mesh.getVertexCoordinates(vertices[i]);
 
-      info.volume = std::abs(det3(
-            info.x[1] - info.x[0],
-            info.x[2] - info.x[0],
-            info.x[3] - info.x[0])) / Real(6);
+      info.volume = std::abs(det3(info.x[1] - info.x[0], info.x[2] - info.x[0],
+                      info.x[3] - info.x[0])) /
+        Real(6);
 
       Real moment = 0;
       for (const auto& bary : TetraBarycentricQuadrature)
@@ -249,19 +237,16 @@ namespace
         pm(1, a) = X(1);
         pm(2, a) = X(2);
       }
-      mesh.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      mesh.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
   }
 #endif
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const LocalMesh& mesh,
-      LocalMesh& moved,
-      const Displacement& u)
+    const LocalMesh& mesh, LocalMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -270,11 +255,8 @@ namespace
     {
       const Vec3 x = mesh.getVertexCoordinates(vertex);
       const auto& dofs = uFes.getDOFs(0, vertex);
-      moved.setVertexCoordinates(
-          vertex,
-          vec3(x(0) + uData(dofs[0]),
-               x(1) + uData(dofs[1]),
-               x(2) + uData(dofs[2])));
+      moved.setVertexCoordinates(vertex,
+        vec3(x(0) + uData(dofs[0]), x(1) + uData(dofs[1]), x(2) + uData(dofs[2])));
     }
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -291,26 +273,22 @@ namespace
       {
         const auto& rc = geomFe.getNode(a);
         cell.getTransformation().transform(X, rc);
-        const Real ux =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3));
-        const Real uy =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 1));
-        const Real uz =
-          uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 2));
+        const Real ux = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3));
+        const Real uy = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 1));
+        const Real uz = uData(uFes.getGlobalIndex({D, cell.getIndex()}, a * 3 + 2));
         pm(0, a) = X(0) + ux;
         pm(1, a) = X(1) + uy;
         pm(2, a) = X(2) + uz;
       }
-      moved.setPolytopeTransformation(
-          {D, cell.getIndex()},
-          new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
-            std::move(pm), geomFe));
+      moved.setPolytopeTransformation({D, cell.getIndex()},
+        new Geometry::ParametricTransformation<Variational::RealH1Element<2>>(
+          std::move(pm), geomFe));
     }
 #endif
   }
 
   std::size_t parseSizeTOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -322,8 +300,7 @@ namespace
     return fallback;
   }
 
-  Real parseRealOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -348,8 +325,7 @@ namespace
 int main(int argc, char** argv)
 {
   const std::size_t n = parseSizeTOption(argc, argv, "n", 24);
-  const std::size_t nFrames =
-    parseSizeTOption(argc, argv, "frames", 24);
+  const std::size_t nFrames = parseSizeTOption(argc, argv, "frames", 24);
 
   const Real orbitR = parseRealOption(argc, argv, "orbitR", Real(0.08));
   const Real amp = parseRealOption(argc, argv, "amp", Real(0.045));
@@ -357,10 +333,8 @@ int main(int argc, char** argv)
   const Real kLobes = parseRealOption(argc, argv, "lobes", Real(6));
 
   const Real h = Real(1) / static_cast<Real>(n - 1);
-  const Real epsilon =
-    parseRealOption(argc, argv, "classifier-eps", Real(1.25) * h);
-  const Real lambdaC =
-    parseRealOption(argc, argv, "classifier-lambda", Real(0.004));
+  const Real epsilon = parseRealOption(argc, argv, "classifier-eps", Real(1.25) * h);
+  const Real lambdaC = parseRealOption(argc, argv, "classifier-lambda", Real(0.004));
   Rodin::Examples::WNGIRExampleDefaults wngirDefaults;
   wngirDefaults.maxIterations = 120;
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
@@ -375,16 +349,13 @@ int main(int argc, char** argv)
   constexpr Attribute interfaceAttribute = 10;
   constexpr Attribute boundaryAttribute = 20;
 
-  const auto wngirParams =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, interfaceAttribute, wngirDefaults);
-  const Real fitTol =
-    parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
+  const auto wngirParams = Rodin::Examples::makeWNGIRParameters(
+    argc, argv, h, interfaceAttribute, wngirDefaults);
+  const Real fitTol = parseRealOption(argc, argv, "fit-tol", wngirParams.activeRMSTol);
   const std::size_t qOrder = wngirParams.quadratureOrder;
   const bool trace = wngirParams.trace;
 
-  LocalMesh mesh =
-    LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, { n, n, n });
+  LocalMesh mesh = LocalMesh::UniformGrid(Polytope::Type::Tetrahedron, {n, n, n});
   mesh.scale(h);
   mesh.getConnectivity().compute(3, 2);
   mesh.getConnectivity().compute(2, 3);
@@ -398,8 +369,7 @@ int main(int argc, char** argv)
 #endif
 
   for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                      boundaryAttribute);
+    mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   using ScalarFES = H1<2, Real, LocalMesh>;
@@ -412,9 +382,9 @@ int main(int argc, char** argv)
 
   ScalarFES scalarFes(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      mesh);
+    mesh);
   ScalarP0 p0Fes(mesh);
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
   VectorFES vectorFes(std::integral_constant<std::size_t, 2>{}, mesh, 3);
@@ -429,7 +399,7 @@ int main(int argc, char** argv)
   GridFunction phaseMoment(p0Fes);
   phaseMoment.setName("phase_moment");
   TrialFunction wngirTrial(vectorFes);
-  TestFunction  wngirTest(vectorFes);
+  TestFunction wngirTest(vectorFes);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");
 
@@ -437,9 +407,9 @@ int main(int argc, char** argv)
   ScalarP0 p0FesMoved(moved);
   ScalarFES scalarFesMoved(
 #ifdef RODIN_WNGIR_P2_DISPLACEMENT
-      std::integral_constant<std::size_t, 2>{},
+    std::integral_constant<std::size_t, 2>{},
 #endif
-      moved);
+    moved);
   GridFunction movedLabel(p0FesMoved);
   movedLabel.setName("cell_label");
   GridFunction phiMoved(scalarFesMoved);
@@ -467,8 +437,7 @@ int main(int argc, char** argv)
   std::cout << "Lobed-sphere WNGIR sweep on " << n << "x" << n << "x" << n
             << " tetrahedral unit-cube mesh, " << nFrames << " frames\n";
   std::cout << "  R0=" << R0 << "  amp=" << amp << "  lobes=" << kLobes
-            << "  orbit R=" << orbitR
-            << "  wngirEll=" << wngirParams.ellM
+            << "  orbit R=" << orbitR << "  wngirEll=" << wngirParams.ellM
             << "  betaMax=" << wngirParams.betaMax << '\n';
 
   std::size_t framesConverged = 0;
@@ -481,29 +450,25 @@ int main(int argc, char** argv)
     const Real angle = Real(2) * Real(M_PI) * t;
 
     LobedSphereLevelSet levelSet;
-    levelSet.c = vec3(
-        Real(0.5) + orbitR * std::cos(angle),
-        Real(0.5) + orbitR * std::sin(angle),
+    levelSet.c =
+      vec3(Real(0.5) + orbitR * std::cos(angle), Real(0.5) + orbitR * std::sin(angle),
         Real(0.5) + Real(0.5) * orbitR * std::sin(Real(2) * angle));
     levelSet.R0 = R0;
     levelSet.amp = amp;
     levelSet.lobes = kLobes;
     levelSet.phase = angle;
 
-    std::cout << "\n--- Frame " << std::setw(2) << frame
-              << " : c=(" << std::fixed << std::setprecision(4)
-              << levelSet.c(0) << ", " << levelSet.c(1) << ", "
+    std::cout << "\n--- Frame " << std::setw(2) << frame << " : c=(" << std::fixed
+              << std::setprecision(4) << levelSet.c(0) << ", " << levelSet.c(1) << ", "
               << levelSet.c(2) << ")"
               << "  phase=" << std::setprecision(3) << angle << " rad\n";
 
     clearXDMFRegionAttributes(mesh);
     for (auto faceIt = mesh.getBoundary(); faceIt; ++faceIt)
-      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()},
-                        boundaryAttribute);
+      mesh.setAttribute({mesh.getDimension() - 1, faceIt->getIndex()}, boundaryAttribute);
 
-    const auto cellMoments =
-      collectCellMomentInfo(
-          mesh, [&](const Vec3& p) { return levelSet.phi(p); }, epsilon);
+    const auto cellMoments = collectCellMomentInfo(
+      mesh, [&](const Vec3& p) { return levelSet.phi(p); }, epsilon);
 
     std::unordered_map<Index, std::size_t> cellToLocal;
     std::vector<Index> localToCell;
@@ -527,24 +492,19 @@ int main(int argc, char** argv)
     for (auto faceIt = mesh.getFace(); faceIt; ++faceIt)
     {
       const Index facet = faceIt->getIndex();
-      const auto& incident =
-        mesh.getConnectivity().getIncidence({2, 3}, facet);
+      const auto& incident = mesh.getConnectivity().getIncidence({2, 3}, facet);
       if (incident.size() != 2)
         continue;
       const auto itA = cellToLocal.find(incident[0]);
       const auto itB = cellToLocal.find(incident[1]);
       if (itA == cellToLocal.end() || itB == cellToLocal.end())
         continue;
-      graphEdges.push_back({
-          static_cast<Index>(itA->second),
-          static_cast<Index>(itB->second),
-          lambdaC * faceArea(mesh, facet),
-          facet});
+      graphEdges.push_back({static_cast<Index>(itA->second),
+        static_cast<Index>(itB->second), lambdaC * faceArea(mesh, facet), facet});
     }
 
     const MinSTCut cut;
-    const MinSTCut::Result classified =
-      cut.classify(volumes, moments, graphEdges);
+    const MinSTCut::Result classified = cut.classify(volumes, moments, graphEdges);
 
     std::vector<Index> interfaceFacets;
     interfaceFacets.reserve(classified.cutEdges.size());
@@ -555,39 +515,32 @@ int main(int argc, char** argv)
     for (std::size_t local = 0; local < classified.labels.size(); ++local)
     {
       const Index cellIdx = localToCell[local];
-      mesh.setAttribute(
-          {mesh.getDimension(), cellIdx},
-          classified.labels[local] == MinSTCut::Inside
-            ? interiorAttribute
-            : exteriorAttribute);
+      mesh.setAttribute({mesh.getDimension(), cellIdx},
+        classified.labels[local] == MinSTCut::Inside ? interiorAttribute
+                                                     : exteriorAttribute);
     }
     for (const Index facet : interfaceFacets)
       mesh.setAttribute({mesh.getDimension() - 1, facet}, interfaceAttribute);
 
-    phiGf = [&](const Geometry::Point& p) -> Real
-    {
+    phiGf = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec3(X(0), X(1), X(2)));
     };
 
-    RealFunction phi(
-        [&](const Geometry::Point& p) -> Real
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.phi(vec3(X(0), X(1), X(2)));
-        });
+    RealFunction phi([&](const Geometry::Point& p) -> Real {
+      const auto& X = p.getPhysicalCoordinates();
+      return levelSet.phi(vec3(X(0), X(1), X(2)));
+    });
     AnalyticVectorFunction gradPhi(
-        [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-        {
-          const auto& X = p.getPhysicalCoordinates();
-          return levelSet.grad(vec3(X(0), X(1), X(2)));
-        },
-        /*dimension=*/3);
+      [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+        const auto& X = p.getPhysicalCoordinates();
+        return levelSet.grad(vec3(X(0), X(1), X(2)));
+      },
+      /*dimension=*/3);
 
     u.getData().setZero();
 
-    auto computeInterfaceFit = [&]() -> Real
-    {
+    auto computeInterfaceFit = [&]() -> Real {
       Real interfacePhi = 0;
       Real interfaceArea = 0;
       const auto& fes = u.getFiniteElementSpace();
@@ -597,8 +550,7 @@ int main(int argc, char** argv)
         const auto face = mesh.getFace(facet);
         const auto& fe = fes.getFiniteElement(meshDim - 1, facet);
         const std::size_t nLocal = fe.getCount();
-        const std::size_t qFitOrder =
-          std::max<std::size_t>(qOrder, 2 * fe.getOrder());
+        const std::size_t qFitOrder = std::max<std::size_t>(qOrder, 2 * fe.getOrder());
         const auto& qf =
           QF::PolytopeQuadratureFormula::get(qFitOrder, face->getGeometry());
         const auto& quad = face->getQuadrature(qf);
@@ -632,7 +584,8 @@ int main(int argc, char** argv)
     {
       std::size_t insideCount = 0;
       for (int lbl : classified.labels)
-        if (lbl == MinSTCut::Inside) ++insideCount;
+        if (lbl == MinSTCut::Inside)
+          ++insideCount;
       std::cout << "    debug: facets=" << interfaceFacets.size()
                 << "  inside=" << insideCount
                 << "  outside=" << (classified.labels.size() - insideCount)
@@ -652,16 +605,12 @@ int main(int argc, char** argv)
       wngir.activeRMSTol = fitTol;
       Rodin::Adaptation::WNGIR wngirSolver(wngirTrial, wngirTest);
       wngirSolver.setParameters(wngir);
-      const auto wngirRep = wngirSolver.solve(
-          mesh, interfaceFacets, phi, gradPhi);
-      std::cout << "    wngir timing: it=" << wngirRep.iterations
-                << std::scientific << std::setprecision(2)
-                << "  assembly=" << wngirRep.tAssembly
-                << "  setup=" << wngirRep.tFactor
-                << "  solve=" << wngirRep.tSolve
+      const auto wngirRep = wngirSolver.solve(mesh, interfaceFacets, phi, gradPhi);
+      std::cout << "    wngir timing: it=" << wngirRep.iterations << std::scientific
+                << std::setprecision(2) << "  assembly=" << wngirRep.tAssembly
+                << "  setup=" << wngirRep.tFactor << "  solve=" << wngirRep.tSolve
                 << "  cgIt=" << wngirRep.linearIterations
-                << "  cgErr=" << wngirRep.linearError
-                << "  ls=" << wngirRep.tLineSearch
+                << "  cgErr=" << wngirRep.linearError << "  ls=" << wngirRep.tLineSearch
                 << "  exit=" << wngirRep.exitReason << '\n';
       iterations = wngirRep.iterations;
       lastAlpha = wngirRep.lastAlpha;
@@ -676,8 +625,8 @@ int main(int argc, char** argv)
         bestU = u.getData();
       }
       if (trace)
-        std::cout << "      wngir sigma=" << wngirRep.sigma
-                  << "  (3h=" << Real(3) * h << ")\n";
+        std::cout << "      wngir sigma=" << wngirRep.sigma << "  (3h=" << Real(3) * h
+                  << ")\n";
     }
 
     u.getData() = bestU;
@@ -694,8 +643,7 @@ int main(int argc, char** argv)
       const Index cellIdx = cellIt->getIndex();
       const std::size_t local = cellToLocal.at(cellIdx);
       const Index dof = p0Fes.getGlobalIndex({D, cellIdx}, 0);
-      cellLabel.getData()(dof) =
-        static_cast<Real>(classified.labels[local]);
+      cellLabel.getData()(dof) = static_cast<Real>(classified.labels[local]);
       phaseMoment.getData()(dof) = cellMoments[local].moment;
     }
 
@@ -741,30 +689,24 @@ int main(int argc, char** argv)
       const Real j = A1.determinant() / A0.determinant();
       const Mat3 F = A1 * A0.inverse();
       jMoved.getData()(dof) = j;
-      qRelMoved.getData()(dof) =
-        j > Real(0)
-          ? F.squaredNorm() / (Real(3) * std::pow(j, Real(2) / Real(3)))
-          : std::numeric_limits<Real>::infinity();
+      qRelMoved.getData()(dof) = j > Real(0)
+        ? F.squaredNorm() / (Real(3) * std::pow(j, Real(2) / Real(3)))
+        : std::numeric_limits<Real>::infinity();
       movedLabel.getData()(dof) =
         static_cast<Real>(classified.labels[cellToLocal.at(cellIdx)]);
     }
 
-    phiMoved = [&](const Geometry::Point& p) -> Real
-    {
+    phiMoved = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       return levelSet.phi(vec3(X(0), X(1), X(2)));
     };
 
-    std::cout << "    WNGIR it=" << iterations
-              << "  fit=" << std::scientific << std::setprecision(3)
-              << interfaceFit
-              << "  alpha=" << lastAlpha
-              << "  step=" << acceptedStep
-              << "  min_j=" << minJ
+    std::cout << "    WNGIR it=" << iterations << "  fit=" << std::scientific
+              << std::setprecision(3) << interfaceFit << "  alpha=" << lastAlpha
+              << "  step=" << acceptedStep << "  min_j=" << minJ
               << "  max_qrel=" << maxQRel
               << "  converged=" << (converged ? "yes" : "best-effort")
-              << "  exit=" << exitReason
-              << '\n';
+              << "  exit=" << exitReason << '\n';
 
     xdmf.write(t).flush();
   }
@@ -772,8 +714,7 @@ int main(int argc, char** argv)
   xdmf.close();
 
   std::cout << "\nSummary\n";
-  std::cout << "  frames converged: " << framesConverged
-            << " / " << nFrames << '\n';
+  std::cout << "  frames converged: " << framesConverged << " / " << nFrames << '\n';
   if (!finalFitPerFrame.empty())
   {
     const Real fitMin =
@@ -784,10 +725,8 @@ int main(int argc, char** argv)
     for (Real x : finalFitPerFrame)
       fitMean += x;
     fitMean /= static_cast<Real>(finalFitPerFrame.size());
-    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific
-              << std::setprecision(3) << fitMin
-              << "  mean=" << fitMean
-              << "  max=" << fitMax << '\n';
+    std::cout << "  ||phi(X+u)||_RMS  min=" << std::scientific << std::setprecision(3)
+              << fitMin << "  mean=" << fitMean << "  max=" << fitMax << '\n';
   }
 
   return 0;

--- a/examples/Heart/CCMLC2014_0D.cpp
+++ b/examples/Heart/CCMLC2014_0D.cpp
@@ -18,8 +18,10 @@ static Real periodic_activation(Real t)
   if (tau < 0.13)  return 0.0;
   if (tau < 0.141) return 35.0 * ((tau - 0.13) / 0.011);
   if (tau < 0.281) return 35.0;
-  if (tau < 0.361) return 35.0 - 55.0 * ((tau - 0.281) / 0.08);
-  if (tau < 0.45)  return -20.0;
+  if (tau < 0.361)
+    return 35.0 - 55.0 * ((tau - 0.281) / 0.08);
+  if (tau < 0.45)
+    return -20.0;
   return 0.0;
 }
 
@@ -145,10 +147,7 @@ int main()
   in.proximalLength = 0.4;
   in.distalRadius = 0.0007;
   in.distalLength = 0.004;
-  in.windkesselRheology =
-    Rodin::Heart::CCMLC2014::Model::WindkesselRheology::Quemada;
-
-
+  in.windkesselRheology = Rodin::Heart::CCMLC2014::Model::WindkesselRheology::Quemada;
 
   // Valve parameters
   in.Kat = 9.0e-6;
@@ -260,21 +259,9 @@ int main()
     const Real Q = 4.0 * std::numbers::pi_v<Real> * R * R * s.v;
     const Real pat = in.pAt(s.t);
 
-    out << s.t << ","
-        << s.y << ","
-        << s.v << ","
-        << s.pv << ","
-        << s.par << ","
-        << s.pd << ","
-        << s.ec << ","
-        << s.gamma << ","
-        << s.beta << ","
-        << s.w << ","
-        << s.kc << ","
-        << s.tauc << ","
-        << V << ","
-        << Q << ","
-        << pat << "\n";
+    out << s.t << "," << s.y << "," << s.v << "," << s.pv << "," << s.par << "," << s.pd
+        << "," << s.ec << "," << s.gamma << "," << s.beta << "," << s.w << "," << s.kc
+        << "," << s.tauc << "," << V << "," << Q << "," << pat << "\n";
   }
 
   return 0;

--- a/examples/Heart/CoronaryArtery/CoupledLV0DCoronary3D.cpp
+++ b/examples/Heart/CoronaryArtery/CoupledLV0DCoronary3D.cpp
@@ -234,8 +234,8 @@ namespace Rodin::Examples::Heart
     input.distalRadius = cfg.lv.distalRadius;
     input.distalLength = cfg.lv.distalLength;
 
-    input.mu_0    = cfg.lv.mu_0;
-    input.mu_Inf  = cfg.lv.mu_Inf;
+    input.mu_0 = cfg.lv.mu_0;
+    input.mu_Inf = cfg.lv.mu_Inf;
     input.lambda = cfg.lv.lambda;
     input.n = cfg.lv.n;
     input.yasuda = cfg.lv.yasuda;
@@ -261,31 +261,25 @@ namespace Rodin::Examples::Heart
       [p = cfg.atrialPressure](Real t) { return atrial_pressure(p, t); };
     input.u =
       [a = cfg.activation](Real t) { return periodic_activation(a, t); };
-    input.m0 =
-      [low = cfg.lv.relaxationM0Low,
-       high = cfg.lv.relaxationM0High,
-       lowEc = cfg.lv.relaxationM0LowEc,
-       highEc = cfg.lv.relaxationM0HighEc](Real ec)
-      {
-        if (highEc <= lowEc)
-          return high;
-        if (ec <= lowEc)
-          return low;
-        if (ec >= highEc)
-          return high;
-        const Real s = (ec - lowEc) / (highEc - lowEc);
-        return (1.0 - s) * low + s * high;
-      };
-    input.dm0 =
-      [low = cfg.lv.relaxationM0Low,
-       high = cfg.lv.relaxationM0High,
-       lowEc = cfg.lv.relaxationM0LowEc,
-       highEc = cfg.lv.relaxationM0HighEc](Real ec)
-      {
-        if (highEc <= lowEc || ec <= lowEc || ec >= highEc)
-          return 0.0;
-        return (high - low) / (highEc - lowEc);
-      };
+    input.m0 = [low = cfg.lv.relaxationM0Low, high = cfg.lv.relaxationM0High,
+                 lowEc = cfg.lv.relaxationM0LowEc,
+                 highEc = cfg.lv.relaxationM0HighEc](Real ec) {
+      if (highEc <= lowEc)
+        return high;
+      if (ec <= lowEc)
+        return low;
+      if (ec >= highEc)
+        return high;
+      const Real s = (ec - lowEc) / (highEc - lowEc);
+      return (1.0 - s) * low + s * high;
+    };
+    input.dm0 = [low = cfg.lv.relaxationM0Low, high = cfg.lv.relaxationM0High,
+                  lowEc = cfg.lv.relaxationM0LowEc,
+                  highEc = cfg.lv.relaxationM0HighEc](Real ec) {
+      if (highEc <= lowEc || ec <= lowEc || ec >= highEc)
+        return 0.0;
+      return (high - low) / (highEc - lowEc);
+    };
 
     {
       using PassiveEnergy = std::decay_t<decltype(input.passiveEnergy)>;
@@ -310,9 +304,7 @@ namespace Rodin::Examples::Heart
 
     const auto& s = model.getState();
 
-    bc.pc =
-      (a * bc.pc + Q + s.pv / bc.Rd)
-      / (a + 1.0 / bc.Rd);
+    bc.pc = (a * bc.pc + Q + s.pv / bc.Rd) / (a + 1.0 / bc.Rd);
 
     bc.qd = (bc.pc - bc.pd) / bc.Rd;
     bc.pout = bc.pc + bc.Rp * Q;
@@ -737,21 +729,15 @@ namespace Rodin::Examples::Heart
 
     const auto& s = m_model.getState();
 
-    Alert::Info()
-      << "Initial 0D state:" << Alert::NewLine
-      << "y     = " << s.y << Alert::NewLine
-      << "v     = " << s.v << Alert::NewLine
-      << "pv    = " << s.pv << Alert::NewLine
-      << "par   = " << s.par << Alert::NewLine
-      << "pd    = " << s.pd << Alert::NewLine
-      << "ec    = " << s.ec << Alert::NewLine
-      << "gamma = " << s.gamma << Alert::NewLine
-      << "beta  = " << s.beta << Alert::NewLine
-      << "w     = " << s.w << Alert::NewLine
-      << "kc    = " << s.kc << Alert::NewLine
-      << "tauc  = " << s.tauc << Alert::NewLine
-      << "3D flow mode: " << flowModeName(m_cfg.flowMode)
-      << Alert::Raise;
+    Alert::Info() << "Initial 0D state:" << Alert::NewLine << "y     = " << s.y
+                  << Alert::NewLine << "v     = " << s.v << Alert::NewLine
+                  << "pv    = " << s.pv << Alert::NewLine << "par   = " << s.par
+                  << Alert::NewLine << "pd    = " << s.pd << Alert::NewLine
+                  << "ec    = " << s.ec << Alert::NewLine << "gamma = " << s.gamma
+                  << Alert::NewLine << "beta  = " << s.beta << Alert::NewLine
+                  << "w     = " << s.w << Alert::NewLine << "kc    = " << s.kc
+                  << Alert::NewLine << "tauc  = " << s.tauc << Alert::NewLine
+                  << "3D flow mode: " << flowModeName(m_cfg.flowMode) << Alert::Raise;
   }
 
   bool CoupledLV0DCoronary3D::isRoot() const
@@ -1182,53 +1168,52 @@ namespace Rodin::Examples::Heart
     if (!isRoot())
       return;
 
-    m_csv
-      << "t,"
-      << "LeftAtriumPressure,"
-      << "VenaCavaPressure,"
-      << "LeftVentricleDisplacement,"
-      << "LeftVentricleVelocity,"
-      << "LeftVentricleRadius,"
-      << "LeftVentricleVolume,"
-      << "LeftVentriclePressure,"
-      << "AortaPressure,"
-      << "DistalPressure,"
-      << "LeftVentricleFlow,"
-      << "CoronaryInletFlux,"
-      << "CoronaryOutlet4Flux,"
-      << "CoronaryOutlet5Flux,"
-      << "CoronaryOutlet6Flux,"
-      << "CoronaryOutlet7Flux,"
-      << "CoronaryOutlet8Flux,"
-      << "CoronaryOutlet9Flux,"
-      << "CoronaryOutletFluxTotal,"
-      << "CoronaryOutlet4DistalFlux,"
-      << "CoronaryOutlet5DistalFlux,"
-      << "CoronaryOutlet6DistalFlux,"
-      << "CoronaryOutlet7DistalFlux,"
-      << "CoronaryOutlet8DistalFlux,"
-      << "CoronaryOutlet9DistalFlux,"
-      << "CoronaryDistalFluxTotal,"
-      << "CoronaryCapChargingFluxTotal,"
-      << "CoronaryOutlet4CapPressure,"
-      << "CoronaryOutlet5CapPressure,"
-      << "CoronaryOutlet6CapPressure,"
-      << "CoronaryOutlet7CapPressure,"
-      << "CoronaryOutlet8CapPressure,"
-      << "CoronaryOutlet9CapPressure,"
-      << "CoronaryOutlet4Pressure,"
-      << "CoronaryOutlet5Pressure,"
-      << "CoronaryOutlet6Pressure,"
-      << "CoronaryOutlet7Pressure,"
-      << "CoronaryOutlet8Pressure,"
-      << "CoronaryOutlet9Pressure,"
-      << "FlowBalance,"
-      << "ec,"
-      << "gamma,"
-      << "beta,"
-      << "w,"
-      << "kc,"
-      << "tauc\n";
+    m_csv << "t,"
+          << "LeftAtriumPressure,"
+          << "VenaCavaPressure,"
+          << "LeftVentricleDisplacement,"
+          << "LeftVentricleVelocity,"
+          << "LeftVentricleRadius,"
+          << "LeftVentricleVolume,"
+          << "LeftVentriclePressure,"
+          << "AortaPressure,"
+          << "DistalPressure,"
+          << "LeftVentricleFlow,"
+          << "CoronaryInletFlux,"
+          << "CoronaryOutlet4Flux,"
+          << "CoronaryOutlet5Flux,"
+          << "CoronaryOutlet6Flux,"
+          << "CoronaryOutlet7Flux,"
+          << "CoronaryOutlet8Flux,"
+          << "CoronaryOutlet9Flux,"
+          << "CoronaryOutletFluxTotal,"
+          << "CoronaryOutlet4DistalFlux,"
+          << "CoronaryOutlet5DistalFlux,"
+          << "CoronaryOutlet6DistalFlux,"
+          << "CoronaryOutlet7DistalFlux,"
+          << "CoronaryOutlet8DistalFlux,"
+          << "CoronaryOutlet9DistalFlux,"
+          << "CoronaryDistalFluxTotal,"
+          << "CoronaryCapChargingFluxTotal,"
+          << "CoronaryOutlet4CapPressure,"
+          << "CoronaryOutlet5CapPressure,"
+          << "CoronaryOutlet6CapPressure,"
+          << "CoronaryOutlet7CapPressure,"
+          << "CoronaryOutlet8CapPressure,"
+          << "CoronaryOutlet9CapPressure,"
+          << "CoronaryOutlet4Pressure,"
+          << "CoronaryOutlet5Pressure,"
+          << "CoronaryOutlet6Pressure,"
+          << "CoronaryOutlet7Pressure,"
+          << "CoronaryOutlet8Pressure,"
+          << "CoronaryOutlet9Pressure,"
+          << "FlowBalance,"
+          << "ec,"
+          << "gamma,"
+          << "beta,"
+          << "w,"
+          << "kc,"
+          << "tauc\n";
 
     m_csv.flush();
   }
@@ -1246,53 +1231,20 @@ namespace Rodin::Examples::Heart
       return (it == m.end()) ? 0.0 : it->second;
     };
 
-    m_csv
-      << d.t << ','
-      << d.pat << ','
-      << d.psv << ','
-      << d.y << ','
-      << d.v << ','
-      << d.radius << ','
-      << d.lvVolume << ','
-      << d.pv << ','
-      << d.par << ','
-      << d.pd << ','
-      << d.lvFlow << ','
-      << d.qIn << ','
-      << get(d.qOut, 4) << ','
-      << get(d.qOut, 5) << ','
-      << get(d.qOut, 6) << ','
-      << get(d.qOut, 7) << ','
-      << get(d.qOut, 8) << ','
-      << get(d.qOut, 9) << ','
-      << d.qOutSum << ','
-      << get(d.qDistal, 4) << ','
-      << get(d.qDistal, 5) << ','
-      << get(d.qDistal, 6) << ','
-      << get(d.qDistal, 7) << ','
-      << get(d.qDistal, 8) << ','
-      << get(d.qDistal, 9) << ','
-      << d.qDistalSum << ','
-      << d.qCapChargingSum << ','
-      << get(d.pc, 4) << ','
-      << get(d.pc, 5) << ','
-      << get(d.pc, 6) << ','
-      << get(d.pc, 7) << ','
-      << get(d.pc, 8) << ','
-      << get(d.pc, 9) << ','
-      << get(d.pOut, 4) << ','
-      << get(d.pOut, 5) << ','
-      << get(d.pOut, 6) << ','
-      << get(d.pOut, 7) << ','
-      << get(d.pOut, 8) << ','
-      << get(d.pOut, 9) << ','
-      << d.flowBalance << ','
-      << d.ec << ','
-      << d.gamma << ','
-      << d.beta << ','
-      << d.w << ','
-      << d.kc << ','
-      << d.tauc << '\n';
+    m_csv << d.t << ',' << d.pat << ',' << d.psv << ',' << d.y << ',' << d.v << ','
+          << d.radius << ',' << d.lvVolume << ',' << d.pv << ',' << d.par << ',' << d.pd
+          << ',' << d.lvFlow << ',' << d.qIn << ',' << get(d.qOut, 4) << ','
+          << get(d.qOut, 5) << ',' << get(d.qOut, 6) << ',' << get(d.qOut, 7) << ','
+          << get(d.qOut, 8) << ',' << get(d.qOut, 9) << ',' << d.qOutSum << ','
+          << get(d.qDistal, 4) << ',' << get(d.qDistal, 5) << ',' << get(d.qDistal, 6)
+          << ',' << get(d.qDistal, 7) << ',' << get(d.qDistal, 8) << ','
+          << get(d.qDistal, 9) << ',' << d.qDistalSum << ',' << d.qCapChargingSum << ','
+          << get(d.pc, 4) << ',' << get(d.pc, 5) << ',' << get(d.pc, 6) << ','
+          << get(d.pc, 7) << ',' << get(d.pc, 8) << ',' << get(d.pc, 9) << ','
+          << get(d.pOut, 4) << ',' << get(d.pOut, 5) << ',' << get(d.pOut, 6) << ','
+          << get(d.pOut, 7) << ',' << get(d.pOut, 8) << ',' << get(d.pOut, 9) << ','
+          << d.flowBalance << ',' << d.ec << ',' << d.gamma << ',' << d.beta << ',' << d.w
+          << ',' << d.kc << ',' << d.tauc << '\n';
 
     m_csv.flush();
   }

--- a/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI.cpp
+++ b/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI.cpp
@@ -73,41 +73,37 @@ namespace
 
   struct FluidBoundary
   {
-    static constexpr Attribute Inlet    = 1;
-    static constexpr Attribute Outlet   = 2;
-    static constexpr Attribute Wall     = 3;
-    static constexpr Attribute FSI      = 4;
+      static constexpr Attribute Inlet = 1;
+      static constexpr Attribute Outlet = 2;
+      static constexpr Attribute Wall = 3;
+      static constexpr Attribute FSI = 4;
   };
 
   struct SolidBoundary
   {
-    static constexpr Attribute FSI        = 11;
-    static constexpr Attribute ClampLeft  = 12;
-    static constexpr Attribute ClampRight = 13;
-    static constexpr Attribute Free       = 14;
+      static constexpr Attribute FSI = 11;
+      static constexpr Attribute ClampLeft = 12;
+      static constexpr Attribute ClampRight = 13;
+      static constexpr Attribute Free = 14;
   };
 
   struct InterfaceSegment
   {
-    Index fluid;
-    Index solid;
-    Real xmin;
-    Real xmax;
+      Index fluid;
+      Index solid;
+      Real xmin;
+      Real xmax;
   };
 
   struct InterfaceMap
   {
-    std::unordered_map<Index, Index> fluidToSolid;
-    std::unordered_map<Index, Index> solidToFluid;
-    std::vector<InterfaceSegment> segments;
+      std::unordered_map<Index, Index> fluidToSolid;
+      std::unordered_map<Index, Index> solidToFluid;
+      std::vector<InterfaceSegment> segments;
   };
 
-  static Real pulseTrain(
-      const Real t,
-      const Real amplitude,
-      const Real duration,
-      const Real gap,
-      const Index count)
+  static Real pulseTrain(const Real t, const Real amplitude, const Real duration,
+    const Real gap, const Index count)
   {
     if (t < 0.0 || duration <= 0.0 || count == 0)
       return 0.0;
@@ -140,21 +136,22 @@ namespace
     return c;
   }
 
-  static std::pair<Real, Real> segmentXRange(const LocalMesh& mesh, const Polytope& segment)
+  static std::pair<Real, Real> segmentXRange(
+    const LocalMesh& mesh, const Polytope& segment)
   {
     const auto& vertices = segment.getVertices();
 
     const Real x0 = mesh.getVertexCoordinates(vertices[0]).x();
     const Real x1 = mesh.getVertexCoordinates(vertices[1]).x();
 
-    return { std::min(x0, x1), std::max(x0, x1) };
+    return {std::min(x0, x1), std::max(x0, x1)};
   }
 
   static void mapMeshToBox(LocalMesh& mesh, Real L, Real H, Real y0)
   {
-    Real xmin =  std::numeric_limits<Real>::max();
+    Real xmin = std::numeric_limits<Real>::max();
     Real xmax = -std::numeric_limits<Real>::max();
-    Real ymin =  std::numeric_limits<Real>::max();
+    Real ymin = std::numeric_limits<Real>::max();
     Real ymax = -std::numeric_limits<Real>::max();
 
     for (auto it = mesh.getVertex(); it; ++it)
@@ -184,7 +181,7 @@ namespace
   {
     Mesh mesh;
 
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx + 1, ny + 1 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {nx + 1, ny + 1});
 
     mapMeshToBox(mesh, L, H, y0);
 
@@ -233,14 +230,12 @@ namespace
   }
 
   static InterfaceMap buildInterfaceMap(
-      const LocalMesh& fluidReferenceMesh,
-      const LocalMesh& solidReferenceMesh)
+    const LocalMesh& fluidReferenceMesh, const LocalMesh& solidReferenceMesh)
   {
     InterfaceMap map;
     std::map<long long, Index> solidByMidpoint;
 
-    auto key = [](Real x) -> long long
-    {
+    auto key = [](Real x) -> long long {
       return static_cast<long long>(std::llround(1e12 * x));
     };
 
@@ -249,9 +244,7 @@ namespace
       if (it->getAttribute() != SolidBoundary::FSI)
         continue;
 
-      solidByMidpoint.emplace(
-          key(centroid(solidReferenceMesh, *it).x()),
-          it->getIndex());
+      solidByMidpoint.emplace(key(centroid(solidReferenceMesh, *it).x()), it->getIndex());
     }
 
     for (auto it = fluidReferenceMesh.getBoundary(); it; ++it)
@@ -272,24 +265,19 @@ namespace
       map.solidToFluid.emplace(solidFace, fluidFace);
 
       const auto [xmin, xmax] = segmentXRange(fluidReferenceMesh, *it);
-      map.segments.push_back({ fluidFace, solidFace, xmin, xmax });
+      map.segments.push_back({fluidFace, solidFace, xmin, xmax});
     }
 
-    std::sort(
-        map.segments.begin(),
-        map.segments.end(),
-        [](const InterfaceSegment& a, const InterfaceSegment& b)
-        {
-          return a.xmin < b.xmin;
-        });
+    std::sort(map.segments.begin(), map.segments.end(),
+      [](const InterfaceSegment& a, const InterfaceSegment& b) {
+        return a.xmin < b.xmin;
+      });
 
     return map;
   }
 
   static Point forwardFluidPointToSolid(
-      const Point& p,
-      const LocalMesh& solidReferenceMesh,
-      const InterfaceMap& map)
+    const Point& p, const LocalMesh& solidReferenceMesh, const InterfaceMap& map)
   {
     const auto found = map.fluidToSolid.find(p.getPolytope().getIndex());
 
@@ -305,9 +293,7 @@ namespace
   }
 
   static Point forwardSolidPointToFluid(
-      const Point& p,
-      const LocalMesh& fluidMesh,
-      const InterfaceMap& map)
+    const Point& p, const LocalMesh& fluidMesh, const InterfaceMap& map)
   {
     const auto found = map.solidToFluid.find(p.getPolytope().getIndex());
 
@@ -333,8 +319,7 @@ namespace
   }
 
   static void saveReferenceVertices(
-      const LocalMesh& mesh,
-      std::vector<Math::SpatialPoint>& vertices)
+    const LocalMesh& mesh, std::vector<Math::SpatialPoint>& vertices)
   {
     vertices.resize(mesh.getVertexCount());
 
@@ -343,8 +328,7 @@ namespace
   }
 
   static void restoreMesh(
-      LocalMesh& mesh,
-      const std::vector<Math::SpatialPoint>& referenceVertices)
+    LocalMesh& mesh, const std::vector<Math::SpatialPoint>& referenceVertices)
   {
     for (auto it = mesh.getVertex(); it; ++it)
     {
@@ -356,11 +340,9 @@ namespace
   }
 
   template <class GridFunctionType>
-  static void moveMeshWithDisplacement(
-      LocalMesh& mesh,
-      const LocalMesh& referenceMesh,
-      const std::vector<Math::SpatialPoint>& referenceVertices,
-      const GridFunctionType& displacement)
+  static void moveMeshWithDisplacement(LocalMesh& mesh, const LocalMesh& referenceMesh,
+    const std::vector<Math::SpatialPoint>& referenceVertices,
+    const GridFunctionType& displacement)
   {
     for (auto it = mesh.getVertex(); it; ++it)
     {
@@ -415,10 +397,13 @@ int main(int argc, char** argv)
   PetscReal finalTimeOpt = 1.0;
 
   PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_nx", &nxOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_fluid_ny", &fluidNyOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_ny", &solidNyOpt, PETSC_NULLPTR);
+  PetscOptionsGetInt(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_fluid_ny", &fluidNyOpt, PETSC_NULLPTR);
+  PetscOptionsGetInt(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_ny", &solidNyOpt, PETSC_NULLPTR);
   PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_Nt", &ntOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_T", &finalTimeOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_T", &finalTimeOpt, PETSC_NULLPTR);
 
   PetscReal pressureScaleOpt = 0.05;
   PetscReal viscousScaleOpt = 1.0;
@@ -436,66 +421,64 @@ int main(int argc, char** argv)
   PetscReal newtonDampingOpt = 1.0;
   PetscBool checkNoSlipOpt = PETSC_TRUE;
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pressure_scale", &pressureScaleOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pressure_scale",
+    &pressureScaleOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_viscous_scale", &viscousScaleOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_viscous_scale", &viscousScaleOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_traction_scale", &tractionScaleOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_traction_scale",
+    &tractionScaleOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_backflow_stabilization_scale",
-      &backflowStabilizationScaleOpt,
-      PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_backflow_stabilization_scale",
+    &backflowStabilizationScaleOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_inlet_amplitude", &inletAmplitudeOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_inlet_amplitude",
+    &inletAmplitudeOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_duration", &pulseDurationOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_duration",
+    &pulseDurationOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_gap", &pulseGapOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_gap", &pulseGapOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_count", &pulseCountOpt, PETSC_NULLPTR);
+  PetscOptionsGetInt(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_count", &pulseCountOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_E", &solidEOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_E", &solidEOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_nu", &solidNuOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_nu", &solidNuOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_density", &solidDensityOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_density", &solidDensityOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_rayleigh_alpha", &solidRayleighAlphaOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_rayleigh_alpha",
+    &solidRayleighAlphaOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_damping", &solidRayleighAlphaOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_damping",
+    &solidRayleighAlphaOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_rayleigh_beta", &solidRayleighBetaOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_rayleigh_beta",
+    &solidRayleighBetaOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_newton_damping", &newtonDampingOpt, PETSC_NULLPTR);
+  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_newton_damping",
+    &newtonDampingOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetBool(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_check_no_slip", &checkNoSlipOpt, PETSC_NULLPTR);
+  PetscOptionsGetBool(
+    PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_check_no_slip", &checkNoSlipOpt, PETSC_NULLPTR);
 
   const size_t nx = static_cast<size_t>(std::max<PetscInt>(2, nxOpt));
   const size_t fluidNy = static_cast<size_t>(std::max<PetscInt>(2, fluidNyOpt));
   const size_t solidNy = static_cast<size_t>(std::max<PetscInt>(1, solidNyOpt));
   const Index Nt = static_cast<Index>(std::max<PetscInt>(1, ntOpt));
 
-  const Real L  = 4.0;
+  const Real L = 4.0;
   const Real Hf = 1.0;
   const Real Hs = 0.25;
 
-  const Real T  = static_cast<Real>(finalTimeOpt);
+  const Real T = static_cast<Real>(finalTimeOpt);
   const Real dt = T / static_cast<Real>(Nt);
 
   {
@@ -639,26 +622,21 @@ int main(int argc, char** argv)
      * Parameters.
      */
     const Real rhoF = 1.0;
-    const Real muF  = 0.02;
+    const Real muF = 0.02;
 
     const Real solidE = static_cast<Real>(solidEOpt);
     const Real solidNu = static_cast<Real>(solidNuOpt);
 
-    const Real solidLambda =
-      solidE * solidNu / ((1.0 + solidNu) * (1.0 - 2.0 * solidNu));
+    const Real solidLambda = solidE * solidNu / ((1.0 + solidNu) * (1.0 - 2.0 * solidNu));
 
-    const Real solidMu =
-      solidE / (2.0 * (1.0 + solidNu));
+    const Real solidMu = solidE / (2.0 * (1.0 + solidNu));
 
     const Real rhoS = static_cast<Real>(solidDensityOpt);
-    const Real solidRayleighAlpha =
-      static_cast<Real>(solidRayleighAlphaOpt);
+    const Real solidRayleighAlpha = static_cast<Real>(solidRayleighAlphaOpt);
 
-    const Real solidRayleighBeta =
-      static_cast<Real>(solidRayleighBetaOpt);
+    const Real solidRayleighBeta = static_cast<Real>(solidRayleighBetaOpt);
 
-    const Real solidMassCoeff =
-      rhoS / (dt * dt) + solidRayleighAlpha * rhoS / dt;
+    const Real solidMassCoeff = rhoS / (dt * dt) + solidRayleighAlpha * rhoS / dt;
 
     Solid::NeoHookean law(solidLambda, solidMu);
 
@@ -670,54 +648,44 @@ int main(int argc, char** argv)
      * This restores the fluid mesh to the reference coordinates, solves the
      * harmonic extension, stores it in fluidDisplacement, then moves fluidMesh.
      */
-    auto solveHarmonicALE =
-      [&](const auto& interfaceSolidDisplacement)
-      {
-        restoreMesh(fluidMesh, fluidReferenceVertices);
+    auto solveHarmonicALE = [&](const auto& interfaceSolidDisplacement) {
+      restoreMesh(fluidMesh, fluidReferenceVertices);
 
-        PETSc::Variational::TrialFunction d(uh);
-        PETSc::Variational::TestFunction  z(uh);
+      PETSc::Variational::TrialFunction d(uh);
+      PETSc::Variational::TestFunction z(uh);
 
-        d.setName("ALEDisplacementTrial");
+      d.setName("ALEDisplacementTrial");
 
-        auto interfaceDisplacement = VectorFunction(dim, [&](const Point& xf)
-        {
-          const Point xs =
-            forwardFluidPointToSolid(xf, solidMesh, interfaceMap);
+      auto interfaceDisplacement = VectorFunction(dim, [&](const Point& xf) {
+        const Point xs = forwardFluidPointToSolid(xf, solidMesh, interfaceMap);
 
-          Math::SpatialVector<Real> value(dim);
-          value.setZero();
+        Math::SpatialVector<Real> value(dim);
+        value.setZero();
 
-          const auto ds = interfaceSolidDisplacement(xs);
-          for (Index i = 0; i < static_cast<Index>(dim); ++i)
-            value(i) = ds(i);
+        const auto ds = interfaceSolidDisplacement(xs);
+        for (Index i = 0; i < static_cast<Index>(dim); ++i)
+          value(i) = ds(i);
 
-          return value;
-        });
+        return value;
+      });
 
-        Problem ale(d, z);
+      Problem ale(d, z);
 
-        ale =
-            Integral(Jacobian(d), Jacobian(z))
-          + DirichletBC(d, Zero(dim)).on(FluidBoundary::Inlet)
-          + DirichletBC(d, Zero(dim)).on(FluidBoundary::Wall)
-          + DirichletBC(d, interfaceDisplacement).on(FluidBoundary::FSI);
+      ale = Integral(Jacobian(d), Jacobian(z)) +
+        DirichletBC(d, Zero(dim)).on(FluidBoundary::Inlet) +
+        DirichletBC(d, Zero(dim)).on(FluidBoundary::Wall) +
+        DirichletBC(d, interfaceDisplacement).on(FluidBoundary::FSI);
 
-        Alert::Info()
-          << "Solving harmonic ALE extension."
-          << Alert::Raise;
+      Alert::Info() << "Solving harmonic ALE extension." << Alert::Raise;
 
-        ale.assemble();
-        Solver::KSP(ale).solve();
+      ale.assemble();
+      Solver::KSP(ale).solve();
 
-        fluidDisplacement.setData(d.getSolution().getData());
+      fluidDisplacement.setData(d.getSolution().getData());
 
-        moveMeshWithDisplacement(
-            fluidMesh,
-            fluidMesh,
-            fluidReferenceVertices,
-            fluidDisplacement);
-      };
+      moveMeshWithDisplacement(
+        fluidMesh, fluidMesh, fluidReferenceVertices, fluidDisplacement);
+    };
 
     Real t = 0.0;
 
@@ -733,28 +701,22 @@ int main(int argc, char** argv)
       fluidDisplacementOld.setData(fluidDisplacement.getData());
       solveHarmonicALE(solidDisplacementOld);
 
-      meshVelocity =
-        (1.0 / dt) * (fluidDisplacement - fluidDisplacementOld);
+      meshVelocity = (1.0 / dt) * (fluidDisplacement - fluidDisplacementOld);
 
-      inletVelocity = VectorFunction(dim, [&](const Point& x)
-      {
+      inletVelocity = VectorFunction(dim, [&](const Point& x) {
         const Real y = std::clamp(x.y(), 0.0, Hf);
         const Real profile = 4.0 * y * (Hf - y) / (Hf * Hf);
 
-        return Math::Vector<Real>{{
-            pulseTrain(
-              t,
-              static_cast<Real>(inletAmplitudeOpt),
-              static_cast<Real>(pulseDurationOpt),
-              static_cast<Real>(pulseGapOpt),
-              static_cast<Index>(pulseCountOpt)) * profile,
-            0.0 }};
+        return Math::Vector<Real>{
+          {pulseTrain(t, static_cast<Real>(inletAmplitudeOpt),
+             static_cast<Real>(pulseDurationOpt), static_cast<Real>(pulseGapOpt),
+             static_cast<Index>(pulseCountOpt)) *
+              profile,
+            0.0}};
       });
 
-      auto interfaceVelocity = VectorFunction(dim, [&](const Point& xf)
-      {
-        const Point xs =
-          forwardFluidPointToSolid(xf, solidMesh, interfaceMap);
+      auto interfaceVelocity = VectorFunction(dim, [&](const Point& xf) {
+        const Point xs = forwardFluidPointToSolid(xf, solidMesh, interfaceMap);
 
         Math::SpatialVector<Real> value(dim);
         value.setZero();
@@ -776,36 +738,26 @@ int main(int argc, char** argv)
 
       Problem flow(u, p, l, v, q, m);
 
-      flow =
-            (rhoF / dt) * Integral(u, v)
-          - (rhoF / dt) * Integral(uOld, v)
-          + rhoF * Integral(Dot(convU, v))
-          + 0.5 * rhoF * Integral(divTransport * Dot(u, v))
-          + muF * Integral(Jacobian(u), Jacobian(v))
-          - Integral(p, Div(v))
-          + Integral(Div(u), q)
-          + Integral(l, q)
-          + Integral(p, m)
-          + backflowStabilizationScale *
-            BoundaryIntegral(
-                0.5 * rhoF * beta * Dot(u, v)).over(FluidBoundary::Outlet)
-          + 1e-10 * Integral(p, q)
-          + 1e-10 * Integral(l, m)
-          + DirichletBC(u, inletVelocity).on(FluidBoundary::Inlet)
-          + DirichletBC(u, Zero(dim)).on(FluidBoundary::Wall)
-          + DirichletBC(u, interfaceVelocity).on(FluidBoundary::FSI);
+      flow = (rhoF / dt) * Integral(u, v) - (rhoF / dt) * Integral(uOld, v) +
+        rhoF * Integral(Dot(convU, v)) + 0.5 * rhoF * Integral(divTransport * Dot(u, v)) +
+        muF * Integral(Jacobian(u), Jacobian(v)) - Integral(p, Div(v)) +
+        Integral(Div(u), q) + Integral(l, q) + Integral(p, m) +
+        backflowStabilizationScale *
+          BoundaryIntegral(0.5 * rhoF * beta * Dot(u, v)).over(FluidBoundary::Outlet) +
+        1e-10 * Integral(p, q) + 1e-10 * Integral(l, m) +
+        DirichletBC(u, inletVelocity).on(FluidBoundary::Inlet) +
+        DirichletBC(u, Zero(dim)).on(FluidBoundary::Wall) +
+        DirichletBC(u, interfaceVelocity).on(FluidBoundary::FSI);
 
-      Alert::Info()
-        << "Fluid BDF1 ALE/Oseen step " << step << " / " << Nt
-        << Alert::Raise;
+      Alert::Info() << "Fluid BDF1 ALE/Oseen step " << step << " / " << Nt
+                    << Alert::Raise;
 
       flow.assemble().setFieldSplits();
       Solver::KSP(flow).solve();
 
       if (checkNoSlipOpt)
       {
-        auto fsiNoSlip =
-          DirichletBC(u, interfaceVelocity).on(FluidBoundary::FSI);
+        auto fsiNoSlip = DirichletBC(u, interfaceVelocity).on(FluidBoundary::FSI);
         fsiNoSlip.assemble();
 
         const auto& fluidVelocityData = u.getSolution().getData();
@@ -813,39 +765,28 @@ int main(int argc, char** argv)
         Real maxFluidFSIVelocity = 0.0;
         Real maxWallFSIVelocity = 0.0;
 
-        for (const auto& [local, target]
-               : std::get<IndexMap<Real>>(fsiNoSlip.getDOFs()))
+        for (const auto& [local, target] : std::get<IndexMap<Real>>(fsiNoSlip.getDOFs()))
         {
           const PetscInt idx = static_cast<PetscInt>(local);
           PetscScalar actual = 0.0;
 
-          const PetscErrorCode ierr =
-            VecGetValues(fluidVelocityData, 1, &idx, &actual);
+          const PetscErrorCode ierr = VecGetValues(fluidVelocityData, 1, &idx, &actual);
           assert(ierr == PETSC_SUCCESS);
-          (void) ierr;
+          (void)ierr;
 
-          maxNoSlipResidual =
-            std::max<Real>(
-                maxNoSlipResidual,
-                std::abs(static_cast<Real>(actual - target)));
+          maxNoSlipResidual = std::max<Real>(
+            maxNoSlipResidual, std::abs(static_cast<Real>(actual - target)));
 
           maxFluidFSIVelocity =
-            std::max<Real>(
-                maxFluidFSIVelocity,
-                std::abs(static_cast<Real>(actual)));
+            std::max<Real>(maxFluidFSIVelocity, std::abs(static_cast<Real>(actual)));
 
           maxWallFSIVelocity =
-            std::max<Real>(
-                maxWallFSIVelocity,
-                std::abs(static_cast<Real>(target)));
+            std::max<Real>(maxWallFSIVelocity, std::abs(static_cast<Real>(target)));
         }
 
-        Alert::Info()
-          << "  fluid FSI no-slip DOF max |u - u_FSI|: "
-          << maxNoSlipResidual
-          << " (max |u|=" << maxFluidFSIVelocity
-          << ", max |u_FSI|=" << maxWallFSIVelocity << ")"
-          << Alert::Raise;
+        Alert::Info() << "  fluid FSI no-slip DOF max |u - u_FSI|: " << maxNoSlipResidual
+                      << " (max |u|=" << maxFluidFSIVelocity
+                      << ", max |u_FSI|=" << maxWallFSIVelocity << ")" << Alert::Raise;
       }
 
       uOld.setData(u.getSolution().getData());
@@ -855,7 +796,7 @@ int main(int argc, char** argv)
        * Solid tangent and internal force.
        */
       TrialFunction du(solidVh);
-      TestFunction  w(solidVh);
+      TestFunction w(solidVh);
 
       auto ivw = Solid::InternalVirtualWork(law, solidDisplacement);
       auto ivwOld = Solid::InternalVirtualWork(law, solidDisplacementOld);
@@ -869,13 +810,11 @@ int main(int argc, char** argv)
       const Real viscousScale = static_cast<Real>(viscousScaleOpt);
       const Real tractionScale = static_cast<Real>(tractionScaleOpt);
 
-      auto fluidTractionLoad = VectorFunction(dim, [&](const Point& xs)
-      {
+      auto fluidTractionLoad = VectorFunction(dim, [&](const Point& xs) {
         Math::SpatialVector<Real> traction(dim);
         traction.setZero();
 
-        const Point xf =
-          forwardSolidPointToFluid(xs, fluidMesh, interfaceMap);
+        const Point xf = forwardSolidPointToFluid(xs, fluidMesh, interfaceMap);
 
         const Real pressure = pOld(xf);
         const auto J = Jacobian(uOld)(xf);
@@ -883,10 +822,8 @@ int main(int argc, char** argv)
 
         const bool pOk = std::isfinite(pressure);
         const bool nOk = isFinite(normal);
-        const bool JOk =
-          (J.rows() == static_cast<int>(dim)) &&
-          (J.cols() == static_cast<int>(dim)) &&
-          isFinite(J);
+        const bool JOk = (J.rows() == static_cast<int>(dim)) &&
+          (J.cols() == static_cast<int>(dim)) && isFinite(J);
 
         if (!pOk || !nOk || !JOk)
         {
@@ -896,13 +833,11 @@ int main(int argc, char** argv)
 
             const auto& pc = xs.getPhysicalCoordinates();
 
-            Alert::Warning()
-              << "fluidTractionLoad: non-finite at xs=("
-              << pc.transpose() << ")"
-              << " pressure=" << pressure
-              << " normalOk=" << nOk
-              << " J(" << J.rows() << "x" << J.cols() << ")Ok=" << JOk
-              << Alert::Raise;
+            Alert::Warning() << "fluidTractionLoad: non-finite at xs=(" << pc.transpose()
+                             << ")"
+                             << " pressure=" << pressure << " normalOk=" << nOk << " J("
+                             << J.rows() << "x" << J.cols() << ")Ok=" << JOk
+                             << Alert::Raise;
           }
 
           return traction;
@@ -911,8 +846,7 @@ int main(int argc, char** argv)
         const auto I = Math::SpatialMatrix<Real>::Identity(dim, dim);
 
         const auto sigmaF =
-            -pressureScale * pressure * I
-            + viscousScale * muF * (J + J.transpose());
+          -pressureScale * pressure * I + viscousScale * muF * (J + J.transpose());
 
         /*
          * nFluid is the outward normal of the fluid.
@@ -925,10 +859,7 @@ int main(int argc, char** argv)
 
       solidFluidTraction = zero;
 
-      solidFluidTraction.project(
-          Region::Boundary,
-          fluidTractionLoad,
-          SolidBoundary::FSI);
+      solidFluidTraction.project(Region::Boundary, fluidTractionLoad, SolidBoundary::FSI);
 
       /*
        * Solid problem.
@@ -951,99 +882,70 @@ int main(int argc, char** argv)
         + DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampLeft) +
         DirichletBC(du, Zero(dim)).on(SolidBoundary::ClampRight);
 
-      Alert::Info()
-        << "Solid BDF1 hyperelastic step " << step << " / " << Nt
-        << Alert::Raise;
+      Alert::Info() << "Solid BDF1 hyperelastic step " << step << " / " << Nt
+                    << Alert::Raise;
 
-      Alert::Info()
-        << "  solidDisplacement norm before Newton: "
-        << solidDisplacement.getData().norm()
-        << Alert::Raise;
+      Alert::Info() << "  solidDisplacement norm before Newton: "
+                    << solidDisplacement.getData().norm() << Alert::Raise;
 
-      Alert::Info()
-        << "  solidFluidTraction norm: "
-        << solidFluidTraction.getData().norm()
-        << Alert::Raise;
+      Alert::Info() << "  solidFluidTraction norm: "
+                    << solidFluidTraction.getData().norm() << Alert::Raise;
 
-      const auto solidDisplacementInitial =
-        solidDisplacement.getData();
+      const auto solidDisplacementInitial = solidDisplacement.getData();
 
       const Real tightSolidTolerance = 1e-10;
       const Real basinSolidTolerance = 1e-8;
 
-      auto solveSolidNewton =
-        [&](const char* label,
-            Real damping,
-            Real absoluteTolerance,
-            Real relativeTolerance)
-        {
-          SparseLU solidLinearSolver(solid);
-          NewtonSolver solidSolver(solidLinearSolver);
+      auto solveSolidNewton = [&](const char* label, Real damping, Real absoluteTolerance,
+                                Real relativeTolerance) {
+        SparseLU solidLinearSolver(solid);
+        NewtonSolver solidSolver(solidLinearSolver);
 
-          solidSolver.setMaxIterations(75)
-                     .setDampingFactor(damping)
-                     .setAbsoluteTolerance(absoluteTolerance)
-                     .setRelativeTolerance(relativeTolerance);
+        solidSolver.setMaxIterations(75)
+          .setDampingFactor(damping)
+          .setAbsoluteTolerance(absoluteTolerance)
+          .setRelativeTolerance(relativeTolerance);
 
-          Alert::Info()
-            << "  " << label
-            << " alpha=" << damping
-            << " atol=" << absoluteTolerance
-            << Alert::Raise;
+        Alert::Info() << "  " << label << " alpha=" << damping
+                      << " atol=" << absoluteTolerance << Alert::Raise;
 
-          solidSolver.setMonitor([](const auto& rep) {
-            Alert::Info() << "    it=" << rep.iterations << " r=" << rep.finalResidual
-                          << " dx=" << rep.finalStepNorm << Alert::Raise;
-          });
+        solidSolver.setMonitor([](const auto& rep) {
+          Alert::Info() << "    it=" << rep.iterations << " r=" << rep.finalResidual
+                        << " dx=" << rep.finalStepNorm << Alert::Raise;
+        });
 
-          solidSolver.solve(solidDisplacement);
+        solidSolver.solve(solidDisplacement);
 
-          return solidSolver.converged();
-        };
+        return solidSolver.converged();
+      };
 
       solidDisplacement.setData(solidDisplacementInitial);
 
       bool solidNewtonConverged =
-        solveSolidNewton(
-            "full Newton attempt",
-            1.0,
-            tightSolidTolerance,
-            1e-8);
+        solveSolidNewton("full Newton attempt", 1.0, tightSolidTolerance, 1e-8);
 
-      Real solidNewtonDamping =
-        std::min<Real>(newtonDampingOpt, 0.5);
+      Real solidNewtonDamping = std::min<Real>(newtonDampingOpt, 0.5);
 
       for (Index attempt = 0; !solidNewtonConverged && attempt < 8; ++attempt)
       {
         solidDisplacement.setData(solidDisplacementInitial);
 
-        Alert::Warning()
-          << "  full Newton did not converge; seeking basin with alpha="
-          << solidNewtonDamping
-          << Alert::Raise;
+        Alert::Warning() << "  full Newton did not converge; seeking basin with alpha="
+                         << solidNewtonDamping << Alert::Raise;
 
-        const bool reachedBasin =
-          solveSolidNewton(
-              "damped basin attempt",
-              solidNewtonDamping,
-              basinSolidTolerance,
-              0.0);
+        const bool reachedBasin = solveSolidNewton(
+          "damped basin attempt", solidNewtonDamping, basinSolidTolerance, 0.0);
 
         if (reachedBasin)
         {
           solidNewtonConverged =
-            solveSolidNewton(
-                "full Newton final",
-                1.0,
-                tightSolidTolerance,
-                1e-8);
+            solveSolidNewton("full Newton final", 1.0, tightSolidTolerance, 1e-8);
 
           if (solidNewtonConverged)
             break;
 
-          Alert::Warning()
-            << "  full Newton failed from damped iterate; reducing alpha."
-            << Alert::Raise;
+          Alert::Warning() << "  full Newton failed from damped iterate; reducing alpha."
+                           << Alert::Raise;
         }
 
         solidNewtonDamping *= 0.5;
@@ -1052,14 +954,13 @@ int main(int argc, char** argv)
       if (!solidNewtonConverged)
       {
         throw std::runtime_error(
-            "Solid Newton failed to converge after basin damping retries.");
+          "Solid Newton failed to converge after basin damping retries.");
       }
 
       /*
        * Commit solid state.
        */
-      solidVelocity =
-        (1.0 / dt) * (solidDisplacement - solidDisplacementOld);
+      solidVelocity = (1.0 / dt) * (solidDisplacement - solidDisplacementOld);
 
       solidDisplacementOld = solidDisplacement;
       solidVelocityOld = solidVelocity;
@@ -1076,16 +977,12 @@ int main(int argc, char** argv)
       fluidDisplacementOld.setData(fluidDisplacement.getData());
       solveHarmonicALE(solidDisplacement);
 
-      meshVelocity =
-        (1.0 / dt) * (fluidDisplacement - fluidDisplacementOld);
+      meshVelocity = (1.0 / dt) * (fluidDisplacement - fluidDisplacementOld);
 
       restoreMesh(solidOutputMesh, solidReferenceVertices);
 
       moveMeshWithDisplacement(
-          solidOutputMesh,
-          solidMesh,
-          solidReferenceVertices,
-          solidDisplacement);
+        solidOutputMesh, solidMesh, solidReferenceVertices, solidDisplacement);
 
       /*
        * Copy solid assembly fields to output fields.

--- a/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI_Monolithic.cpp
+++ b/examples/PETSc/PDEs/Seq_BDF1_ALE_FSI_Monolithic.cpp
@@ -113,27 +113,23 @@ namespace
 
   struct Volume
   {
-    static constexpr Attribute Fluid = 1;
-    static constexpr Attribute Solid = 2;
+      static constexpr Attribute Fluid = 1;
+      static constexpr Attribute Solid = 2;
   };
 
   struct Boundary
   {
-    static constexpr Attribute Inlet          = 10;
-    static constexpr Attribute Outlet         = 11;
-    static constexpr Attribute FluidWall      = 12;
-    static constexpr Attribute SolidClampLeft = 13;
-    static constexpr Attribute SolidClampRight = 14;
-    static constexpr Attribute SolidFree      = 15;
-    static constexpr Attribute FSI            = 16;
+      static constexpr Attribute Inlet = 10;
+      static constexpr Attribute Outlet = 11;
+      static constexpr Attribute FluidWall = 12;
+      static constexpr Attribute SolidClampLeft = 13;
+      static constexpr Attribute SolidClampRight = 14;
+      static constexpr Attribute SolidFree = 15;
+      static constexpr Attribute FSI = 16;
   };
 
-  static Real pulseTrain(
-      const Real t,
-      const Real amplitude,
-      const Real duration,
-      const Real gap,
-      const Index count)
+  static Real pulseTrain(const Real t, const Real amplitude, const Real duration,
+    const Real gap, const Index count)
   {
     if (t < 0.0 || duration <= 0.0 || count == 0)
       return 0.0;
@@ -172,16 +168,11 @@ namespace
    * Hf / (Hf + Hs) differs from nfy / (nfy + nsy).
    */
   static void mapMeshToFSIStrip(
-      LocalMesh& mesh,
-      size_t nfy,
-      size_t nsy,
-      Real L,
-      Real Hf,
-      Real Hs)
+    LocalMesh& mesh, size_t nfy, size_t nsy, Real L, Real Hf, Real Hs)
   {
-    Real xmin =  std::numeric_limits<Real>::max();
+    Real xmin = std::numeric_limits<Real>::max();
     Real xmax = -std::numeric_limits<Real>::max();
-    Real ymin =  std::numeric_limits<Real>::max();
+    Real ymin = std::numeric_limits<Real>::max();
     Real ymax = -std::numeric_limits<Real>::max();
 
     for (auto it = mesh.getVertex(); it; ++it)
@@ -193,8 +184,7 @@ namespace
       ymax = std::max(ymax, x.y());
     }
 
-    const Real rInterface =
-      static_cast<Real>(nfy) / static_cast<Real>(nfy + nsy);
+    const Real rInterface = static_cast<Real>(nfy) / static_cast<Real>(nfy + nsy);
 
     for (auto it = mesh.getVertex(); it; ++it)
     {
@@ -221,8 +211,7 @@ namespace
   }
 
   static void saveReferenceVertices(
-      const LocalMesh& mesh,
-      std::vector<Math::SpatialPoint>& vertices)
+    const LocalMesh& mesh, std::vector<Math::SpatialPoint>& vertices)
   {
     vertices.resize(mesh.getVertexCount());
 
@@ -231,11 +220,9 @@ namespace
   }
 
   template <class FESType, class GridFunctionType>
-  static void moveMeshWithVertexDisplacement(
-      LocalMesh& mesh,
-      const std::vector<Math::SpatialPoint>& referenceVertices,
-      const FESType& displacementFES,
-      const GridFunctionType& displacement)
+  static void moveMeshWithVertexDisplacement(LocalMesh& mesh,
+    const std::vector<Math::SpatialPoint>& referenceVertices,
+    const FESType& displacementFES, const GridFunctionType& displacement)
   {
     assert(mesh.getVertexCount() == referenceVertices.size());
     assert(displacementFES.getVectorDimension() >= mesh.getSpaceDimension());
@@ -248,7 +235,7 @@ namespace
       auto x = referenceVertices[vertex];
 
       for (Index c = 0; c < static_cast<Index>(dim); ++c)
-        x(c) += displacement[displacementFES.getGlobalIndex({ 0, vertex }, c)];
+        x(c) += displacement[displacementFES.getGlobalIndex({0, vertex}, c)];
 
       mesh.setVertexCoordinates(vertex, x);
     }
@@ -256,10 +243,11 @@ namespace
     mesh.flush();
   }
 
-  static LocalMesh makeFSIMesh(size_t nx, size_t nfy, size_t nsy, Real L, Real Hf, Real Hs)
+  static LocalMesh makeFSIMesh(
+    size_t nx, size_t nfy, size_t nsy, Real L, Real Hf, Real Hs)
   {
     Mesh mesh;
-    mesh = mesh.UniformGrid(Polytope::Type::Triangle, { nx + 1, nfy + nsy + 1 });
+    mesh = mesh.UniformGrid(Polytope::Type::Triangle, {nx + 1, nfy + nsy + 1});
 
     mapMeshToFSIStrip(mesh, nfy, nsy, L, Hf, Hs);
 
@@ -328,7 +316,7 @@ namespace
       }
 
       if (!touchesExterior && std::abs(c.y() - Hf) < eps)
-        mesh.setAttribute({ faceDim, it->getIndex() }, Boundary::FSI);
+        mesh.setAttribute({faceDim, it->getIndex()}, Boundary::FSI);
     }
 
     return mesh;
@@ -340,69 +328,72 @@ int main(int argc, char** argv)
   PetscInitialize(&argc, &argv, PETSC_NULLPTR, PETSC_NULLPTR);
 
   {
-  PetscInt nxOpt = 48;
-  PetscInt fluidNyOpt = 12;
-  PetscInt solidNyOpt = 4;
-  PetscInt ntOpt = 100;
+    PetscInt nxOpt = 48;
+    PetscInt fluidNyOpt = 12;
+    PetscInt solidNyOpt = 4;
+    PetscInt ntOpt = 100;
 
-  PetscReal finalTimeOpt = 1.0;
-  PetscReal inletAmplitudeOpt = 1.25;
-  PetscReal pulseDurationOpt = 0.18;
-  PetscReal pulseGapOpt = 0.35;
-  PetscInt pulseCountOpt = 1;
+    PetscReal finalTimeOpt = 1.0;
+    PetscReal inletAmplitudeOpt = 1.25;
+    PetscReal pulseDurationOpt = 0.18;
+    PetscReal pulseGapOpt = 0.35;
+    PetscInt pulseCountOpt = 1;
 
-  PetscReal solidEOpt = 2.0e2;
-  PetscReal solidNuOpt = 0.3;
-  PetscReal solidDensityOpt = 5.0e-1;
-  PetscReal solidRayleighAlphaOpt = 5.0e-2;
-  PetscReal inactiveOpt = 1e-8;
-  PetscBool moveMeshDuringNewtonOpt = PETSC_FALSE;
+    PetscReal solidEOpt = 2.0e2;
+    PetscReal solidNuOpt = 0.3;
+    PetscReal solidDensityOpt = 5.0e-1;
+    PetscReal solidRayleighAlphaOpt = 5.0e-2;
+    PetscReal inactiveOpt = 1e-8;
+    PetscBool moveMeshDuringNewtonOpt = PETSC_FALSE;
 
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_nx", &nxOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_fluid_ny", &fluidNyOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_ny", &solidNyOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_Nt", &ntOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_T", &finalTimeOpt, PETSC_NULLPTR);
+    PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_nx", &nxOpt, PETSC_NULLPTR);
+    PetscOptionsGetInt(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_fluid_ny", &fluidNyOpt, PETSC_NULLPTR);
+    PetscOptionsGetInt(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_ny", &solidNyOpt, PETSC_NULLPTR);
+    PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_Nt", &ntOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_T", &finalTimeOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_inlet_amplitude", &inletAmplitudeOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_duration", &pulseDurationOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_gap", &pulseGapOpt, PETSC_NULLPTR);
-  PetscOptionsGetInt(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_pulse_count", &pulseCountOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_inlet_amplitude",
+      &inletAmplitudeOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_duration",
+      &pulseDurationOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_gap", &pulseGapOpt, PETSC_NULLPTR);
+    PetscOptionsGetInt(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_pulse_count", &pulseCountOpt, PETSC_NULLPTR);
 
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_E", &solidEOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_nu", &solidNuOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_density", &solidDensityOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_solid_rayleigh_alpha", &solidRayleighAlphaOpt, PETSC_NULLPTR);
-  PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_inactive_regularization", &inactiveOpt, PETSC_NULLPTR);
-  PetscOptionsGetBool(PETSC_NULLPTR, PETSC_NULLPTR,
-      "-fsi_move_mesh_during_newton", &moveMeshDuringNewtonOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_E", &solidEOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(
+      PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_nu", &solidNuOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_density",
+      &solidDensityOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_solid_rayleigh_alpha",
+      &solidRayleighAlphaOpt, PETSC_NULLPTR);
+    PetscOptionsGetReal(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_inactive_regularization",
+      &inactiveOpt, PETSC_NULLPTR);
+    PetscOptionsGetBool(PETSC_NULLPTR, PETSC_NULLPTR, "-fsi_move_mesh_during_newton",
+      &moveMeshDuringNewtonOpt, PETSC_NULLPTR);
 
-  const size_t nx = static_cast<size_t>(std::max<PetscInt>(3, nxOpt));
-  const size_t nfy = static_cast<size_t>(std::max<PetscInt>(2, fluidNyOpt));
-  const size_t nsy = static_cast<size_t>(std::max<PetscInt>(1, solidNyOpt));
-  const Index Nt = static_cast<Index>(std::max<PetscInt>(1, ntOpt));
+    const size_t nx = static_cast<size_t>(std::max<PetscInt>(3, nxOpt));
+    const size_t nfy = static_cast<size_t>(std::max<PetscInt>(2, fluidNyOpt));
+    const size_t nsy = static_cast<size_t>(std::max<PetscInt>(1, solidNyOpt));
+    const Index Nt = static_cast<Index>(std::max<PetscInt>(1, ntOpt));
 
-  const Real L = 4.0;
-  const Real Hf = 1.0;
-  const Real Hs = 0.25;
-  const Real T = static_cast<Real>(finalTimeOpt);
-  const Real dt = T / static_cast<Real>(Nt);
+    const Real L = 4.0;
+    const Real Hf = 1.0;
+    const Real Hs = 0.25;
+    const Real T = static_cast<Real>(finalTimeOpt);
+    const Real dt = T / static_cast<Real>(Nt);
 
-  LocalMesh mesh = makeFSIMesh(nx, nfy, nsy, L, Hf, Hs);
-  const size_t dim = mesh.getSpaceDimension();
-  const bool moveMeshDuringNewton = (moveMeshDuringNewtonOpt == PETSC_TRUE);
+    LocalMesh mesh = makeFSIMesh(nx, nfy, nsy, L, Hf, Hs);
+    const size_t dim = mesh.getSpaceDimension();
+    const bool moveMeshDuringNewton = (moveMeshDuringNewtonOpt == PETSC_TRUE);
 
-  std::vector<Math::SpatialPoint> referenceVertices;
-  saveReferenceVertices(mesh, referenceVertices);
+    std::vector<Math::SpatialPoint> referenceVertices;
+    saveReferenceVertices(mesh, referenceVertices);
 
   /* Global spaces.
    *
@@ -410,90 +401,88 @@ int main(int argc, char** argv)
    * Displacement is physical in the solid and ALE mesh displacement in the
    * fluid.
    */
-  H1 uh(std::integral_constant<size_t, 2>{}, mesh, dim);
-  H1 ph(std::integral_constant<size_t, 1>{}, mesh);
-  P0g lh(mesh);
-  H1 dh(std::integral_constant<size_t, 2>{}, mesh, dim);
+    H1 uh(std::integral_constant<size_t, 2>{}, mesh, dim);
+    H1 ph(std::integral_constant<size_t, 1>{}, mesh);
+    P0g lh(mesh);
+    H1 dh(std::integral_constant<size_t, 2>{}, mesh, dim);
 
-  PETSc::Variational::TrialFunction du(uh);
-  PETSc::Variational::TrialFunction dp(ph);
-  PETSc::Variational::TrialFunction dlambda(lh);
-  PETSc::Variational::TrialFunction deta(dh);
+    PETSc::Variational::TrialFunction du(uh);
+    PETSc::Variational::TrialFunction dp(ph);
+    PETSc::Variational::TrialFunction dlambda(lh);
+    PETSc::Variational::TrialFunction deta(dh);
 
-  PETSc::Variational::TestFunction v(uh);
-  PETSc::Variational::TestFunction q(ph);
-  PETSc::Variational::TestFunction m(lh);
-  PETSc::Variational::TestFunction z(dh);
+    PETSc::Variational::TestFunction v(uh);
+    PETSc::Variational::TestFunction q(ph);
+    PETSc::Variational::TestFunction m(lh);
+    PETSc::Variational::TestFunction z(dh);
 
-  du.setName("du");
-  dp.setName("dp");
-  dlambda.setName("dlambda");
-  deta.setName("deta");
+    du.setName("du");
+    dp.setName("dp");
+    dlambda.setName("dlambda");
+    deta.setName("deta");
 
-  PETSc::Variational::GridFunction uState(uh);
-  PETSc::Variational::GridFunction pState(ph);
-  PETSc::Variational::GridFunction lambdaState(lh);
-  PETSc::Variational::GridFunction etaState(dh);
-  PETSc::Variational::GridFunction dState(dh);
+    PETSc::Variational::GridFunction uState(uh);
+    PETSc::Variational::GridFunction pState(ph);
+    PETSc::Variational::GridFunction lambdaState(lh);
+    PETSc::Variational::GridFunction etaState(dh);
+    PETSc::Variational::GridFunction dState(dh);
 
-  PETSc::Variational::GridFunction uOld(uh);
-  PETSc::Variational::GridFunction pOld(ph);
-  PETSc::Variational::GridFunction etaOld(dh);
-  PETSc::Variational::GridFunction dOld(dh);
+    PETSc::Variational::GridFunction uOld(uh);
+    PETSc::Variational::GridFunction pOld(ph);
+    PETSc::Variational::GridFunction etaOld(dh);
+    PETSc::Variational::GridFunction dOld(dh);
 
-  PETSc::Variational::GridFunction meshVelocity(dh);
-  PETSc::Variational::GridFunction inletVelocity(uh);
+    PETSc::Variational::GridFunction meshVelocity(dh);
+    PETSc::Variational::GridFunction inletVelocity(uh);
 
-  auto moveMeshToCurrentDisplacement = [&]()
-  {
-    moveMeshWithVertexDisplacement(mesh, referenceVertices, dh, dState);
-  };
+    auto moveMeshToCurrentDisplacement = [&]() {
+      moveMeshWithVertexDisplacement(mesh, referenceVertices, dh, dState);
+    };
 
-  uState.setName("FluidVelocity");
-  pState.setName("FluidPressure");
-  lambdaState.setName("PressureGauge");
-  etaState.setName("DisplacementIncrement");
-  dState.setName("Displacement");
-  meshVelocity.setName("ALEMeshVelocity");
+    uState.setName("FluidVelocity");
+    pState.setName("FluidPressure");
+    lambdaState.setName("PressureGauge");
+    etaState.setName("DisplacementIncrement");
+    dState.setName("Displacement");
+    meshVelocity.setName("ALEMeshVelocity");
 
-  uState = Zero(dim);
-  pState = 0.0;
-  lambdaState = 0.0;
-  etaState = Zero(dim);
-  dState = Zero(dim);
-  uOld = Zero(dim);
-  pOld = 0.0;
-  etaOld = Zero(dim);
-  dOld = Zero(dim);
-  meshVelocity = Zero(dim);
-  inletVelocity = Zero(dim);
+    uState = Zero(dim);
+    pState = 0.0;
+    lambdaState = 0.0;
+    etaState = Zero(dim);
+    dState = Zero(dim);
+    uOld = Zero(dim);
+    pOld = 0.0;
+    etaOld = Zero(dim);
+    dOld = Zero(dim);
+    meshVelocity = Zero(dim);
+    inletVelocity = Zero(dim);
 
-  IO::XDMF xdmf("out/Seq_BDF1_Monolithic_ALE_FSI");
-  auto grid = xdmf.grid("FSI");
-  grid.setMesh(mesh, IO::XDMF::MeshPolicy::Transient);
-  grid.add("velocity", uState);
-  grid.add("pressure", pState);
-  grid.add("displacement", dState);
-  grid.add("mesh_velocity", meshVelocity);
-  xdmf.write(0.0).flush();
+    IO::XDMF xdmf("out/Seq_BDF1_Monolithic_ALE_FSI");
+    auto grid = xdmf.grid("FSI");
+    grid.setMesh(mesh, IO::XDMF::MeshPolicy::Transient);
+    grid.add("velocity", uState);
+    grid.add("pressure", pState);
+    grid.add("displacement", dState);
+    grid.add("mesh_velocity", meshVelocity);
+    xdmf.write(0.0).flush();
 
-  const Real rhoF = 1.0;
-  const Real muF = 0.02;
+    const Real rhoF = 1.0;
+    const Real muF = 0.02;
 
-  const Real solidE = static_cast<Real>(solidEOpt);
-  const Real solidNu = static_cast<Real>(solidNuOpt);
-  const Real solidLambda =
-    solidE * solidNu / ((1.0 + solidNu) * (1.0 - 2.0 * solidNu));
-  const Real solidMu = solidE / (2.0 * (1.0 + solidNu));
-  const Real rhoS = static_cast<Real>(solidDensityOpt);
-  const Real solidRayleighAlpha = static_cast<Real>(solidRayleighAlphaOpt);
-  const Real inactive = static_cast<Real>(inactiveOpt);
+    const Real solidE = static_cast<Real>(solidEOpt);
+    const Real solidNu = static_cast<Real>(solidNuOpt);
+    const Real solidLambda = solidE * solidNu / ((1.0 + solidNu) * (1.0 - 2.0 * solidNu));
+    const Real solidMu = solidE / (2.0 * (1.0 + solidNu));
+    const Real rhoS = static_cast<Real>(solidDensityOpt);
+    const Real solidRayleighAlpha = static_cast<Real>(solidRayleighAlphaOpt);
+    const Real inactive = static_cast<Real>(inactiveOpt);
 
-  Solid::NeoHookean law(solidLambda, solidMu);
+    Solid::NeoHookean law(solidLambda, solidMu);
 
-  auto ivw = Solid::InternalVirtualWork(law, dState);
+    auto ivw = Solid::InternalVirtualWork(law, dState);
 
-  auto n = BoundaryNormal(mesh);
+    auto n = BoundaryNormal(mesh);
 
   /* Fully nonlinear BDF1 ALE Navier--Stokes fluid block.
    *
@@ -517,127 +506,125 @@ int main(int argc, char** argv)
    * + 0.5 rho div(beta) du
    * + 0.5 rho div(delta beta) u.
    */
-  const auto meshVelocityState = (1.0 / dt) * etaState;
-  const auto transportVelocity = uState - meshVelocityState;
+    const auto meshVelocityState = (1.0 / dt) * etaState;
+    const auto transportVelocity = uState - meshVelocityState;
 
-  const auto convState = Mult(Jacobian(uState), transportVelocity);
-  const auto convTangentVelocity = Mult(Jacobian(du), transportVelocity);
-  const auto convTangentTransportU = Mult(Jacobian(uState), du);
-  const auto convTangentTransportEta = Mult(Jacobian(uState), deta);
+    const auto convState = Mult(Jacobian(uState), transportVelocity);
+    const auto convTangentVelocity = Mult(Jacobian(du), transportVelocity);
+    const auto convTangentTransportU = Mult(Jacobian(uState), du);
+    const auto convTangentTransportEta = Mult(Jacobian(uState), deta);
 
   /* Div does not currently have a deduction guide for Sum expressions such as
    * Div(uState - etaState / dt), so write the divergence algebraically.
   */
-  const auto divTransport = Div(uState) - (1.0 / dt) * Div(etaState);
-  const auto beta = Max(-Dot(transportVelocity, n), 0.0);
+    const auto divTransport = Div(uState) - (1.0 / dt) * Div(etaState);
+    const auto beta = Max(-Dot(transportVelocity, n), 0.0);
 
-  Problem fsi(du, dp, dlambda, deta, v, q, m, z);
+    Problem fsi(du, dp, dlambda, deta, v, q, m, z);
 
-  fsi =
+    fsi =
       /* Fully nonlinear ALE Navier--Stokes tangent over fluid cells. */
-    (rhoF / dt) * Integral(du, v).over(Volume::Fluid) +
-    rhoF * Integral(Dot(convTangentVelocity, v)).over(Volume::Fluid) +
-    rhoF * Integral(Dot(convTangentTransportU, v)).over(Volume::Fluid) -
-    (rhoF / dt) * Integral(Dot(convTangentTransportEta, v)).over(Volume::Fluid) +
-    0.5 * rhoF * Integral(divTransport * Dot(du, v)).over(Volume::Fluid) +
-    0.5 * rhoF * Integral(Dot(Div(du) * uState, v)).over(Volume::Fluid) -
-    (0.5 * rhoF / dt) * Integral(Dot(Div(deta) * uState, v)).over(Volume::Fluid) +
-    muF * Integral(Jacobian(du), Jacobian(v)).over(Volume::Fluid) -
-    Integral(dp, Div(v)).over(Volume::Fluid) + Integral(Div(du), q).over(Volume::Fluid) +
-    Integral(dlambda, q).over(Volume::Fluid) + Integral(dp, m).over(Volume::Fluid) +
-    BoundaryIntegral(0.5 * rhoF * beta * Dot(du, v)).over(Boundary::Outlet) +
-    1e-10 * Integral(dp, q).over(Volume::Fluid) +
-    1e-10 * Integral(dlambda, m)
+      (rhoF / dt) * Integral(du, v).over(Volume::Fluid) +
+      rhoF * Integral(Dot(convTangentVelocity, v)).over(Volume::Fluid) +
+      rhoF * Integral(Dot(convTangentTransportU, v)).over(Volume::Fluid) -
+      (rhoF / dt) * Integral(Dot(convTangentTransportEta, v)).over(Volume::Fluid) +
+      0.5 * rhoF * Integral(divTransport * Dot(du, v)).over(Volume::Fluid) +
+      0.5 * rhoF * Integral(Dot(Div(du) * uState, v)).over(Volume::Fluid) -
+      (0.5 * rhoF / dt) * Integral(Dot(Div(deta) * uState, v)).over(Volume::Fluid) +
+      muF * Integral(Jacobian(du), Jacobian(v)).over(Volume::Fluid) -
+      Integral(dp, Div(v)).over(Volume::Fluid) +
+      Integral(Div(du), q).over(Volume::Fluid) +
+      Integral(dlambda, q).over(Volume::Fluid) + Integral(dp, m).over(Volume::Fluid) +
+      BoundaryIntegral(0.5 * rhoF * beta * Dot(du, v)).over(Boundary::Outlet) +
+      1e-10 * Integral(dp, q).over(Volume::Fluid) +
+      1e-10 * Integral(dlambda, m)
 
       /* Fully nonlinear ALE Navier--Stokes residual over fluid cells. */
-    + (rhoF / dt) * Integral(uState - uOld, v).over(Volume::Fluid) +
-    rhoF * Integral(Dot(convState, v)).over(Volume::Fluid) +
-    0.5 * rhoF * Integral(Dot(divTransport * uState, v)).over(Volume::Fluid) +
-    muF * Integral(Jacobian(uState), Jacobian(v)).over(Volume::Fluid) -
-    Integral(pState, Div(v)).over(Volume::Fluid) +
-    Integral(Div(uState), q).over(Volume::Fluid) +
-    Integral(lambdaState, q).over(Volume::Fluid) +
-    Integral(pState, m).over(Volume::Fluid) +
-    BoundaryIntegral(0.5 * rhoF * Dot(beta * uState, v)).over(Boundary::Outlet) +
-    1e-10 * Integral(pState, q).over(Volume::Fluid) +
-    1e-10 * Integral(lambdaState, m)
+      + (rhoF / dt) * Integral(uState - uOld, v).over(Volume::Fluid) +
+      rhoF * Integral(Dot(convState, v)).over(Volume::Fluid) +
+      0.5 * rhoF * Integral(Dot(divTransport * uState, v)).over(Volume::Fluid) +
+      muF * Integral(Jacobian(uState), Jacobian(v)).over(Volume::Fluid) -
+      Integral(pState, Div(v)).over(Volume::Fluid) +
+      Integral(Div(uState), q).over(Volume::Fluid) +
+      Integral(lambdaState, q).over(Volume::Fluid) +
+      Integral(pState, m).over(Volume::Fluid) +
+      BoundaryIntegral(0.5 * rhoF * Dot(beta * uState, v)).over(Boundary::Outlet) +
+      1e-10 * Integral(pState, q).over(Volume::Fluid) +
+      1e-10 * Integral(lambdaState, m)
 
       /* Harmonic ALE displacement in the fluid. */
-    + Integral(Jacobian(deta), Jacobian(z)).over(Volume::Fluid) +
-    Integral(Jacobian(etaState), Jacobian(z)).over(Volume::Fluid)
+      + Integral(Jacobian(deta), Jacobian(z)).over(Volume::Fluid) +
+      Integral(Jacobian(etaState), Jacobian(z)).over(Volume::Fluid)
 
       /* Solid BDF1/Newmark-like displacement increment equation. */
-    + (rhoS / (dt * dt)) * Integral(deta, z).over(Volume::Solid) +
-    (solidRayleighAlpha * rhoS / dt) * Integral(deta, z).over(Volume::Solid) +
-    ivw.Tangent(deta, z).over(Volume::Solid)
+      + (rhoS / (dt * dt)) * Integral(deta, z).over(Volume::Solid) +
+      (solidRayleighAlpha * rhoS / dt) * Integral(deta, z).over(Volume::Solid) +
+      ivw.Tangent(deta, z).over(Volume::Solid)
 
-    + (rhoS / (dt * dt)) * Integral(etaState - etaOld, z).over(Volume::Solid) +
-    (solidRayleighAlpha * rhoS / dt) * Integral(etaState, z).over(Volume::Solid) +
-    ivw.Residual(z).over(Volume::Solid)
+      + (rhoS / (dt * dt)) * Integral(etaState - etaOld, z).over(Volume::Solid) +
+      (solidRayleighAlpha * rhoS / dt) * Integral(etaState, z).over(Volume::Solid) +
+      ivw.Residual(z).over(Volume::Solid)
 
       /* Temporary inactive-region regularization for globally-defined fluid
        * variables.  Replace by subdomain-restricted spaces when available.
        */
-    + inactive * Integral(du, v).over(Volume::Solid) +
-    inactive * Integral(uState, v).over(Volume::Solid) +
-    inactive * Integral(dp, q).over(Volume::Solid) +
-    inactive * Integral(pState, q).over(Volume::Solid)
+      + inactive * Integral(du, v).over(Volume::Solid) +
+      inactive * Integral(uState, v).over(Volume::Solid) +
+      inactive * Integral(dp, q).over(Volume::Solid) +
+      inactive * Integral(pState, q).over(Volume::Solid)
 
       /* Boundary and interface constraints. */
-    + DirichletBC(du, inletVelocity - uState).on(Boundary::Inlet) +
-    DirichletBC(du, -uState).on(Boundary::FluidWall) +
-    DirichletBC(deta, -etaState)
-      .on(Boundary::Inlet, Boundary::Outlet, Boundary::FluidWall) +
-    DirichletBC(deta, -etaState).on(Boundary::SolidClampLeft, Boundary::SolidClampRight) +
-    DirichletBC(du, (1.0 / dt) * deta, (1.0 / dt) * etaState - uState).on(Boundary::FSI);
+      + DirichletBC(du, inletVelocity - uState).on(Boundary::Inlet) +
+      DirichletBC(du, -uState).on(Boundary::FluidWall) +
+      DirichletBC(deta, -etaState)
+        .on(Boundary::Inlet, Boundary::Outlet, Boundary::FluidWall) +
+      DirichletBC(deta, -etaState)
+        .on(Boundary::SolidClampLeft, Boundary::SolidClampRight) +
+      DirichletBC(du, (1.0 / dt) * deta, (1.0 / dt) * etaState - uState)
+        .on(Boundary::FSI);
 
-  fsi.assemble().setFieldSplits();
+    fsi.assemble().setFieldSplits();
 
-  Solver::KSP ksp(fsi);
-  Solver::SNES snes(ksp);
+    Solver::KSP ksp(fsi);
+    Solver::SNES snes(ksp);
 
-  snes.setTolerances(1e-10, 1e-8, 1e-10, 30, 10000);
+    snes.setTolerances(1e-10, 1e-8, 1e-10, 30, 10000);
 
-  snes.setStateUpdate([&](const PETSc::Math::Vector& state)
-  {
-    const size_t uOffset = 0;
-    const size_t pOffset = uOffset + uh.getSize();
-    const size_t lambdaOffset = pOffset + ph.getSize();
-    const size_t etaOffset = lambdaOffset + lh.getSize();
+    snes.setStateUpdate([&](const PETSc::Math::Vector& state) {
+      const size_t uOffset = 0;
+      const size_t pOffset = uOffset + uh.getSize();
+      const size_t lambdaOffset = pOffset + ph.getSize();
+      const size_t etaOffset = lambdaOffset + lh.getSize();
 
-    uState.setData(state, uOffset);
-    pState.setData(state, pOffset);
-    lambdaState.setData(state, lambdaOffset);
-    etaState.setData(state, etaOffset);
+      uState.setData(state, uOffset);
+      pState.setData(state, pOffset);
+      lambdaState.setData(state, lambdaOffset);
+      etaState.setData(state, etaOffset);
 
-    dState = dOld + etaState;
-    meshVelocity = (1.0 / dt) * etaState;
-    if (moveMeshDuringNewton)
-      moveMeshToCurrentDisplacement();
-  });
+      dState = dOld + etaState;
+      meshVelocity = (1.0 / dt) * etaState;
+      if (moveMeshDuringNewton)
+        moveMeshToCurrentDisplacement();
+    });
 
-  Real t = 0.0;
+    Real t = 0.0;
 
-  for (Index step = 1; step <= Nt; ++step)
-  {
-    t += dt;
-
-    inletVelocity = VectorFunction(dim, [&](const Point& x)
+    for (Index step = 1; step <= Nt; ++step)
     {
-      const Real y = std::clamp(x.y(), 0.0, Hf);
-      const Real profile = 4.0 * y * (Hf - y) / (Hf * Hf);
-      const Real amplitude = pulseTrain(
-          t,
-          static_cast<Real>(inletAmplitudeOpt),
-          static_cast<Real>(pulseDurationOpt),
-          static_cast<Real>(pulseGapOpt),
+      t += dt;
+
+      inletVelocity = VectorFunction(dim, [&](const Point& x) {
+        const Real y = std::clamp(x.y(), 0.0, Hf);
+        const Real profile = 4.0 * y * (Hf - y) / (Hf * Hf);
+        const Real amplitude = pulseTrain(t, static_cast<Real>(inletAmplitudeOpt),
+          static_cast<Real>(pulseDurationOpt), static_cast<Real>(pulseGapOpt),
           static_cast<Index>(pulseCountOpt));
 
-      Math::SpatialVector<Real> value(dim);
-      value.setZero();
-      value(0) = amplitude * profile;
-      return value;
-    });
+        Math::SpatialVector<Real> value(dim);
+        value.setZero();
+        value(0) = amplitude * profile;
+        return value;
+      });
 
     /* Initial Newton guess.
      *
@@ -645,35 +632,34 @@ int main(int argc, char** argv)
      * The affine FSI correction row below still drives the nonlinear
      * kinematic residual to zero if this guess is not exact.
      */
-    uState = uOld;
-    pState = pOld;
-    lambdaState = 0.0;
-    etaState = dt * uOld;
-    dState = dOld + etaState;
-    meshVelocity = (1.0 / dt) * etaState;
-    moveMeshToCurrentDisplacement();
+      uState = uOld;
+      pState = pOld;
+      lambdaState = 0.0;
+      etaState = dt * uOld;
+      dState = dOld + etaState;
+      meshVelocity = (1.0 / dt) * etaState;
+      moveMeshToCurrentDisplacement();
 
-    Alert::Info()
-      << "Monolithic BDF1 ALE FSI step " << step << " / " << Nt
-      << Alert::Raise;
+      Alert::Info() << "Monolithic BDF1 ALE FSI step " << step << " / " << Nt
+                    << Alert::Raise;
 
-    snes.solve();
+      snes.solve();
 
-    if (!snes.converged())
-    {
-      Alert::MemberFunctionException("Seq_BDF1_Monolithic_ALE_FSI", "main")
-        << "SNES failed to converge at step " << step << Alert::Raise;
+      if (!snes.converged())
+      {
+        Alert::MemberFunctionException("Seq_BDF1_Monolithic_ALE_FSI", "main")
+          << "SNES failed to converge at step " << step << Alert::Raise;
+      }
+
+      uOld.setData(uState.getData());
+      pOld.setData(pState.getData());
+      etaOld.setData(etaState.getData());
+      dOld.setData(dState.getData());
+
+      moveMeshToCurrentDisplacement();
+      xdmf.write(t).flush();
+      xdmf.flush();
     }
-
-    uOld.setData(uState.getData());
-    pOld.setData(pState.getData());
-    etaOld.setData(etaState.getData());
-    dOld.setData(dState.getData());
-
-    moveMeshToCurrentDisplacement();
-    xdmf.write(t).flush();
-    xdmf.flush();
-  }
   }
 
   PetscFinalize();

--- a/examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp
+++ b/examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp
@@ -276,7 +276,6 @@ int main(int argc, char** argv)
 
       t += dt;
 
-
       // Oseen / Picard linearization:
       //   (u_old \cdot \nabla)u
       const auto conv_u = Mult(Jacobian(u), u_old);

--- a/examples/ShapeOptimization/LevelSetWNGIRCantilever2D.cpp
+++ b/examples/ShapeOptimization/LevelSetWNGIRCantilever2D.cpp
@@ -64,7 +64,7 @@ namespace
   constexpr Attribute Gamma0 = 1;               // free outer       (bdr attr 1)
   constexpr Attribute GammaD = 2;               // clamped left     (bdr attr 2)
   constexpr Attribute GammaN = 3;               // loaded right-mid (bdr attr 3)
-  constexpr Attribute Gamma  = 4;               // free interface   (bdr attr 4)
+  constexpr Attribute Gamma = 4;               // free interface   (bdr attr 4)
 
   // Lame coefficients (plane, matching LevelSetCantilever2D).
   constexpr Real muLame = 0.3846;
@@ -83,18 +83,15 @@ namespace
     return std::tanh(phi / epsilon);
   }
 
-  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {{
-    {{ Real(2) / 3, Real(1) / 6, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(2) / 3, Real(1) / 6 }},
-    {{ Real(1) / 6, Real(1) / 6, Real(2) / 3 }}
-  }};
+  constexpr std::array<std::array<Real, 3>, 3> TriangleBarycentricQuadrature = {
+    {{{Real(2) / 3, Real(1) / 6, Real(1) / 6}}, {{Real(1) / 6, Real(2) / 3, Real(1) / 6}},
+      {{Real(1) / 6, Real(1) / 6, Real(2) / 3}}}};
 
   Real facetLength(const WNGIRMesh& mesh, Index facet)
   {
     const auto face = mesh.getFace(facet);
     const auto& v = face->getVertices();
-    return (mesh.getVertexCoordinates(v[1]) - mesh.getVertexCoordinates(v[0]))
-      .norm();
+    return (mesh.getVertexCoordinates(v[1]) - mesh.getVertexCoordinates(v[0])).norm();
   }
 
   // Distance from point p to segment [a,b].
@@ -116,8 +113,7 @@ namespace
   // zero set to the fitted interface (the int_Gamma a^2 gradient).
   // `a` is row-major a[i*ny + j] on a gnx x gny lattice with spacing h.
   void reinitIR(std::vector<Real>& a, int gnx, int gny, Real h,
-                const std::vector<std::array<Vec2, 2>>& seg,
-                int K, Real lambdaIR)
+    const std::vector<std::array<Vec2, 2>>& seg, int K, Real lambdaIR)
   {
     auto AT = [&](int i, int j) -> Real& { return a[i * gny + j]; };
     auto bilinear = [&](Real x, Real y) -> Real {
@@ -125,8 +121,8 @@ namespace
       int i = std::max(0, std::min(gnx - 2, (int)gx));
       int j = std::max(0, std::min(gny - 2, (int)gy));
       Real u = gx - i, v = gy - j;
-      return (1 - u) * (1 - v) * AT(i, j) + u * (1 - v) * AT(i + 1, j)
-           + (1 - u) * v * AT(i, j + 1) + u * v * AT(i + 1, j + 1);
+      return (1 - u) * (1 - v) * AT(i, j) + u * (1 - v) * AT(i + 1, j) +
+        (1 - u) * v * AT(i, j + 1) + u * v * AT(i + 1, j + 1);
     };
     std::vector<Real> S0(a.size());
     for (std::size_t k = 0; k < a.size(); ++k)
@@ -146,10 +142,13 @@ namespace
           const Real cp = (AT(i, j + 1) - AT(i, j)) / h;
           auto sq = [](Real x) { return x * x; };
           Real gx2, gy2;
-          if (S > 0) {
+          if (S > 0)
+          {
             gx2 = std::max(sq(std::max(am, Real(0))), sq(std::min(ap, Real(0))));
             gy2 = std::max(sq(std::max(cm, Real(0))), sq(std::min(cp, Real(0))));
-          } else {
+          }
+          else
+          {
             gx2 = std::max(sq(std::min(am, Real(0))), sq(std::max(ap, Real(0))));
             gy2 = std::max(sq(std::min(cm, Real(0))), sq(std::max(cp, Real(0))));
           }
@@ -162,12 +161,13 @@ namespace
         const Real ds = (s[1] - s[0]).norm();
         Real gx = m(0) / h, gy = m(1) / h;
         int i = (int)gx, j = (int)gy;
-        if (i < 1 || i > gnx - 2 || j < 1 || j > gny - 2) continue;
+        if (i < 1 || i > gnx - 2 || j < 1 || j > gny - 2)
+          continue;
         Real u = gx - i, v = gy - j;
         const Real f = -dtau * lambdaIR * Real(2) * bilinear(m(0), m(1)) * ds / h;
-        np[i * gny + j]         += f * (1 - u) * (1 - v);
-        np[(i + 1) * gny + j]   += f * u * (1 - v);
-        np[i * gny + j + 1]     += f * (1 - u) * v;
+        np[i * gny + j] += f * (1 - u) * (1 - v);
+        np[(i + 1) * gny + j] += f * u * (1 - v);
+        np[i * gny + j + 1] += f * (1 - u) * v;
         np[(i + 1) * gny + j + 1] += f * u * v;
       }
       a.swap(np);
@@ -176,17 +176,17 @@ namespace
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real area = 0;
-    Real moment = 0;
-    std::array<Index, 3> vertices{};
-    std::array<Vec2, 3> x;
+      Index index = 0;
+      Real area = 0;
+      Real moment = 0;
+      std::array<Index, 3> vertices{};
+      std::array<Vec2, 3> x;
   };
 
   // Phase moments of the carried discrete level set phiH (P1) per cell.
   template <class PhiGf>
   std::vector<CellMomentInfo> collectCellMomentInfo(
-      const WNGIRMesh& mesh, const PhiGf& phiH, Real epsilon)
+    const WNGIRMesh& mesh, const PhiGf& phiH, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -221,7 +221,7 @@ namespace
 
   template <class Displacement>
   void updateMovedMeshFromDisplacement(
-      const WNGIRMesh& mesh, WNGIRMesh& moved, const Displacement& u)
+    const WNGIRMesh& mesh, WNGIRMesh& moved, const Displacement& u)
   {
     const auto& uFes = u.getFiniteElementSpace();
     const auto& uData = u.getData();
@@ -229,23 +229,22 @@ namespace
     {
       const Vec2 x = mesh.getVertexCoordinates(v);
       const auto& dofs = uFes.getDOFs(0, v);
-      moved.setVertexCoordinates(v, vec2(x(0) + uData(dofs[0]),
-                                         x(1) + uData(dofs[1])));
+      moved.setVertexCoordinates(v, vec2(x(0) + uData(dofs[0]), x(1) + uData(dofs[1])));
     }
   }
 
-  std::size_t parseSizeTOption(int argc, char** argv, const std::string& name,
-                               std::size_t fallback)
+  std::size_t parseSizeTOption(
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
       if (std::string(argv[i]).rfind(prefix, 0) == 0)
-        return static_cast<std::size_t>(std::stoul(std::string(argv[i]).substr(prefix.size())));
+        return static_cast<std::size_t>(
+          std::stoul(std::string(argv[i]).substr(prefix.size())));
     return fallback;
   }
 
-  Real parseRealOption(int argc, char** argv, const std::string& name,
-                       Real fallback)
+  Real parseRealOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -254,8 +253,8 @@ namespace
     return fallback;
   }
 
-  std::string parseStringOption(int argc, char** argv, const std::string& name,
-                                const std::string& fallback)
+  std::string parseStringOption(
+    int argc, char** argv, const std::string& name, const std::string& fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -266,17 +265,17 @@ namespace
 
   struct StageTimer
   {
-    using Clock = std::chrono::steady_clock;
+      using Clock = std::chrono::steady_clock;
 
-    Clock::time_point t = Clock::now();
+      Clock::time_point t = Clock::now();
 
-    Real reset()
-    {
-      const auto now = Clock::now();
-      const Real out = std::chrono::duration<Real>(now - t).count();
-      t = now;
-      return out;
-    }
+      Real reset()
+      {
+        const auto now = Clock::now();
+        const Real out = std::chrono::duration<Real>(now - t).count();
+        t = now;
+        return out;
+      }
   };
 }
 
@@ -289,12 +288,9 @@ int main(int argc, char** argv)
   const Real ell = parseRealOption(argc, argv, "ell", Real(0.4));
   const Real h = H / static_cast<Real>(n);   // uniform cell size = metric h
   const Real hmin = parseRealOption(argc, argv, "hmin", Real(0.1) * h);
-  const bool initialMMG =
-    parseSizeTOption(argc, argv, "initial-mmg", 0) != 0;
-  const Real initialMMGHMin =
-    parseRealOption(argc, argv, "initial-mmg-hmin", hmin);
-  const Real initialMMGHMax =
-    parseRealOption(argc, argv, "initial-mmg-hmax", h);
+  const bool initialMMG = parseSizeTOption(argc, argv, "initial-mmg", 0) != 0;
+  const Real initialMMGHMin = parseRealOption(argc, argv, "initial-mmg-hmin", hmin);
+  const Real initialMMGHMax = parseRealOption(argc, argv, "initial-mmg-hmax", h);
   const Real initialMMGHausd =
     parseRealOption(argc, argv, "initial-mmg-hausd", Real(0.5) * hmin);
   // Design-smoothness knobs (sensitive — raise gently):
@@ -307,7 +303,7 @@ int main(int argc, char** argv)
   const Real lambdaC = parseRealOption(argc, argv, "classifier-lambda", Real(0.004));
   // Adaptive step: start at dt, grow x1.3 on accepted steps up to dtMax, halve
   // on a rejected (blown-up) step.
-  const Real dt    = parseRealOption(argc, argv, "dt", Real(2) * h);
+  const Real dt = parseRealOption(argc, argv, "dt", Real(2) * h);
   const Real dtMax = parseRealOption(argc, argv, "dt-max", Real(4) * h);
   const bool objectiveLineSearch =
     parseSizeTOption(argc, argv, "objective-linesearch", 1) != 0;
@@ -339,26 +335,19 @@ int main(int argc, char** argv)
   const std::string reinitMode = parseStringOption(argc, argv, "reinit", "cp");
   const std::size_t irSteps = parseSizeTOption(argc, argv, "ir-steps", 30);
   const Real irLambda = parseRealOption(argc, argv, "ir-lambda", Real(20));
-  const Real irDtauFactor =
-    parseRealOption(argc, argv, "ir-dtau-factor", Real(0.1));
-  const Real irDeltaEps =
-    parseRealOption(argc, argv, "ir-delta-eps", Real(1.5) * h);
-  const std::size_t reinitEvery =
-    parseSizeTOption(argc, argv, "reinit-every", 1);
+  const Real irDtauFactor = parseRealOption(argc, argv, "ir-dtau-factor", Real(0.1));
+  const Real irDeltaEps = parseRealOption(argc, argv, "ir-delta-eps", Real(1.5) * h);
+  const std::size_t reinitEvery = parseSizeTOption(argc, argv, "reinit-every", 1);
   const std::string redistanceMode =
     parseStringOption(argc, argv, "redistance-mode", "none");
-  const std::size_t redistanceEvery =
-    parseSizeTOption(argc, argv, "redistance-every", 0);
-  const std::size_t outputEvery =
-    parseSizeTOption(argc, argv, "output-every", 1);
+  const std::size_t redistanceEvery = parseSizeTOption(argc, argv, "redistance-every", 0);
+  const std::size_t outputEvery = parseSizeTOption(argc, argv, "output-every", 1);
   const std::size_t irDpUpdateEvery =
     std::max<std::size_t>(1, parseSizeTOption(argc, argv, "ir-dp-update-every", 1));
-  const std::size_t repairEvery =
-    parseSizeTOption(argc, argv, "repair-every", 5);
+  const std::size_t repairEvery = parseSizeTOption(argc, argv, "repair-every", 5);
   const Real repairEta = parseRealOption(argc, argv, "repair-eta", Real(0.5) * h);
   const Real repairBand = parseRealOption(argc, argv, "repair-band", Real(4) * h);
-  const bool repairCalibrate =
-    parseSizeTOption(argc, argv, "repair-calibrate", 0) != 0;
+  const bool repairCalibrate = parseSizeTOption(argc, argv, "repair-calibrate", 0) != 0;
   const bool printTiming = parseSizeTOption(argc, argv, "timing", 0) != 0;
   const bool trace = parseSizeTOption(argc, argv, "trace", 0) != 0;
 
@@ -368,7 +357,7 @@ int main(int argc, char** argv)
   {
     const std::size_t nx = static_cast<std::size_t>(std::lround(L / h)) + 1;
     const std::size_t ny = n + 1;
-    mesh = WNGIRMesh::UniformGrid(Polytope::Type::Triangle, { nx, ny });
+    mesh = WNGIRMesh::UniformGrid(Polytope::Type::Triangle, {nx, ny});
     mesh.scale(h);
   }
   else
@@ -383,8 +372,7 @@ int main(int argc, char** argv)
 
   // Tag outer boundary: left edge clamped (GammaD), small right-edge segment
   // loaded (GammaN), the rest free (Gamma0).
-  auto tagBoundary = [&](WNGIRMesh& m)
-  {
+  auto tagBoundary = [&](WNGIRMesh& m) {
     const std::size_t D = m.getDimension();
     for (auto it = m.getBoundary(); it; ++it)
     {
@@ -397,8 +385,7 @@ int main(int argc, char** argv)
       Attribute attr = Gamma0;
       if (xm < Real(1e-9))
         attr = GammaD;                                   // left edge
-      else if (xm > L - Real(1e-9)
-               && ym > Real(0.45) * H && ym < Real(0.55) * H)
+      else if (xm > L - Real(1e-9) && ym > Real(0.45) * H && ym < Real(0.55) * H)
         attr = GammaN;                                   // right-middle load
       m.setAttribute({D - 1, f}, attr);
     }
@@ -408,14 +395,11 @@ int main(int argc, char** argv)
   if (initialMMG)
   {
     std::cout << "  initial MMG remesh:"
-              << " hmin=" << initialMMGHMin
-              << " hmax=" << initialMMGHMax
+              << " hmin=" << initialMMGHMin << " hmax=" << initialMMGHMax
               << " hausd=" << initialMMGHausd << "\n";
     MMG::Mesh mmgMesh(std::move(mesh));
     MMG::Optimizer optimizer;
-    optimizer.setHMin(initialMMGHMin)
-             .setHMax(initialMMGHMax)
-             .setAngleDetection(false);
+    optimizer.setHMin(initialMMGHMin).setHMax(initialMMGHMax).setAngleDetection(false);
     if (initialMMGHausd > 0)
       optimizer.setHausdorff(initialMMGHausd);
     optimizer.optimize(mmgMesh);
@@ -448,12 +432,14 @@ int main(int argc, char** argv)
   ScalarP0 p0(mesh);
   VectorP1 vh(mesh, 2);
 
-  GridFunction phiH(sh);          phiH.setName("phi");
+  GridFunction phiH(sh);
+  phiH.setName("phi");
   TrialFunction wngirTrial(vh);
-  TestFunction  wngirTest(vh);
+  TestFunction wngirTest(vh);
   auto& u = wngirTrial.getSolution();
   u.setName("displacement");      // WNGIR fit
-  GridFunction dJ(vh);            dJ.setName("dJ");            // shape velocity
+  GridFunction dJ(vh);
+  dJ.setName("dJ");            // shape velocity
 
   // Reusable background-space objects. The background mesh connectivity is
   // fixed; only coefficients, attributes, and vertex coordinates are updated.
@@ -461,17 +447,16 @@ int main(int argc, char** argv)
   GridFunction gradPhiSmoothed(gradFes);
   auto gradPhiDiscrete = Grad(phiH);
   TrialFunction gradTrial(gradFes);
-  TestFunction  gradTest(gradFes);
+  TestFunction gradTest(gradFes);
   Problem gradProjection(gradTrial, gradTest);
-  gradProjection = Integral(gradTrial, gradTest)
-                 - Integral(gradPhiDiscrete, gradTest);
+  gradProjection = Integral(gradTrial, gradTest) - Integral(gradPhiDiscrete, gradTest);
 
   GridFunction dist(sh);
   GridFunction speed(sh);
   GridFunction phiR(sh);
   GridFunction dp(p0);
   TrialFunction irTrial(sh);
-  TestFunction  irTest(sh);
+  TestFunction irTest(sh);
   BilinearForm irMass(irTrial, irTest);
   irMass = Integral(irTrial, irTest);
   irMass.assemble();
@@ -484,21 +469,20 @@ int main(int argc, char** argv)
   repairStiffness.assemble();
   Math::SparseMatrix<Real> repairOperator = irMass.getOperator();
   repairOperator += (repairEta * repairEta) * repairStiffness.getOperator();
-  Eigen::ConjugateGradient<Math::SparseMatrix<Real>,
-    Eigen::Lower | Eigen::Upper> repairCG;
+  Eigen::ConjugateGradient<Math::SparseMatrix<Real>, Eigen::Lower | Eigen::Upper>
+    repairCG;
   repairCG.setTolerance(Real(1e-10));
   repairCG.setMaxIterations(static_cast<int>(phiH.getData().size()));
   repairCG.compute(repairOperator);
 
   TrialFunction adv(sh);
-  TestFunction  advTest(sh);
+  TestFunction advTest(sh);
 
   Rodin::Examples::WNGIRExampleDefaults wngirDefaults;
   wngirDefaults.maxIterations = 60;
   wngirDefaults.activeRMSOverHTol = Real(0.2);
   WNGIRParameters wp =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, Gamma, wngirDefaults);
+    Rodin::Examples::makeWNGIRParameters(argc, argv, h, Gamma, wngirDefaults);
   wp.trace = trace;
   WNGIR wngir(wngirTrial, wngirTest);
   wngir.setParameters(wp);
@@ -507,12 +491,10 @@ int main(int argc, char** argv)
   if (meshFile.empty())
   {
     // Uniform grid: analytic array of holes (classic cantilever seed).
-    phiH = [&](const Geometry::Point& p) -> Real
-    {
+    phiH = [&](const Geometry::Point& p) -> Real {
       const auto& X = p.getCoordinates();
       const Real nxh = 8, nyh = 4;
-      const Real s = std::cos(nxh * M_PI * X(0) / L)
-                   * std::cos(nyh * M_PI * X(1) / H);
+      const Real s = std::cos(nxh * M_PI * X(0) / L) * std::cos(nyh * M_PI * X(1) / H);
       return -(s + Real(0.4));   // phi<0 (material) where s > -0.4
     };
   }
@@ -523,12 +505,14 @@ int main(int argc, char** argv)
     {
       const Index f = faceIt->getIndex();
       const auto& inc = mesh.getConnectivity().getIncidence({1, 2}, f);
-      if (inc.size() != 2) continue;
+      if (inc.size() != 2)
+        continue;
       const auto a = mesh.getAttribute(D, inc[0]);
       const auto b = mesh.getAttribute(D, inc[1]);
       const bool ia = a && *a == interiorAttribute;
       const bool ib = b && *b == interiorAttribute;
-      if (ia != ib) mesh.setAttribute({D - 1, f}, Gamma);
+      if (ia != ib)
+        mesh.setAttribute({D - 1, f}, Gamma);
     }
     phiH = Real(0);
     Distance::Eikonal<ScalarP1, Math::Vector<Real>>(phiH)
@@ -542,35 +526,28 @@ int main(int argc, char** argv)
   auto domainGrid = xdmf.grid("domain");
   domainGrid.setMesh(mesh, IO::XDMF::MeshPolicy::Transient);
   domainGrid.add(phiH, IO::XDMF::Center::Node);
-  domainGrid.add(dJ,   IO::XDMF::Center::Node);
+  domainGrid.add(dJ, IO::XDMF::Center::Node);
 
   WNGIRMesh moved(mesh);
   VectorP1 vhMoved(moved, 2);
   TrialFunction g(vhMoved);
-  TestFunction  w(vhMoved);
+  TestFunction w(vhMoved);
   auto stateGrid = xdmf.grid("state");
 
-  const std::string meshDescription =
-    meshFile.empty()
-      ? (initialMMG ? "uniform grid + initial MMG" : "uniform grid")
-      : (initialMMG ? meshFile + " + initial MMG" : meshFile);
+  const std::string meshDescription = meshFile.empty()
+    ? (initialMMG ? "uniform grid + initial MMG" : "uniform grid")
+    : (initialMMG ? meshFile + " + initial MMG" : meshFile);
   std::cout << "WNGIR cantilever on " << mesh.getCellCount() << " cells ("
             << meshDescription << ")"
             << "\n  domain [0," << L << "]x[0," << H << "]"
-            << "  ell=" << ell << "  alpha=" << alphaReg
-            << "  h=" << h << "  dt=" << dt
+            << "  ell=" << ell << "  alpha=" << alphaReg << "  h=" << h << "  dt=" << dt
             << "  objectiveLineSearch=" << objectiveLineSearch
-            << "\n  WNGIR: gammaM=" << wp.gammaM
-            << " gammaDev=" << wp.gammaH
-            << " gammaDiv=" << wp.gammaDiv
-            << " ellM=" << wp.ellM
-            << " rmsTol=" << wp.activeRMSTol
-            << " supTol=" << wp.activeSupTol
-            << " steps=" << wp.maxIterations
-            << "  reinit=" << reinitMode << "/" << reinitEvery
-            << "  redistance=" << redistanceMode << "/" << redistanceEvery
-            << "  repairEvery=" << repairEvery
-            << "  outputEvery=" << outputEvery << '\n';
+            << "\n  WNGIR: gammaM=" << wp.gammaM << " gammaDev=" << wp.gammaH
+            << " gammaDiv=" << wp.gammaDiv << " ellM=" << wp.ellM
+            << " rmsTol=" << wp.activeRMSTol << " supTol=" << wp.activeSupTol
+            << " steps=" << wp.maxIterations << "  reinit=" << reinitMode << "/"
+            << reinitEvery << "  redistance=" << redistanceMode << "/" << redistanceEvery
+            << "  repairEvery=" << repairEvery << "  outputEvery=" << outputEvery << '\n';
   std::ofstream fObj("LevelSetWNGIRCantilever2D.obj.txt");
 
   // Backtracking guard: body-fitted topology optimization can sever the load
@@ -581,9 +558,8 @@ int main(int argc, char** argv)
   Real dtCur = dt;
   Real complianceCap = std::numeric_limits<Real>::infinity();  // set after it 0
   Real lastAcceptedObjective = std::numeric_limits<Real>::infinity();
-  auto backgroundCellGradientMagnitude = [&](const auto& gf,
-                                             const Polytope& cell) -> Real
-  {
+  auto backgroundCellGradientMagnitude = [&](
+                                           const auto& gf, const Polytope& cell) -> Real {
     const auto& vv = cell.getVertices();
     const Vec2 x0 = mesh.getVertexCoordinates(vv[0]);
     const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
@@ -598,7 +574,7 @@ int main(int argc, char** argv)
       return Real(1);
     const Real g0 = p1v - p0v;
     const Real g1 = p2v - p0v;
-    const Real gx = ( J11 * g0 - J10 * g1) / det;
+    const Real gx = (J11 * g0 - J10 * g1) / det;
     const Real gy = (-J01 * g0 + J00 * g1) / det;
     return std::sqrt(gx * gx + gy * gy);
   };
@@ -647,13 +623,14 @@ int main(int argc, char** argv)
     {
       const Index facet = faceIt->getIndex();
       const auto& inc = mesh.getConnectivity().getIncidence({1, 2}, facet);
-      if (inc.size() != 2) continue;
+      if (inc.size() != 2)
+        continue;
       const auto a = cellToLocal.find(inc[0]);
       const auto b = cellToLocal.find(inc[1]);
-      if (a == cellToLocal.end() || b == cellToLocal.end()) continue;
-      graphEdges.push_back({ static_cast<Index>(a->second),
-                             static_cast<Index>(b->second),
-                             lambdaC * facetLength(mesh, facet), facet });
+      if (a == cellToLocal.end() || b == cellToLocal.end())
+        continue;
+      graphEdges.push_back({static_cast<Index>(a->second), static_cast<Index>(b->second),
+        lambdaC * facetLength(mesh, facet), facet});
     }
 
     const MinSTCut cut;
@@ -661,8 +638,7 @@ int main(int argc, char** argv)
 
     for (std::size_t l = 0; l < classified.labels.size(); ++l)
       mesh.setAttribute({D, localToCell[l]},
-                        classified.labels[l] == MinSTCut::Inside
-                          ? interiorAttribute : exteriorAttribute);
+        classified.labels[l] == MinSTCut::Inside ? interiorAttribute : exteriorAttribute);
 
     // ---- Connected-component cleanup -------------------------------------
     // Remove interior material not connected, through interior cells, to the
@@ -676,26 +652,36 @@ int main(int argc, char** argv)
       {
         if (mesh.getAttribute(D - 1, it->getIndex()) != Attribute{GammaD})
           continue;
-        for (const Index c :
-             mesh.getConnectivity().getIncidence({1, 2}, it->getIndex()))
+        for (const Index c : mesh.getConnectivity().getIncidence({1, 2}, it->getIndex()))
           isSupportCell[c] = 1;
       }
-      const auto comps = mesh.ccl(
-          [](const Polytope& a, const Polytope& b)
-          { return a.getAttribute() == b.getAttribute(); }).getComponents();
+      const auto comps = mesh
+                           .ccl([](const Polytope& a, const Polytope& b) {
+                             return a.getAttribute() == b.getAttribute();
+                           })
+                           .getComponents();
       std::size_t removed = 0;
       for (const auto& comp : comps)
       {
-        if (comp.empty()) continue;
+        if (comp.empty())
+          continue;
         const Index rep = *comp.begin();
         const auto ra = mesh.getAttribute(D, rep);
-        if (!ra || *ra != interiorAttribute) continue;   // exterior component
+        if (!ra || *ra != interiorAttribute)
+          continue;   // exterior component
         bool anchored = false;
         for (const Index c : comp)
-          if (isSupportCell[c]) { anchored = true; break; }
+          if (isSupportCell[c])
+          {
+            anchored = true;
+            break;
+          }
         if (!anchored)
           for (const Index c : comp)
-          { mesh.setAttribute({D, c}, exteriorAttribute); ++removed; }
+          {
+            mesh.setAttribute({D, c}, exteriorAttribute);
+            ++removed;
+          }
       }
       if (removed)
         std::cout << "  CCL: removed " << removed
@@ -708,7 +694,8 @@ int main(int argc, char** argv)
     {
       const Index f = faceIt->getIndex();
       const auto& inc = mesh.getConnectivity().getIncidence({1, 2}, f);
-      if (inc.size() != 2) continue;
+      if (inc.size() != 2)
+        continue;
       const auto a = mesh.getAttribute(D, inc[0]);
       const auto b = mesh.getAttribute(D, inc[1]);
       const bool ia = a && *a == interiorAttribute;
@@ -726,13 +713,15 @@ int main(int argc, char** argv)
     {
       const auto a = mesh.getAttribute(D, localToCell[l]);
       if (a && *a == interiorAttribute)
-      { ++nInside; areaInterior += cellMoments[l].area; }
+      {
+        ++nInside;
+        areaInterior += cellMoments[l].area;
+      }
     }
 
     std::cout << "  classify: interior cells=" << nInside
               << "  interface facets=" << interfaceFacets.size()
-              << "  area=" << std::fixed << std::setprecision(4)
-              << areaInterior << '\n';
+              << "  area=" << std::fixed << std::setprecision(4) << areaInterior << '\n';
     tClassify = iterTimer.reset();
 
     // ---- Stage 2: WNGIR fit mesh so skeleton lands on phi=0 --------------
@@ -741,10 +730,12 @@ int main(int argc, char** argv)
     gradPhiSmoothed.getData() = gradTrial.getSolution().getData();
     tGrad = iterTimer.reset();
     RealFunction phiFn(
-        [&](const Geometry::Point& p) -> Real { return phiH.getValue(p); });
+      [&](const Geometry::Point& p) -> Real { return phiH.getValue(p); });
     AnalyticVectorFunction gradPhiFn(
-        [&](const Geometry::Point& p) -> Math::SpatialVector<Real>
-        { return gradPhiSmoothed.getValue(p); }, /*dim=*/2);
+      [&](const Geometry::Point& p) -> Math::SpatialVector<Real> {
+        return gradPhiSmoothed.getValue(p);
+      },
+      /*dim=*/2);
 
     u.getData().setZero();
     {
@@ -758,17 +749,13 @@ int main(int argc, char** argv)
         const Real ux = u.getData()(d[0]), uy = u.getData()(d[1]);
         maxUoverH = std::max(maxUoverH, std::sqrt(ux * ux + uy * uy) / h);
       }
-      const Real activeRMSOverH =
-        h > Real(0) ? rep.activeRMS / h : Real(0);
-      const Real activeSupOverH =
-        h > Real(0) ? rep.activeSup / h : Real(0);
-      std::cout << "  WNGIR: it=" << rep.iterations
-                << "  exit=" << rep.exitReason
+      const Real activeRMSOverH = h > Real(0) ? rep.activeRMS / h : Real(0);
+      const Real activeSupOverH = h > Real(0) ? rep.activeSup / h : Real(0);
+      std::cout << "  WNGIR: it=" << rep.iterations << "  exit=" << rep.exitReason
                 << "  activeRMS=" << std::scientific << std::setprecision(2)
-                << rep.activeRMS
-                << "  activeRMS/h=" << activeRMSOverH
-                << "  activeSup/h=" << activeSupOverH
-                << "  max|u|/h=" << maxUoverH << '\n';
+                << rep.activeRMS << "  activeRMS/h=" << activeRMSOverH
+                << "  activeSup/h=" << activeSupOverH << "  max|u|/h=" << maxUoverH
+                << '\n';
     }
     tWNGIR = iterTimer.reset();
 
@@ -790,25 +777,25 @@ int main(int argc, char** argv)
     tMoveTrim = iterTimer.reset();
 
     VectorP1 vhInt(trimmed, 2);
-    auto fLoad = VectorFunction{ Real(0), Real(-1) };
+    auto fLoad = VectorFunction{Real(0), Real(-1)};
     TrialFunction us(vhInt);
-    TestFunction  vs(vhInt);
+    TestFunction vs(vhInt);
     // Tikhonov soft-foundation: a tiny mass term k_reg*(u,v) removes the
     // near-rigid-body null space that a one-cell-wide (nearly disconnected)
     // member produces, so the solve stays well-posed (bounded compliance)
     // instead of blowing up and freezing the optimizer. Body-fitted analogue
     // of the weak ersatz material. k_reg is tiny relative to the stiffness.
     Problem elasticity(us, vs);
-    elasticity = LinearElasticityIntegral(us, vs)(lambdaLame, muLame)
-               - BoundaryIntegral(fLoad, vs).over(GammaN)
-               + DirichletBC(us, VectorFunction{ Real(0), Real(0) }).on(GammaD);
+    elasticity = LinearElasticityIntegral(us, vs)(lambdaLame, muLame) -
+      BoundaryIntegral(fLoad, vs).over(GammaN) +
+      DirichletBC(us, VectorFunction{Real(0), Real(0)}).on(GammaD);
     Solver::CG(elasticity).solve();
 
     // Compliance = a(u,u).
     Real compliance = 0;
     {
       TrialFunction cu(vhInt);
-      TestFunction  cv(vhInt);
+      TestFunction cv(vhInt);
       BilinearForm bf(cu, cv);
       bf = LinearElasticityIntegral(cu, cv)(lambdaLame, muLame);
       bf.assemble();
@@ -822,19 +809,19 @@ int main(int argc, char** argv)
     // value. The monotonicity check is delayed by one outer iteration: the
     // trial design created by the previous advection is evaluated here, and
     // rejected by restoring the last accepted carrier and halving dt.
-    const bool blewUp = !std::isfinite(compliance) || compliance < Real(0)
-                        || compliance > complianceCap;
-    const bool objectiveIncreased =
-      objectiveLineSearch && std::isfinite(lastAcceptedObjective)
-      && objective > lastAcceptedObjective
-                   + objectiveDecreaseTol * std::max(Real(1), std::abs(lastAcceptedObjective));
+    const bool blewUp =
+      !std::isfinite(compliance) || compliance < Real(0) || compliance > complianceCap;
+    const bool objectiveIncreased = objectiveLineSearch &&
+      std::isfinite(lastAcceptedObjective) &&
+      objective > lastAcceptedObjective +
+          objectiveDecreaseTol * std::max(Real(1), std::abs(lastAcceptedObjective));
     if (blewUp)
     {
       dtCur *= Real(0.5);
       phiH.getData() = phiGood;
       std::cout << "  REJECT (blow-up, compliance=" << std::scientific
-                << std::setprecision(2) << compliance
-                << "): reverting, dt -> " << dtCur << '\n';
+                << std::setprecision(2) << compliance << "): reverting, dt -> " << dtCur
+                << '\n';
       if (dtCur < Real(1e-3) * h)
       {
         stopReason = "dt-floor-after-blow-up-rejections";
@@ -847,8 +834,7 @@ int main(int argc, char** argv)
       dtCur *= Real(0.5);
       phiH.getData() = phiGood;
       std::cout << "  REJECT (objective increase, J=" << std::scientific
-                << std::setprecision(4) << objective
-                << " > " << lastAcceptedObjective
+                << std::setprecision(4) << objective << " > " << lastAcceptedObjective
                 << "): reverting, dt -> " << dtCur << '\n';
       if (dtCur < Real(1e-3) * h)
       {
@@ -863,10 +849,11 @@ int main(int argc, char** argv)
     if (it == 0)
       complianceCap = Real(50) * compliance;   // blow-up threshold
 
-    fObj << objective << "\n"; fObj.flush();
-    std::cout << "  compliance=" << std::scientific << std::setprecision(4)
-              << compliance << "  area=" << areaInterior
-              << "  J=" << objective << "  dt=" << dtCur << '\n';
+    fObj << objective << "\n";
+    fObj.flush();
+    std::cout << "  compliance=" << std::scientific << std::setprecision(4) << compliance
+              << "  area=" << areaInterior << "  J=" << objective << "  dt=" << dtCur
+              << '\n';
 
     // ---- Stage 4: shape gradient + Hilbert regularization ----------------
     // The state lives on `trimmed` (a SubMesh of `moved`), so the gradient and
@@ -881,11 +868,10 @@ int main(int argc, char** argv)
     auto nrm = FaceNormal(moved);
     nrm.traceOf(interiorAttribute);
     Problem hilbert(g, w);
-    hilbert = Integral(alphaReg * alphaReg * Jacobian(g), Jacobian(w))
-            + Integral(g, w)
-            - FaceIntegral(Dot(Ae, e) - ell, Dot(nrm, w)).over(Gamma)
-            + DirichletBC(g, VectorFunction{ Real(0), Real(0) }).on(GammaD)
-            + DirichletBC(g, VectorFunction{ Real(0), Real(0) }).on(GammaN);
+    hilbert = Integral(alphaReg * alphaReg * Jacobian(g), Jacobian(w)) + Integral(g, w) -
+      FaceIntegral(Dot(Ae, e) - ell, Dot(nrm, w)).over(Gamma) +
+      DirichletBC(g, VectorFunction{Real(0), Real(0)}).on(GammaD) +
+      DirichletBC(g, VectorFunction{Real(0), Real(0)}).on(GammaN);
     Solver::CG(hilbert).solve();
     // Velocity is computed on `moved`; carry it to the fixed background grid
     // (same connectivity) to advect phi there. The moved->background transfer
@@ -919,13 +905,10 @@ int main(int argc, char** argv)
     // interface facets (moved-mesh segments at X+u), so phi carries the
     // sub-cell interface position forward instead of re-quantizing every step.
     std::string activeReinitMode = reinitMode;
-    bool doReinit =
-      reinitMode != "none"
-      && reinitEvery > 0
-      && (it % reinitEvery == 0 || it + 1 == maxIt);
-    if (!doReinit && reinitMode == "none" && redistanceMode != "none"
-        && redistanceEvery > 0
-        && ((it + 1) % redistanceEvery == 0 || it + 1 == maxIt))
+    bool doReinit = reinitMode != "none" && reinitEvery > 0 &&
+      (it % reinitEvery == 0 || it + 1 == maxIt);
+    if (!doReinit && reinitMode == "none" && redistanceMode != "none" &&
+      redistanceEvery > 0 && ((it + 1) % redistanceEvery == 0 || it + 1 == maxIt))
     {
       activeReinitMode = redistanceMode;
       doReinit = true;
@@ -952,127 +935,135 @@ int main(int argc, char** argv)
       // from the fitted interface itself, NOT from the stale FMM/staircase sign.
       // Using the FMM sign caused a spurious zero crossing (phantom sliver ->
       // singular elasticity) wherever the fit moved the interface across a node.
-      std::vector<std::array<Vec2, 2>> fittedSeg;
-      std::vector<Vec2> fittedN;
-      fittedSeg.reserve(interfaceFacets.size());
-      fittedN.reserve(interfaceFacets.size());
-      for (const Index f : interfaceFacets)
-      {
-        const auto& vv = moved.getFace(f)->getVertices();
-        const Vec2 a = moved.getVertexCoordinates(vv[0]);
-        const Vec2 b = moved.getVertexCoordinates(vv[1]);
-        Vec2 nrm = vec2(b(1) - a(1), -(b(0) - a(0)));        // perp to segment
-        const Real nn = nrm.norm();
-        if (nn > Real(1e-30)) nrm = nrm / nn; else nrm = vec2(1, 0);
+        std::vector<std::array<Vec2, 2>> fittedSeg;
+        std::vector<Vec2> fittedN;
+        fittedSeg.reserve(interfaceFacets.size());
+        fittedN.reserve(interfaceFacets.size());
+        for (const Index f : interfaceFacets)
+        {
+          const auto& vv = moved.getFace(f)->getVertices();
+          const Vec2 a = moved.getVertexCoordinates(vv[0]);
+          const Vec2 b = moved.getVertexCoordinates(vv[1]);
+          Vec2 nrm = vec2(b(1) - a(1), -(b(0) - a(0)));        // perp to segment
+          const Real nn = nrm.norm();
+          if (nn > Real(1e-30))
+            nrm = nrm / nn;
+          else
+            nrm = vec2(1, 0);
         // orient away from the interior incident cell's (moved) centroid
-        const auto& inc = mesh.getConnectivity().getIncidence({1, 2}, f);
-        Vec2 cInt = vec2(0, 0); bool haveInt = false;
-        for (const Index c : inc)
-        {
-          const auto at = mesh.getAttribute(D, c);
-          if (at && *at == interiorAttribute)
+          const auto& inc = mesh.getConnectivity().getIncidence({1, 2}, f);
+          Vec2 cInt = vec2(0, 0);
+          bool haveInt = false;
+          for (const Index c : inc)
           {
-            const auto& cvv = mesh.getCell(c)->getVertices();
-            Vec2 ctr = vec2(0, 0);
-            for (const Index cv : cvv) ctr += moved.getVertexCoordinates(cv);
-            cInt = ctr / static_cast<Real>(cvv.size()); haveInt = true; break;
+            const auto at = mesh.getAttribute(D, c);
+            if (at && *at == interiorAttribute)
+            {
+              const auto& cvv = mesh.getCell(c)->getVertices();
+              Vec2 ctr = vec2(0, 0);
+              for (const Index cv : cvv)
+                ctr += moved.getVertexCoordinates(cv);
+              cInt = ctr / static_cast<Real>(cvv.size());
+              haveInt = true;
+              break;
+            }
           }
+          const Vec2 mid = Real(0.5) * (a + b);
+          if (haveInt && (mid - cInt).dot(nrm) < Real(0))
+            nrm = -nrm;
+          fittedSeg.push_back({a, b});
+          fittedN.push_back(nrm);
         }
-        const Vec2 mid = Real(0.5) * (a + b);
-        if (haveInt && (mid - cInt).dot(nrm) < Real(0)) nrm = -nrm;
-        fittedSeg.push_back({ a, b });
-        fittedN.push_back(nrm);
-      }
-      auto overwriteClosestPointBand = [&]()
-      {
-        const Real band = Real(6) * h;
-        for (Index v = 0; v < mesh.getVertexCount(); ++v)
-        {
-          const Index d = sh.getGlobalIndex({0, v}, 0);
-          if (std::abs(fmmDist(d)) > band) continue;
-          const Vec2 X = mesh.getVertexCoordinates(v);
-          Real dmin = std::numeric_limits<Real>::infinity();
-          std::size_t kmin = 0;
-          for (std::size_t k = 0; k < fittedSeg.size(); ++k)
+        auto overwriteClosestPointBand = [&]() {
+          const Real band = Real(6) * h;
+          for (Index v = 0; v < mesh.getVertexCount(); ++v)
           {
-            const Real dk =
-              pointSegmentDistance(X, fittedSeg[k][0], fittedSeg[k][1]);
-            if (dk < dmin) { dmin = dk; kmin = k; }
-          }
-          if (std::isfinite(dmin))
-          {
-            const Vec2 mid =
-              Real(0.5) * (fittedSeg[kmin][0] + fittedSeg[kmin][1]);
-            const Real s = (X - mid).dot(fittedN[kmin]) >= Real(0)
-                             ? Real(1) : Real(-1);   // outward = exterior = +
-            dist.getData()(d) = s * dmin;
-          }
-        }
-      };
-
-      auto cellGradientMagnitude = [&](const auto& gf,
-                                       const Polytope& cell) -> Real
-      {
-        const auto& vv = cell.getVertices();
-        const Vec2 x0 = mesh.getVertexCoordinates(vv[0]);
-        const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
-        const Vec2 x2 = mesh.getVertexCoordinates(vv[2]);
-        const Real p0v = gf.getData()(sh.getGlobalIndex({0, vv[0]}, 0));
-        const Real p1v = gf.getData()(sh.getGlobalIndex({0, vv[1]}, 0));
-        const Real p2v = gf.getData()(sh.getGlobalIndex({0, vv[2]}, 0));
-        const Real J00 = x1(0) - x0(0), J01 = x2(0) - x0(0);
-        const Real J10 = x1(1) - x0(1), J11 = x2(1) - x0(1);
-        const Real det = J00 * J11 - J01 * J10;
-        if (std::abs(det) < Real(1e-30))
-          return Real(1);
-        const Real g0 = p1v - p0v;
-        const Real g1 = p2v - p0v;
-        const Real gx = ( J11 * g0 - J10 * g1) / det;
-        const Real gy = (-J01 * g0 + J00 * g1) / det;
-        return std::sqrt(gx * gx + gy * gy);
-      };
-
-      auto gradientStats = [&](const auto& gf, bool cutCellsOnly)
-      {
-        Real gmin = std::numeric_limits<Real>::infinity();
-        Real gmax = Real(0);
-        const Real band = Real(4) * h;
-        std::size_t cnt = 0;
-        for (auto cit = mesh.getCell(); cit; ++cit)
-        {
-          const auto& vv = cit->getVertices();
-          Real av = Real(0);
-          Real vmin = std::numeric_limits<Real>::infinity();
-          Real vmax = -std::numeric_limits<Real>::infinity();
-          for (const Index v : vv)
-          {
-            const Real pv = gf.getData()(sh.getGlobalIndex({0, v}, 0));
-            av += std::abs(pv);
-            vmin = std::min(vmin, pv);
-            vmax = std::max(vmax, pv);
-          }
-          av /= static_cast<Real>(vv.size());
-          if (cutCellsOnly)
-          {
-            if (!(vmin <= Real(0) && vmax >= Real(0)))
+            const Index d = sh.getGlobalIndex({0, v}, 0);
+            if (std::abs(fmmDist(d)) > band)
               continue;
+            const Vec2 X = mesh.getVertexCoordinates(v);
+            Real dmin = std::numeric_limits<Real>::infinity();
+            std::size_t kmin = 0;
+            for (std::size_t k = 0; k < fittedSeg.size(); ++k)
+            {
+              const Real dk = pointSegmentDistance(X, fittedSeg[k][0], fittedSeg[k][1]);
+              if (dk < dmin)
+              {
+                dmin = dk;
+                kmin = k;
+              }
+            }
+            if (std::isfinite(dmin))
+            {
+              const Vec2 mid = Real(0.5) * (fittedSeg[kmin][0] + fittedSeg[kmin][1]);
+              const Real s = (X - mid).dot(fittedN[kmin]) >= Real(0)
+                ? Real(1)
+                : Real(-1);   // outward = exterior = +
+              dist.getData()(d) = s * dmin;
+            }
           }
-          else if (av > band)
-          {
-            continue;
-          }
-          const Real gm = cellGradientMagnitude(gf, *cit);
-          gmin = std::min(gmin, gm);
-          gmax = std::max(gmax, gm);
-          ++cnt;
-        }
-        if (cnt == 0)
-          return std::array<Real, 2>{ Real(0), Real(0) };
-        return std::array<Real, 2>{ gmin, gmax };
-      };
+        };
 
-      if (activeReinitMode == "ir" || activeReinitMode == "ir-phi")
-      {
+        auto cellGradientMagnitude = [&](const auto& gf, const Polytope& cell) -> Real {
+          const auto& vv = cell.getVertices();
+          const Vec2 x0 = mesh.getVertexCoordinates(vv[0]);
+          const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
+          const Vec2 x2 = mesh.getVertexCoordinates(vv[2]);
+          const Real p0v = gf.getData()(sh.getGlobalIndex({0, vv[0]}, 0));
+          const Real p1v = gf.getData()(sh.getGlobalIndex({0, vv[1]}, 0));
+          const Real p2v = gf.getData()(sh.getGlobalIndex({0, vv[2]}, 0));
+          const Real J00 = x1(0) - x0(0), J01 = x2(0) - x0(0);
+          const Real J10 = x1(1) - x0(1), J11 = x2(1) - x0(1);
+          const Real det = J00 * J11 - J01 * J10;
+          if (std::abs(det) < Real(1e-30))
+            return Real(1);
+          const Real g0 = p1v - p0v;
+          const Real g1 = p2v - p0v;
+          const Real gx = (J11 * g0 - J10 * g1) / det;
+          const Real gy = (-J01 * g0 + J00 * g1) / det;
+          return std::sqrt(gx * gx + gy * gy);
+        };
+
+        auto gradientStats = [&](const auto& gf, bool cutCellsOnly) {
+          Real gmin = std::numeric_limits<Real>::infinity();
+          Real gmax = Real(0);
+          const Real band = Real(4) * h;
+          std::size_t cnt = 0;
+          for (auto cit = mesh.getCell(); cit; ++cit)
+          {
+            const auto& vv = cit->getVertices();
+            Real av = Real(0);
+            Real vmin = std::numeric_limits<Real>::infinity();
+            Real vmax = -std::numeric_limits<Real>::infinity();
+            for (const Index v : vv)
+            {
+              const Real pv = gf.getData()(sh.getGlobalIndex({0, v}, 0));
+              av += std::abs(pv);
+              vmin = std::min(vmin, pv);
+              vmax = std::max(vmax, pv);
+            }
+            av /= static_cast<Real>(vv.size());
+            if (cutCellsOnly)
+            {
+              if (!(vmin <= Real(0) && vmax >= Real(0)))
+                continue;
+            }
+            else if (av > band)
+            {
+              continue;
+            }
+            const Real gm = cellGradientMagnitude(gf, *cit);
+            gmin = std::min(gmin, gm);
+            gmax = std::max(gmax, gm);
+            ++cnt;
+          }
+          if (cnt == 0)
+            return std::array<Real, 2>{Real(0), Real(0)};
+          return std::array<Real, 2>{gmin, gmax};
+        };
+
+        if (activeReinitMode == "ir" || activeReinitMode == "ir-phi")
+        {
         // Li-Xu DRLSE with the full signed bounded double-well diffusivity
         //
         //   d_p(s) = 1 - 1/s,                 s >= 1,
@@ -1083,212 +1074,205 @@ int main(int argc, char** argv)
         // reinit=ir-phi, the pin is the coarea approximation
         // int delta_eps(phi_h) |grad phi_h| phi^2 dx, hence the geometric
         // reference is the level set itself and not the classified mesh.
-        const Real dtauR = irDtauFactor * h * h;
-        const int  Kr    = static_cast<int>(irSteps);
-        if (activeReinitMode == "ir")
-        {
+          const Real dtauR = irDtauFactor * h * h;
+          const int Kr = static_cast<int>(irSteps);
+          if (activeReinitMode == "ir")
+          {
           // Mesh-pinned variant: start from the clean FMM SDF and use the
           // fitted mesh only as a zero-trace constraint.
-          dist.getData() = fmmDist;
-          phiR.getData() = dist.getData();
-        }
-        else
-        {
-          // Phi-pinned variant: start from the carried level set, rescaled by
-          // the average cut-cell gradient so the unknown has distance units.
-          Real gsum = Real(0);
-          std::size_t gcnt = 0;
-          for (auto cit = mesh.getCell(); cit; ++cit)
-          {
-            const auto& vv = cit->getVertices();
-            Real vmin = std::numeric_limits<Real>::infinity();
-            Real vmax = -std::numeric_limits<Real>::infinity();
-            for (const Index v : vv)
-            {
-              const Real pv = phiH.getData()(sh.getGlobalIndex({0, v}, 0));
-              vmin = std::min(vmin, pv);
-              vmax = std::max(vmax, pv);
-            }
-            if (vmin <= Real(0) && vmax >= Real(0))
-            {
-              gsum += cellGradientMagnitude(phiH, *cit);
-              ++gcnt;
-            }
+            dist.getData() = fmmDist;
+            phiR.getData() = dist.getData();
           }
-          const Real gscale =
-            gcnt > 0 ? std::max(gsum / static_cast<Real>(gcnt), Real(1e-12))
-                     : Real(1);
-          phiR.getData() = phiH.getData() / gscale;
-        }
-        std::vector<Eigen::Triplet<Real>> pinTriplets;
-
-        auto addPinPoint = [&](const Vec2& y, Real w)
-        {
-          Math::SpatialPoint pc(2);
-          pc(0) = y(0);
-          pc(1) = y(1);
-          constexpr Real tol = Real(1e-10);
-          for (auto cit = mesh.getCell(); cit; ++cit)
+          else
           {
-            Math::SpatialPoint rc(2);
-            cit->getTransformation().inverse(rc, pc);
-            const Real l0 = Real(1) - rc(0) - rc(1);
-            const Real l1 = rc(0);
-            const Real l2 = rc(1);
-            if (l0 < -tol || l1 < -tol || l2 < -tol)
-              continue;
-            const auto& vv = cit->getVertices();
-            const std::array<Real, 3> N = {{ l0, l1, l2 }};
-            for (std::size_t a = 0; a < 3; ++a)
-            {
-              const Index ia = sh.getGlobalIndex({0, vv[a]}, 0);
-              for (std::size_t b = 0; b < 3; ++b)
-              {
-                const Index ib = sh.getGlobalIndex({0, vv[b]}, 0);
-                pinTriplets.emplace_back(
-                    static_cast<int>(ia),
-                    static_cast<int>(ib),
-                    w * N[a] * N[b]);
-              }
-            }
-            return;
-          }
-        };
-
-        if (activeReinitMode == "ir")
-        {
-          pinTriplets.reserve(18 * fittedSeg.size());
-          // Two-point Gauss quadrature on every moved interface segment.
-          constexpr Real q0 = Real(0.21132486540518711775);
-          constexpr Real q1 = Real(0.78867513459481288225);
-          for (const auto& seg : fittedSeg)
-          {
-            const Vec2 a = seg[0];
-            const Vec2 b = seg[1];
-            const Real ds = (b - a).norm();
-            addPinPoint((Real(1) - q0) * a + q0 * b, Real(0.5) * ds);
-            addPinPoint((Real(1) - q1) * a + q1 * b, Real(0.5) * ds);
-          }
-        }
-        else
-        {
-          pinTriplets.reserve(27 * mesh.getCellCount());
-          Real gsum = Real(0);
-          std::size_t gcnt = 0;
-          for (auto cit = mesh.getCell(); cit; ++cit)
-          {
-            const auto& vv = cit->getVertices();
-            Real vmin = std::numeric_limits<Real>::infinity();
-            Real vmax = -std::numeric_limits<Real>::infinity();
-            for (const Index v : vv)
-            {
-              const Real pv = phiH.getData()(sh.getGlobalIndex({0, v}, 0));
-              vmin = std::min(vmin, pv);
-              vmax = std::max(vmax, pv);
-            }
-            if (vmin <= Real(0) && vmax >= Real(0))
-            {
-              gsum += cellGradientMagnitude(phiH, *cit);
-              ++gcnt;
-            }
-          }
-          const Real gavg =
-            gcnt > 0 ? std::max(gsum / static_cast<Real>(gcnt), Real(1e-12))
-                     : Real(1);
-          const Real epsPhi = std::max(irDeltaEps * gavg, Real(1e-12));
-          for (auto cit = mesh.getCell(); cit; ++cit)
-          {
-            const auto& vv = cit->getVertices();
-            const Vec2 x0 = mesh.getVertexCoordinates(vv[0]);
-            const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
-            const Vec2 x2 = mesh.getVertexCoordinates(vv[2]);
-            const Real area = std::abs(Real(0.5) *
-              ((x1(0) - x0(0)) * (x2(1) - x0(1))
-             - (x1(1) - x0(1)) * (x2(0) - x0(0))));
-            const Real gmag = cellGradientMagnitude(phiH, *cit);
-            std::array<Index, 3> gd;
-            std::array<Real, 3> pv;
-            for (std::size_t a = 0; a < 3; ++a)
-            {
-              gd[a] = sh.getGlobalIndex({0, vv[a]}, 0);
-              pv[a] = phiH.getData()(gd[a]);
-            }
-            for (const auto& bary : TriangleBarycentricQuadrature)
-            {
-              const std::array<Real, 3> N = {{ bary[0], bary[1], bary[2] }};
-              const Real phiq = N[0] * pv[0] + N[1] * pv[1] + N[2] * pv[2];
-              if (std::abs(phiq) >= epsPhi)
-                continue;
-              const Real delta =
-                (Real(1) / (Real(2) * epsPhi))
-                * (Real(1) + std::cos(M_PI * phiq / epsPhi));
-              const Real w = (area / Real(3)) * delta * gmag;
-              for (std::size_t a = 0; a < 3; ++a)
-                for (std::size_t b = 0; b < 3; ++b)
-                  pinTriplets.emplace_back(
-                      static_cast<int>(gd[a]),
-                      static_cast<int>(gd[b]),
-                      w * N[a] * N[b]);
-            }
-          }
-        }
-
-        Math::SparseMatrix<Real> A(phiR.getData().size(), phiR.getData().size());
-        std::vector<Eigen::Triplet<Real>> aTriplets;
-        aTriplets.reserve(
-            static_cast<std::size_t>(phiR.getData().size()) + pinTriplets.size());
-        for (Eigen::Index i = 0; i < phiR.getData().size(); ++i)
-          aTriplets.emplace_back(
-              static_cast<int>(i), static_cast<int>(i), irMassLump(i) / dtauR);
-        for (const auto& t : pinTriplets)
-          aTriplets.emplace_back(t.row(), t.col(), Real(2) * irLambda * t.value());
-        A.setFromTriplets(aTriplets.begin(), aTriplets.end());
-        Eigen::ConjugateGradient<Math::SparseMatrix<Real>,
-          Eigen::Lower | Eigen::Upper> irCG;
-        irCG.setTolerance(Real(1e-10));
-        irCG.setMaxIterations(static_cast<int>(phiR.getData().size()));
-        irCG.compute(A);
-        const auto gInCut = gradientStats(phiR, true);
-        const auto gInBand = gradientStats(phiR, false);
-        Math::Vector<Real> rK(phiR.getData().size());
-        for (int kk = 0; kk < Kr; ++kk)
-        {
-          if (kk == 0 || static_cast<std::size_t>(kk) % irDpUpdateEvery == 0)
-          {
+            // Phi-pinned variant: start from the carried level set, rescaled by
+            // the average cut-cell gradient so the unknown has distance units.
+            Real gsum = Real(0);
+            std::size_t gcnt = 0;
             for (auto cit = mesh.getCell(); cit; ++cit)
             {
-              const Index dc = p0.getGlobalIndex({D, cit->getIndex()}, 0);
-              const Real s = cellGradientMagnitude(phiR, *cit);
-              Real dpv;
-              if (s >= Real(1)) dpv = Real(1) - Real(1)/s;
-              else { const Real x = Real(2)*M_PI*s;
-                     dpv = s > Real(1e-6) ? std::sin(x)/x : Real(1); }
-              dp.getData()(dc) = dpv;
+              const auto& vv = cit->getVertices();
+              Real vmin = std::numeric_limits<Real>::infinity();
+              Real vmax = -std::numeric_limits<Real>::infinity();
+              for (const Index v : vv)
+              {
+                const Real pv = phiH.getData()(sh.getGlobalIndex({0, v}, 0));
+                vmin = std::min(vmin, pv);
+                vmax = std::max(vmax, pv);
+              }
+              if (vmin <= Real(0) && vmax >= Real(0))
+              {
+                gsum += cellGradientMagnitude(phiH, *cit);
+                ++gcnt;
+              }
             }
-            irDiffusion.assemble();
+            const Real gscale =
+              gcnt > 0 ? std::max(gsum / static_cast<Real>(gcnt), Real(1e-12)) : Real(1);
+            phiR.getData() = phiH.getData() / gscale;
           }
-          rK = irDiffusion.getOperator() * phiR.getData();
-          Math::Vector<Real> rhs(phiR.getData().size());
+          std::vector<Eigen::Triplet<Real>> pinTriplets;
+
+          auto addPinPoint = [&](const Vec2& y, Real w) {
+            Math::SpatialPoint pc(2);
+            pc(0) = y(0);
+            pc(1) = y(1);
+            constexpr Real tol = Real(1e-10);
+            for (auto cit = mesh.getCell(); cit; ++cit)
+            {
+              Math::SpatialPoint rc(2);
+              cit->getTransformation().inverse(rc, pc);
+              const Real l0 = Real(1) - rc(0) - rc(1);
+              const Real l1 = rc(0);
+              const Real l2 = rc(1);
+              if (l0 < -tol || l1 < -tol || l2 < -tol)
+                continue;
+              const auto& vv = cit->getVertices();
+              const std::array<Real, 3> N = {{l0, l1, l2}};
+              for (std::size_t a = 0; a < 3; ++a)
+              {
+                const Index ia = sh.getGlobalIndex({0, vv[a]}, 0);
+                for (std::size_t b = 0; b < 3; ++b)
+                {
+                  const Index ib = sh.getGlobalIndex({0, vv[b]}, 0);
+                  pinTriplets.emplace_back(
+                    static_cast<int>(ia), static_cast<int>(ib), w * N[a] * N[b]);
+                }
+              }
+              return;
+            }
+          };
+
+          if (activeReinitMode == "ir")
+          {
+            pinTriplets.reserve(18 * fittedSeg.size());
+            // Two-point Gauss quadrature on every moved interface segment.
+            constexpr Real q0 = Real(0.21132486540518711775);
+            constexpr Real q1 = Real(0.78867513459481288225);
+            for (const auto& seg : fittedSeg)
+            {
+              const Vec2 a = seg[0];
+              const Vec2 b = seg[1];
+              const Real ds = (b - a).norm();
+              addPinPoint((Real(1) - q0) * a + q0 * b, Real(0.5) * ds);
+              addPinPoint((Real(1) - q1) * a + q1 * b, Real(0.5) * ds);
+            }
+          }
+          else
+          {
+            pinTriplets.reserve(27 * mesh.getCellCount());
+            Real gsum = Real(0);
+            std::size_t gcnt = 0;
+            for (auto cit = mesh.getCell(); cit; ++cit)
+            {
+              const auto& vv = cit->getVertices();
+              Real vmin = std::numeric_limits<Real>::infinity();
+              Real vmax = -std::numeric_limits<Real>::infinity();
+              for (const Index v : vv)
+              {
+                const Real pv = phiH.getData()(sh.getGlobalIndex({0, v}, 0));
+                vmin = std::min(vmin, pv);
+                vmax = std::max(vmax, pv);
+              }
+              if (vmin <= Real(0) && vmax >= Real(0))
+              {
+                gsum += cellGradientMagnitude(phiH, *cit);
+                ++gcnt;
+              }
+            }
+            const Real gavg =
+              gcnt > 0 ? std::max(gsum / static_cast<Real>(gcnt), Real(1e-12)) : Real(1);
+            const Real epsPhi = std::max(irDeltaEps * gavg, Real(1e-12));
+            for (auto cit = mesh.getCell(); cit; ++cit)
+            {
+              const auto& vv = cit->getVertices();
+              const Vec2 x0 = mesh.getVertexCoordinates(vv[0]);
+              const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
+              const Vec2 x2 = mesh.getVertexCoordinates(vv[2]);
+              const Real area = std::abs(Real(0.5) *
+                ((x1(0) - x0(0)) * (x2(1) - x0(1)) - (x1(1) - x0(1)) * (x2(0) - x0(0))));
+              const Real gmag = cellGradientMagnitude(phiH, *cit);
+              std::array<Index, 3> gd;
+              std::array<Real, 3> pv;
+              for (std::size_t a = 0; a < 3; ++a)
+              {
+                gd[a] = sh.getGlobalIndex({0, vv[a]}, 0);
+                pv[a] = phiH.getData()(gd[a]);
+              }
+              for (const auto& bary : TriangleBarycentricQuadrature)
+              {
+                const std::array<Real, 3> N = {{bary[0], bary[1], bary[2]}};
+                const Real phiq = N[0] * pv[0] + N[1] * pv[1] + N[2] * pv[2];
+                if (std::abs(phiq) >= epsPhi)
+                  continue;
+                const Real delta = (Real(1) / (Real(2) * epsPhi)) *
+                  (Real(1) + std::cos(M_PI * phiq / epsPhi));
+                const Real w = (area / Real(3)) * delta * gmag;
+                for (std::size_t a = 0; a < 3; ++a)
+                  for (std::size_t b = 0; b < 3; ++b)
+                    pinTriplets.emplace_back(
+                      static_cast<int>(gd[a]), static_cast<int>(gd[b]), w * N[a] * N[b]);
+              }
+            }
+          }
+
+          Math::SparseMatrix<Real> A(phiR.getData().size(), phiR.getData().size());
+          std::vector<Eigen::Triplet<Real>> aTriplets;
+          aTriplets.reserve(
+            static_cast<std::size_t>(phiR.getData().size()) + pinTriplets.size());
           for (Eigen::Index i = 0; i < phiR.getData().size(); ++i)
-            rhs(i) = (irMassLump(i) / dtauR) * phiR.getData()(i) - rK(i);
-          phiR.getData() = irCG.solve(rhs);
+            aTriplets.emplace_back(
+              static_cast<int>(i), static_cast<int>(i), irMassLump(i) / dtauR);
+          for (const auto& t : pinTriplets)
+            aTriplets.emplace_back(t.row(), t.col(), Real(2) * irLambda * t.value());
+          A.setFromTriplets(aTriplets.begin(), aTriplets.end());
+          Eigen::ConjugateGradient<Math::SparseMatrix<Real>, Eigen::Lower | Eigen::Upper>
+            irCG;
+          irCG.setTolerance(Real(1e-10));
+          irCG.setMaxIterations(static_cast<int>(phiR.getData().size()));
+          irCG.compute(A);
+          const auto gInCut = gradientStats(phiR, true);
+          const auto gInBand = gradientStats(phiR, false);
+          Math::Vector<Real> rK(phiR.getData().size());
+          for (int kk = 0; kk < Kr; ++kk)
+          {
+            if (kk == 0 || static_cast<std::size_t>(kk) % irDpUpdateEvery == 0)
+            {
+              for (auto cit = mesh.getCell(); cit; ++cit)
+              {
+                const Index dc = p0.getGlobalIndex({D, cit->getIndex()}, 0);
+                const Real s = cellGradientMagnitude(phiR, *cit);
+                Real dpv;
+                if (s >= Real(1))
+                  dpv = Real(1) - Real(1) / s;
+                else
+                {
+                  const Real x = Real(2) * M_PI * s;
+                  dpv = s > Real(1e-6) ? std::sin(x) / x : Real(1);
+                }
+                dp.getData()(dc) = dpv;
+              }
+              irDiffusion.assemble();
+            }
+            rK = irDiffusion.getOperator() * phiR.getData();
+            Math::Vector<Real> rhs(phiR.getData().size());
+            for (Eigen::Index i = 0; i < phiR.getData().size(); ++i)
+              rhs(i) = (irMassLump(i) / dtauR) * phiR.getData()(i) - rK(i);
+            phiR.getData() = irCG.solve(rhs);
+          }
+          const auto gOutCut = gradientStats(phiR, true);
+          const auto gOutBand = gradientStats(phiR, false);
+          std::cout << "    IR-DRLSE" << (activeReinitMode == "ir-phi" ? "-phi" : "")
+                    << ": |grad phi| cut [" << std::fixed << std::setprecision(3)
+                    << gInCut[0] << "," << gInCut[1] << "] -> [" << gOutCut[0] << ","
+                    << gOutCut[1] << "]"
+                    << "  band [" << gInBand[0] << "," << gInBand[1] << "] -> ["
+                    << gOutBand[0] << "," << gOutBand[1] << "]\n";
+          dist.getData() = phiR.getData();
         }
-        const auto gOutCut = gradientStats(phiR, true);
-        const auto gOutBand = gradientStats(phiR, false);
-        std::cout << "    IR-DRLSE"
-                  << (activeReinitMode == "ir-phi" ? "-phi" : "")
-                  << ": |grad phi| cut ["
-                  << std::fixed << std::setprecision(3)
-                  << gInCut[0] << "," << gInCut[1] << "] -> ["
-                  << gOutCut[0] << "," << gOutCut[1] << "]"
-                  << "  band [" << gInBand[0] << "," << gInBand[1]
-                  << "] -> [" << gOutBand[0] << "," << gOutBand[1] << "]\n";
-        dist.getData() = phiR.getData();
-      }
-      else
-      {
-        overwriteClosestPointBand();
-      }
+        else
+        {
+          overwriteClosestPointBand();
+        }
       }
     }
     tRedistance = iterTimer.reset();
@@ -1324,8 +1308,7 @@ int main(int argc, char** argv)
           const Vec2 x1 = mesh.getVertexCoordinates(vv[1]);
           const Vec2 x2 = mesh.getVertexCoordinates(vv[2]);
           const Real area = std::abs(Real(0.5) *
-            ((x1(0) - x0(0)) * (x2(1) - x0(1))
-           - (x1(1) - x0(1)) * (x2(0) - x0(0))));
+            ((x1(0) - x0(0)) * (x2(1) - x0(1)) - (x1(1) - x0(1)) * (x2(0) - x0(0))));
           gsum += area * backgroundCellGradientMagnitude(phiH, *cit);
           wsum += area;
         }
@@ -1333,8 +1316,8 @@ int main(int argc, char** argv)
         {
           const Real c = std::max(gsum / wsum, Real(1e-12));
           phiH.getData() /= c;
-          std::cout << "    repair: scale=" << std::scientific
-                    << std::setprecision(3) << c << '\n';
+          std::cout << "    repair: scale=" << std::scientific << std::setprecision(3)
+                    << c << '\n';
         }
       }
     }
@@ -1342,30 +1325,22 @@ int main(int argc, char** argv)
 
     if (printTiming)
     {
-      const Real total = tClassify + tGrad + tWNGIR + tMoveTrim
-                       + tElasticity + tHilbert + tRedistance + tAdvect
-                       + tRepair + tWrite;
+      const Real total = tClassify + tGrad + tWNGIR + tMoveTrim + tElasticity + tHilbert +
+        tRedistance + tAdvect + tRepair + tWrite;
       std::cout << "  timing:"
                 << " classify=" << std::scientific << std::setprecision(2) << tClassify
-                << " grad=" << tGrad
-                << " wngir=" << tWNGIR
-                << " moveTrim=" << tMoveTrim
-                << " elas=" << tElasticity
-                << " hilbert=" << tHilbert
-                << " redist=" << tRedistance
-                << " advect=" << tAdvect
-                << " repair=" << tRepair
-                << " write=" << tWrite
-                << " total=" << total << '\n';
+                << " grad=" << tGrad << " wngir=" << tWNGIR << " moveTrim=" << tMoveTrim
+                << " elas=" << tElasticity << " hilbert=" << tHilbert
+                << " redist=" << tRedistance << " advect=" << tAdvect
+                << " repair=" << tRepair << " write=" << tWrite << " total=" << total
+                << '\n';
     }
     ++acceptedShapeIterations;
   }
 
   xdmf.close();
-  std::cout << "\nDone. Accepted shape iterations: "
-            << acceptedShapeIterations << " / " << maxIt
-            << "  attempts=" << shapeAttempts
-            << "  stop=" << stopReason
+  std::cout << "\nDone. Accepted shape iterations: " << acceptedShapeIterations << " / "
+            << maxIt << "  attempts=" << shapeAttempts << "  stop=" << stopReason
             << ". Objective history in LevelSetWNGIRCantilever2D.obj.txt\n";
   return 0;
 }

--- a/examples/ShapeOptimization/LevelSetWNGIRCantilever3D.cpp
+++ b/examples/ShapeOptimization/LevelSetWNGIRCantilever3D.cpp
@@ -78,8 +78,7 @@ namespace
     KSPGetPC(ksp, &pc);
     const char* pcType = nullptr;
     PCGetType(pc, &pcType);
-    if (pcType && (!std::strcmp(pcType, PCLU)
-                || !std::strcmp(pcType, PCCHOLESKY)))
+    if (pcType && (!std::strcmp(pcType, PCLU) || !std::strcmp(pcType, PCCHOLESKY)))
     {
       PCFactorSetReuseOrdering(pc, PETSC_TRUE);
       PCFactorSetReuseFill(pc, PETSC_TRUE);
@@ -97,9 +96,8 @@ namespace
 
   Vec3 cross3(const Vec3& a, const Vec3& b)
   {
-    return vec3(a(1) * b(2) - a(2) * b(1),
-                a(2) * b(0) - a(0) * b(2),
-                a(0) * b(1) - a(1) * b(0));
+    return vec3(
+      a(1) * b(2) - a(2) * b(1), a(2) * b(0) - a(0) * b(2), a(0) * b(1) - a(1) * b(0));
   }
 
   Real det3(const Vec3& a, const Vec3& b, const Vec3& c)
@@ -127,16 +125,17 @@ namespace
 
   // Squared distance to a triangle, following the Voronoi-region test of
   // Christer Ericson, Real-Time Collision Detection, Section 5.1.5.
-  Real pointTriangleDistance(
-      const Vec3& p, const Vec3& a, const Vec3& b, const Vec3& c)
+  Real pointTriangleDistance(const Vec3& p, const Vec3& a, const Vec3& b, const Vec3& c)
   {
     const Vec3 ab = b - a, ac = c - a, ap = p - a;
     const Real d1 = ab.dot(ap), d2 = ac.dot(ap);
-    if (d1 <= 0 && d2 <= 0) return ap.norm();
+    if (d1 <= 0 && d2 <= 0)
+      return ap.norm();
 
     const Vec3 bp = p - b;
     const Real d3 = ab.dot(bp), d4 = ac.dot(bp);
-    if (d3 >= 0 && d4 <= d3) return bp.norm();
+    if (d3 >= 0 && d4 <= d3)
+      return bp.norm();
 
     const Real vc = d1 * d4 - d3 * d2;
     if (vc <= 0 && d1 >= 0 && d3 <= 0)
@@ -144,7 +143,8 @@ namespace
 
     const Vec3 cp = p - c;
     const Real d5 = ab.dot(cp), d6 = ac.dot(cp);
-    if (d6 >= 0 && d5 <= d6) return cp.norm();
+    if (d6 >= 0 && d5 <= d6)
+      return cp.norm();
 
     const Real vb = d5 * d2 - d1 * d6;
     if (vb <= 0 && d2 >= 0 && d6 <= 0)
@@ -158,28 +158,24 @@ namespace
     return (p - (a + vb * denom * ab + vc * denom * ac)).norm();
   }
 
-  constexpr std::array<std::array<Real, 4>, 4> TetraQuadrature = {{
-    {{ 0.5854101966249685, 0.1381966011250105,
-       0.1381966011250105, 0.1381966011250105 }},
-    {{ 0.1381966011250105, 0.5854101966249685,
-       0.1381966011250105, 0.1381966011250105 }},
-    {{ 0.1381966011250105, 0.1381966011250105,
-       0.5854101966249685, 0.1381966011250105 }},
-    {{ 0.1381966011250105, 0.1381966011250105,
-       0.1381966011250105, 0.5854101966249685 }}
-  }};
+  constexpr std::array<std::array<Real, 4>, 4> TetraQuadrature = {
+    {{{0.5854101966249685, 0.1381966011250105, 0.1381966011250105, 0.1381966011250105}},
+      {{0.1381966011250105, 0.5854101966249685, 0.1381966011250105, 0.1381966011250105}},
+      {{0.1381966011250105, 0.1381966011250105, 0.5854101966249685, 0.1381966011250105}},
+      {{0.1381966011250105, 0.1381966011250105, 0.1381966011250105,
+        0.5854101966249685}}}};
 
   struct CellMomentInfo
   {
-    Index index = 0;
-    Real volume = 0;
-    Real moment = 0;
-    std::array<Vec3, 4> x;
+      Index index = 0;
+      Real volume = 0;
+      Real moment = 0;
+      std::array<Vec3, 4> x;
   };
 
   template <class Phi>
   std::vector<CellMomentInfo> collectCellMoments(
-      const WNGIRMesh& mesh, const Phi& phi, Real epsilon)
+    const WNGIRMesh& mesh, const Phi& phi, Real epsilon)
   {
     std::vector<CellMomentInfo> cells;
     cells.reserve(mesh.getCellCount());
@@ -190,9 +186,9 @@ namespace
       const auto& v = it->getVertices();
       for (std::size_t i = 0; i < 4; ++i)
         info.x[i] = mesh.getVertexCoordinates(v[i]);
-      info.volume = std::abs(det3(info.x[1] - info.x[0],
-                                  info.x[2] - info.x[0],
-                                  info.x[3] - info.x[0])) / Real(6);
+      info.volume = std::abs(det3(info.x[1] - info.x[0], info.x[2] - info.x[0],
+                      info.x[3] - info.x[0])) /
+        Real(6);
       for (const auto& l : TetraQuadrature)
       {
         Math::SpatialPoint rc(3);
@@ -208,8 +204,7 @@ namespace
   }
 
   template <class Displacement>
-  void updateMovedMesh(
-      const WNGIRMesh& mesh, WNGIRMesh& moved, const Displacement& u)
+  void updateMovedMesh(const WNGIRMesh& mesh, WNGIRMesh& moved, const Displacement& u)
   {
     const auto& fes = u.getFiniteElementSpace();
     for (Index v = 0; v < mesh.getVertexCount(); ++v)
@@ -221,7 +216,7 @@ namespace
   }
 
   std::size_t sizeOption(
-      int argc, char** argv, const std::string& name, std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -230,8 +225,7 @@ namespace
     return fallback;
   }
 
-  Real realOption(
-      int argc, char** argv, const std::string& name, Real fallback)
+  Real realOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -241,7 +235,7 @@ namespace
   }
 
   std::string stringOption(
-      int argc, char** argv, const std::string& name, std::string fallback)
+    int argc, char** argv, const std::string& name, std::string fallback)
   {
     const std::string prefix = "--" + name + "=";
     for (int i = 1; i < argc; ++i)
@@ -277,12 +271,9 @@ int run(int argc, char** argv)
   const Real h = H / static_cast<Real>(n);
   const Real hmin = realOption(argc, argv, "hmin", Real(0.1) * h);
   const bool initialMMG = sizeOption(argc, argv, "initial-mmg", 0) != 0;
-  const Real initialMMGHMin =
-    realOption(argc, argv, "initial-mmg-hmin", hmin);
-  const Real initialMMGHMax =
-    realOption(argc, argv, "initial-mmg-hmax", h);
-  const Real initialMMGHausd =
-    realOption(argc, argv, "initial-mmg-hausd", Real(0));
+  const Real initialMMGHMin = realOption(argc, argv, "initial-mmg-hmin", hmin);
+  const Real initialMMGHMax = realOption(argc, argv, "initial-mmg-hmax", h);
+  const Real initialMMGHausd = realOption(argc, argv, "initial-mmg-hausd", Real(0));
   const Real ell = realOption(argc, argv, "ell", Real(0.5));
   const Real alphaReg = realOption(argc, argv, "alpha", Real(2) * h);
   const Real epsilon = realOption(argc, argv, "classifier-eps", Real(1.25) * h);
@@ -293,8 +284,7 @@ int run(int argc, char** argv)
   const Real objectiveTol = realOption(argc, argv, "objective-decrease-tol", 1e-10);
   const std::string reinitMode = stringOption(argc, argv, "reinit", "none");
   const std::size_t reinitEvery = sizeOption(argc, argv, "reinit-every", 1);
-  const std::string redistanceMode =
-    stringOption(argc, argv, "redistance-mode", "none");
+  const std::string redistanceMode = stringOption(argc, argv, "redistance-mode", "none");
   const std::size_t redistanceEvery = sizeOption(argc, argv, "redistance-every", 0);
   const std::size_t repairEvery = sizeOption(argc, argv, "repair-every", 5);
   const Real repairEta = realOption(argc, argv, "repair-eta", Real(0.5) * h);
@@ -304,8 +294,7 @@ int run(int argc, char** argv)
   const std::size_t nx = static_cast<std::size_t>(std::lround(L / h)) + 1;
   const std::size_t ny = n + 1;
   const std::size_t nz = static_cast<std::size_t>(std::lround(W / h)) + 1;
-  WNGIRMesh mesh = WNGIRMesh::UniformGrid(
-      Polytope::Type::Tetrahedron, { nx, ny, nz });
+  WNGIRMesh mesh = WNGIRMesh::UniformGrid(Polytope::Type::Tetrahedron, {nx, ny, nz});
   mesh.scale(h);
   mesh.getConnectivity().compute(2, 3);
   mesh.getConnectivity().compute(3, 2);
@@ -313,8 +302,7 @@ int run(int argc, char** argv)
   mesh.getConnectivity().compute(0, 0);
   const std::size_t D = mesh.getDimension();
 
-  auto tagBoundary = [&](WNGIRMesh& m)
-  {
+  auto tagBoundary = [&](WNGIRMesh& m) {
     for (auto it = m.getBoundary(); it; ++it)
     {
       Vec3 c = vec3();
@@ -324,9 +312,8 @@ int run(int argc, char** argv)
       Attribute attr = Gamma0;
       if (c(0) < Real(1e-9))
         attr = GammaD;
-      else if (c(0) > L - Real(1e-9)
-               && std::abs(c(1) - H / 2) < Real(0.15) * H
-               && std::abs(c(2) - W / 2) < Real(0.15) * W)
+      else if (c(0) > L - Real(1e-9) && std::abs(c(1) - H / 2) < Real(0.15) * H &&
+        std::abs(c(2) - W / 2) < Real(0.15) * W)
         attr = GammaN;
       m.setAttribute({D - 1, it->getIndex()}, attr);
     }
@@ -336,14 +323,11 @@ int run(int argc, char** argv)
   if (initialMMG)
   {
     std::cout << "  initial MMG remesh:"
-              << " hmin=" << initialMMGHMin
-              << " hmax=" << initialMMGHMax
+              << " hmin=" << initialMMGHMin << " hmax=" << initialMMGHMax
               << " hausd=" << initialMMGHausd << "\n";
     MMG::Mesh mmgMesh(std::move(mesh));
     MMG::Optimizer optimizer;
-    optimizer.setHMin(initialMMGHMin)
-             .setHMax(initialMMGHMax)
-             .setAngleDetection(false);
+    optimizer.setHMin(initialMMGHMin).setHMax(initialMMGHMax).setAngleDetection(false);
     if (initialMMGHausd > 0)
       optimizer.setHausdorff(initialMMGHausd);
     optimizer.optimize(mmgMesh);
@@ -362,16 +346,17 @@ int run(int argc, char** argv)
   ScalarP1 sh(mesh);
   ScalarP0 p0(mesh);
   VectorP1 vh(mesh, 3);
-  GridFunction phiH(sh); phiH.setName("phi");
+  GridFunction phiH(sh);
+  phiH.setName("phi");
   PETSc::Variational::TrialFunction wngirTrial(vh);
   PETSc::Variational::TestFunction wngirTest(vh);
   auto& u = wngirTrial.getSolution();
   u.setName("fit");
-  GridFunction dJ(vh); dJ.setName("dJ");
+  GridFunction dJ(vh);
+  dJ.setName("dJ");
 
   // A solid box perforated by a regular array of spherical voids.
-  phiH = [&](const Geometry::Point& p) -> Real
-  {
+  phiH = [&](const Geometry::Point& p) -> Real {
     const auto& x = p.getCoordinates();
     Real value = -std::numeric_limits<Real>::infinity();
     const Real radius = Real(0.16) * std::min(H, W);
@@ -421,8 +406,7 @@ int run(int argc, char** argv)
   wngirDefaults.maxIterations = 60;
   wngirDefaults.activeRMSOverHTol = Real(0.2);
   WNGIRParameters wp =
-    Rodin::Examples::makeWNGIRParameters(
-        argc, argv, h, Gamma, wngirDefaults);
+    Rodin::Examples::makeWNGIRParameters(argc, argv, h, Gamma, wngirDefaults);
   wp.trace = trace;
   Adaptation::WNGIR wngir(wngirTrial, wngirTest);
   wngir.setParameters(wp);
@@ -444,14 +428,12 @@ int run(int argc, char** argv)
   Real complianceCap = std::numeric_limits<Real>::infinity();
 
   std::cout << "3D WNGIR cantilever: " << mesh.getCellCount() << " tetrahedra"
-            << "  grid=" << nx << "x" << ny << "x" << nz
-            << "\n  h=" << h << " ell=" << ell << " alpha=" << alphaReg
-            << " dt=" << dt << " reinit=" << reinitMode << "/" << reinitEvery
+            << "  grid=" << nx << "x" << ny << "x" << nz << "\n  h=" << h
+            << " ell=" << ell << " alpha=" << alphaReg << " dt=" << dt
+            << " reinit=" << reinitMode << "/" << reinitEvery
             << " redistance=" << redistanceMode << "/" << redistanceEvery
-            << " repair=" << repairEvery
-            << "\n  WNGIR metric: gammaM=" << wp.gammaM
-            << " gammaDev=" << wp.gammaH
-            << " gammaDiv=" << wp.gammaDiv
+            << " repair=" << repairEvery << "\n  WNGIR metric: gammaM=" << wp.gammaM
+            << " gammaDev=" << wp.gammaH << " gammaDiv=" << wp.gammaDiv
             << " ellM=" << wp.ellM << '\n';
 
   std::size_t shapeAttempts = 0;
@@ -483,15 +465,15 @@ int run(int argc, char** argv)
     {
       const Index f = fit->getIndex();
       const auto& inc = conn.getIncidence({2, 3}, f);
-      if (inc.size() != 2) continue;
+      if (inc.size() != 2)
+        continue;
       edges.push_back({static_cast<Index>(cellToLocal.at(inc[0])),
-                       static_cast<Index>(cellToLocal.at(inc[1])),
-                       lambdaC * triangleArea(mesh, f), f});
+        static_cast<Index>(cellToLocal.at(inc[1])), lambdaC * triangleArea(mesh, f), f});
     }
     const auto classified = MinSTCut().classify(volumes, moments, edges);
     for (std::size_t i = 0; i < classified.labels.size(); ++i)
       mesh.setAttribute({D, localToCell[i]},
-          classified.labels[i] == MinSTCut::Inside ? Interior : Exterior);
+        classified.labels[i] == MinSTCut::Inside ? Interior : Exterior);
 
     // Keep only material components connected to the clamped boundary.
     std::vector<char> support(mesh.getCellCount(), 0);
@@ -499,17 +481,23 @@ int run(int argc, char** argv)
       if (mesh.getAttribute(D - 1, bit->getIndex()) == Attribute{GammaD})
         for (const Index c : conn.getIncidence({2, 3}, bit->getIndex()))
           support[c] = 1;
-    for (const auto& component : mesh.ccl(
-          [](const Polytope& a, const Polytope& b)
-          { return a.getAttribute() == b.getAttribute(); }).getComponents())
+    for (const auto& component : mesh
+                                   .ccl([](const Polytope& a, const Polytope& b) {
+                                     return a.getAttribute() == b.getAttribute();
+                                   })
+                                   .getComponents())
     {
-      if (component.empty()) continue;
+      if (component.empty())
+        continue;
       const auto attr = mesh.getAttribute(D, *component.begin());
-      if (!attr || *attr != Interior) continue;
+      if (!attr || *attr != Interior)
+        continue;
       bool anchored = false;
-      for (const Index c : component) anchored = anchored || support[c];
+      for (const Index c : component)
+        anchored = anchored || support[c];
       if (!anchored)
-        for (const Index c : component) mesh.setAttribute({D, c}, Exterior);
+        for (const Index c : component)
+          mesh.setAttribute({D, c}, Exterior);
     }
 
     std::vector<Index> interfaceFacets;
@@ -517,7 +505,8 @@ int run(int argc, char** argv)
     {
       const Index f = fit->getIndex();
       const auto& inc = conn.getIncidence({2, 3}, f);
-      if (inc.size() != 2) continue;
+      if (inc.size() != 2)
+        continue;
       const auto a = mesh.getAttribute(D, inc[0]);
       const auto b = mesh.getAttribute(D, inc[1]);
       if ((a && *a == Interior) != (b && *b == Interior))
@@ -530,10 +519,12 @@ int run(int argc, char** argv)
     std::size_t insideCount = 0;
     for (std::size_t i = 0; i < cells.size(); ++i)
       if (mesh.getAttribute(D, localToCell[i]) == Attribute{Interior})
-      { volume += cells[i].volume; ++insideCount; }
+      {
+        volume += cells[i].volume;
+        ++insideCount;
+      }
     std::cout << "  classify: inside=" << insideCount
-              << " interface=" << interfaceFacets.size()
-              << " volume=" << volume << '\n';
+              << " interface=" << interfaceFacets.size() << " volume=" << volume << '\n';
     if (interfaceFacets.empty())
     {
       std::cerr << "  empty classified interface; stopping\n";
@@ -544,16 +535,14 @@ int run(int argc, char** argv)
     gradProjection.solve(gradSolver);
     enableFactorReuse(gradSolver.getHandle());
     if (trace)
-      std::cout << "  PETSc grad: it="
-                << kspIterations(gradSolver.getHandle()) << '\n';
+      std::cout << "  PETSc grad: it=" << kspIterations(gradSolver.getHandle()) << '\n';
     copyPETScToEigen(gp.getSolution().getData(), gradPhi.getData());
     RealFunction phiFn([&](const Geometry::Point& p) { return phiH.getValue(p); });
     AnalyticVectorFunction gradFn(
-        [&](const Geometry::Point& p) { return gradPhi.getValue(p); }, 3);
+      [&](const Geometry::Point& p) { return gradPhi.getValue(p); }, 3);
     u = Real(0);
     const auto report = wngir.solve(mesh, interfaceFacets, phiFn, gradFn);
-    std::cout << "  WNGIR: it=" << report.iterations
-              << " exit=" << report.exitReason
+    std::cout << "  WNGIR: it=" << report.iterations << " exit=" << report.exitReason
               << " activeRMS=" << std::scientific << report.activeRMS
               << " activeRMS/h=" << (h > Real(0) ? report.activeRMS / h : Real(0))
               << " activeSup/h=" << (h > Real(0) ? report.activeSup / h : Real(0))
@@ -561,7 +550,8 @@ int run(int argc, char** argv)
 
     updateMovedMesh(mesh, moved, u);
     for (Index c = 0; c < static_cast<Index>(mesh.getCellCount()); ++c)
-      if (const auto a = mesh.getAttribute(D, c)) moved.setAttribute({D, c}, *a);
+      if (const auto a = mesh.getAttribute(D, c))
+        moved.setAttribute({D, c}, *a);
     for (auto fit = mesh.getFace(); fit; ++fit)
       if (const auto a = mesh.getAttribute(D - 1, fit->getIndex()))
         moved.setAttribute({D - 1, fit->getIndex()}, *a);
@@ -575,9 +565,9 @@ int run(int argc, char** argv)
     PETSc::Variational::TrialFunction us(vhInterior);
     PETSc::Variational::TestFunction vs(vhInterior);
     Problem elasticity(us, vs);
-    elasticity = LinearElasticityIntegral(us, vs)(lambdaLame, muLame)
-               - BoundaryIntegral(VectorFunction{0, 0, -1}, vs).over(GammaN)
-               + DirichletBC(us, VectorFunction{0, 0, 0}).on(GammaD);
+    elasticity = LinearElasticityIntegral(us, vs)(lambdaLame, muLame) -
+      BoundaryIntegral(VectorFunction{0, 0, -1}, vs).over(GammaN) +
+      DirichletBC(us, VectorFunction{0, 0, 0}).on(GammaD);
     Solver::KSP elasticitySolver(elasticity);
     elasticitySolver.setPrefix("elasticity_");
     elasticity.assemble();
@@ -588,26 +578,28 @@ int run(int argc, char** argv)
                 << kspIterations(elasticitySolver.getHandle()) << '\n';
     PetscScalar complianceValue = 0;
     VecDot(elasticity.getLinearSystem().getVector(),
-           elasticity.getLinearSystem().getSolution(), &complianceValue);
+      elasticity.getLinearSystem().getSolution(), &complianceValue);
     const Real compliance = PetscRealPart(complianceValue);
     const Real objective = compliance + ell * volume;
-    const bool invalid = !std::isfinite(compliance) || compliance < 0
-                         || compliance > complianceCap;
-    const bool increased = objectiveGuard && std::isfinite(lastObjective)
-      && objective > lastObjective
-                   + objectiveTol * std::max(Real(1), std::abs(lastObjective));
+    const bool invalid =
+      !std::isfinite(compliance) || compliance < 0 || compliance > complianceCap;
+    const bool increased = objectiveGuard && std::isfinite(lastObjective) &&
+      objective >
+        lastObjective + objectiveTol * std::max(Real(1), std::abs(lastObjective));
     if (invalid || increased)
     {
       phiH.getData() = phiGood;
       dt *= Real(0.5);
       std::cout << "  REJECT: J=" << objective << " dt -> " << dt << '\n';
-      if (dt < Real(1e-3) * h) break;
+      if (dt < Real(1e-3) * h)
+        break;
       continue;
     }
     phiGood = phiH.getData();
     lastObjective = objective;
     dt = std::min(dtMax, Real(1.3) * dt);
-    if (itn == 0) complianceCap = Real(50) * compliance;
+    if (itn == 0)
+      complianceCap = Real(50) * compliance;
     objectiveFile << objective << '\n';
     std::cout << "  compliance=" << compliance << " volume=" << volume
               << " J=" << objective << " dt=" << dt << '\n';
@@ -615,24 +607,23 @@ int run(int argc, char** argv)
     auto jac = Jacobian(us.getSolution());
     jac.traceOf(Interior);
     auto strain = Real(0.5) * (jac + jac.T());
-    auto stress = Real(2) * muLame * strain
-                + lambdaLame * Trace(strain) * IdentityMatrix(3);
+    auto stress =
+      Real(2) * muLame * strain + lambdaLame * Trace(strain) * IdentityMatrix(3);
     auto normal = FaceNormal(moved);
     normal.traceOf(Interior);
     Problem hilbert(g, w);
-    hilbert = Integral(alphaReg * alphaReg * Jacobian(g), Jacobian(w))
-            + Integral(g, w)
-            - FaceIntegral(Dot(stress, strain) - ell, Dot(normal, w)).over(Gamma)
-            + DirichletBC(g, VectorFunction{0, 0, 0}).on(GammaD)
-            + DirichletBC(g, VectorFunction{0, 0, 0}).on(GammaN);
+    hilbert = Integral(alphaReg * alphaReg * Jacobian(g), Jacobian(w)) + Integral(g, w) -
+      FaceIntegral(Dot(stress, strain) - ell, Dot(normal, w)).over(Gamma) +
+      DirichletBC(g, VectorFunction{0, 0, 0}).on(GammaD) +
+      DirichletBC(g, VectorFunction{0, 0, 0}).on(GammaN);
     Solver::KSP hilbertSolver(hilbert);
     hilbertSolver.setPrefix("hilbert_");
     hilbert.assemble();
     hilbert.solve(hilbertSolver);
     enableFactorReuse(hilbertSolver.getHandle());
     if (trace)
-      std::cout << "  PETSc hilbert: it="
-                << kspIterations(hilbertSolver.getHandle()) << '\n';
+      std::cout << "  PETSc hilbert: it=" << kspIterations(hilbertSolver.getHandle())
+                << '\n';
     copyPETScToEigen(g.getSolution().getData(), dJ.getData());
 
     // Write before redistance/advection mutates phiH into the next trial
@@ -649,11 +640,10 @@ int run(int argc, char** argv)
     }
 
     std::string activeMode = reinitMode;
-    bool doRedistance = reinitMode != "none" && reinitEvery > 0
-      && (itn % reinitEvery == 0 || itn + 1 == maxIt);
-    if (!doRedistance && reinitMode == "none" && redistanceMode != "none"
-        && redistanceEvery > 0
-        && ((itn + 1) % redistanceEvery == 0 || itn + 1 == maxIt))
+    bool doRedistance = reinitMode != "none" && reinitEvery > 0 &&
+      (itn % reinitEvery == 0 || itn + 1 == maxIt);
+    if (!doRedistance && reinitMode == "none" && redistanceMode != "none" &&
+      redistanceEvery > 0 && ((itn + 1) % redistanceEvery == 0 || itn + 1 == maxIt))
     {
       activeMode = redistanceMode;
       doRedistance = true;
@@ -661,17 +651,25 @@ int run(int argc, char** argv)
     if (doRedistance)
     {
       Distance::Eikonal<ScalarP1, Math::Vector<Real>>(dist)
-        .setInterior(Interior).setInterface(Gamma).solve().sign();
+        .setInterior(Interior)
+        .setInterface(Gamma)
+        .solve()
+        .sign();
       if (activeMode == "cp")
       {
-        struct FittedFace { std::array<Vec3, 3> x; Vec3 normal; };
+        struct FittedFace
+        {
+            std::array<Vec3, 3> x;
+            Vec3 normal;
+        };
         std::vector<FittedFace> fitted;
         fitted.reserve(interfaceFacets.size());
         for (const Index f : interfaceFacets)
         {
           const auto& fv = moved.getFace(f)->getVertices();
           FittedFace ff;
-          for (int i = 0; i < 3; ++i) ff.x[i] = moved.getVertexCoordinates(fv[i]);
+          for (int i = 0; i < 3; ++i)
+            ff.x[i] = moved.getVertexCoordinates(fv[i]);
           ff.normal = cross3(ff.x[1] - ff.x[0], ff.x[2] - ff.x[0]);
           ff.normal /= std::max(ff.normal.norm(), Real(1e-30));
           Vec3 fc = (ff.x[0] + ff.x[1] + ff.x[2]) / Real(3);
@@ -682,7 +680,8 @@ int run(int argc, char** argv)
               for (const Index v : moved.getCell(c)->getVertices())
                 cc += moved.getVertexCoordinates(v);
               cc /= Real(4);
-              if ((fc - cc).dot(ff.normal) < 0) ff.normal = -ff.normal;
+              if ((fc - cc).dot(ff.normal) < 0)
+                ff.normal = -ff.normal;
               break;
             }
           fitted.push_back(ff);
@@ -691,18 +690,24 @@ int run(int argc, char** argv)
         for (Index v = 0; v < mesh.getVertexCount(); ++v)
         {
           const Index dof = sh.getGlobalIndex({0, v}, 0);
-          if (std::abs(dist.getData()(dof)) > band) continue;
+          if (std::abs(dist.getData()(dof)) > band)
+            continue;
           const Vec3 x = mesh.getVertexCoordinates(v);
           Real dmin = std::numeric_limits<Real>::infinity();
           std::size_t nearest = 0;
           for (std::size_t i = 0; i < fitted.size(); ++i)
           {
-            const Real d = pointTriangleDistance(
-                x, fitted[i].x[0], fitted[i].x[1], fitted[i].x[2]);
-            if (d < dmin) { dmin = d; nearest = i; }
+            const Real d =
+              pointTriangleDistance(x, fitted[i].x[0], fitted[i].x[1], fitted[i].x[2]);
+            if (d < dmin)
+            {
+              dmin = d;
+              nearest = i;
+            }
           }
-          const Vec3 fc = (fitted[nearest].x[0] + fitted[nearest].x[1]
-                         + fitted[nearest].x[2]) / Real(3);
+          const Vec3 fc =
+            (fitted[nearest].x[0] + fitted[nearest].x[1] + fitted[nearest].x[2]) /
+            Real(3);
           dist.getData()(dof) =
             ((x - fc).dot(fitted[nearest].normal) >= 0 ? dmin : -dmin);
         }
@@ -722,8 +727,7 @@ int run(int argc, char** argv)
     dJ /= std::max(speed.max(), Real(1e-30));
     Advection::Lagrangian(adv, advTest, dist, dJ).step(dt);
     phiH.getData() = adv.getSolution().getData();
-    if (repairEvery > 0
-        && ((itn + 1) % repairEvery == 0 || itn + 1 == maxIt))
+    if (repairEvery > 0 && ((itn + 1) % repairEvery == 0 || itn + 1 == maxIt))
     {
       const Math::Vector<Real> rhs = mass.getOperator() * phiH.getData();
       phiH.getData() = repairCG.solve(rhs);
@@ -733,9 +737,8 @@ int run(int argc, char** argv)
   }
 
   xdmf.close();
-  std::cout << "\nDone. Accepted shape iterations: "
-            << acceptedShapeIterations << " / " << maxIt
-            << "  attempts=" << shapeAttempts
+  std::cout << "\nDone. Accepted shape iterations: " << acceptedShapeIterations << " / "
+            << maxIt << "  attempts=" << shapeAttempts
             << ". Objective history in LevelSetWNGIRCantilever3D.obj.txt\n";
   return 0;
 }

--- a/examples/Solid/ActiveContractionPlaneWave.cpp
+++ b/examples/Solid/ActiveContractionPlaneWave.cpp
@@ -64,21 +64,21 @@ namespace
 {
   struct LocalState
   {
-    Real ec    = 0.0;
-    Real gamma = 0.0;
-    Real beta  = 0.0;
-    Real e1D = 0.0;   // committed fiber strain e_1D^n
+      Real ec = 0.0;
+      Real gamma = 0.0;
+      Real beta = 0.0;
+      Real e1D = 0.0;   // committed fiber strain e_1D^n
   };
 
   using StateBuffer = std::vector<std::vector<LocalState>>;
 
   struct StepDiagnostics
   {
-    Real minActiveExtension = std::numeric_limits<Real>::infinity();
-    Real maxActiveExtension = -std::numeric_limits<Real>::infinity();
-    Real maxGamma = 0.0;
-    Real maxBeta = 0.0;
-    size_t maxLocalIterations = 0;
+      Real minActiveExtension = std::numeric_limits<Real>::infinity();
+      Real maxActiveExtension = -std::numeric_limits<Real>::infinity();
+      Real maxGamma = 0.0;
+      Real maxBeta = 0.0;
+      size_t maxLocalIterations = 0;
   };
 
   size_t parseSize(const char* value, const char* name)
@@ -145,13 +145,13 @@ int main(int argc, char** argv)
 
   // ---- geometry -----------------------------------------------------------
   Mesh mesh;
-  mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, { nc, nc, nc });
+  mesh = mesh.UniformGrid(Polytope::Type::Tetrahedron, {nc, nc, nc});
   mesh.scale(1.0 / static_cast<Real>(nc - 1));
   mesh.getConnectivity().compute(2, 3);
   mesh.save("miaow.mesh", IO::FileFormat::MEDIT);
 
-  std::cout << "Mesh: " << mesh.getVertexCount() << " vertices, "
-            << mesh.getCellCount() << " cells." << std::endl;
+  std::cout << "Mesh: " << mesh.getVertexCount() << " vertices, " << mesh.getCellCount()
+            << " cells." << std::endl;
 
   // ---- label top boundary -------------------------------------------------
   constexpr Attribute topBC = 1;
@@ -166,7 +166,7 @@ int main(int argc, char** argv)
       ySum += mesh.getVertexCoordinates(verts[i])(1);
     const Real yMid = ySum / static_cast<Real>(nv);
     if (yMid > 1.0 - eps)
-      mesh.setAttribute({ 2, it->getIndex() }, topBC);
+      mesh.setAttribute({2, it->getIndex()}, topBC);
   }
 
   // ---- finite-element spaces ----------------------------------------------
@@ -175,26 +175,26 @@ int main(int argc, char** argv)
   P1 Sh(mesh);        // scalar (electrical activation)
 
   // ---- materials ----------------------------------------------------------
-  const Real E      = 50.0;
-  const Real nu     = 0.3;
+  const Real E = 50.0;
+  const Real nu = 0.3;
   const Real lambda = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
-  const Real mu     = E / (2.0 * (1.0 + nu));
-  const Real rho    = 1.0;
+  const Real mu = E / (2.0 * (1.0 + nu));
+  const Real rho = 1.0;
   Solid::NeoHookean passive(lambda, mu);
 
   Solid::ActiveFiberLaw::Parameters activeParams;
   activeParams.stiffness = activeScale * 20.0;
-  activeParams.damping              = 300;
-  activeParams.destructionRate      = 0.4;
+  activeParams.damping = 300;
+  activeParams.destructionRate = 0.4;
   activeParams.crossBridgeStiffness = activeScale * 100.0;
   activeParams.contractility = activeScale * 20.0;
-  activeParams.initial.extension    = 0.0;
-  activeParams.initial.stiffness    = 0.0;
-  activeParams.initial.stress       = 0.0;
+  activeParams.initial.extension = 0.0;
+  activeParams.initial.stiffness = 0.0;
+  activeParams.initial.stress = 0.0;
   Solid::ActiveFiberLaw activeLaw(activeParams);
 
-  Solid::ActiveContraction<Solid::NeoHookean, Solid::ActiveFiberLaw>
-    law(passive, activeLaw);
+  Solid::ActiveContraction<Solid::NeoHookean, Solid::ActiveFiberLaw> law(
+    passive, activeLaw);
   law.setLocalTolerance(1e-14).setLocalMaxIterations(80);
 
   // ---- repeated electrical activation plane waves -------------------------
@@ -203,24 +203,23 @@ int main(int argc, char** argv)
   // time so there is a quiet relaxation gap between waves.
   struct PlaneWaveParams
   {
-    Real amplitude;
-    Real speed;
-    Real width;
-    Real start;
-    Real gap;
+      Real amplitude;
+      Real speed;
+      Real width;
+      Real start;
+      Real gap;
   };
 
   const size_t nWaves = 2;
 
   PlaneWaveParams wave;
   wave.amplitude = activeScale * 20.0;
-  wave.speed          = 0.5;
-  wave.width          = 0.05;
-  wave.start          = 0;
-  wave.gap            = 1.5;
+  wave.speed = 0.5;
+  wave.width = 0.05;
+  wave.start = 0;
+  wave.gap = 1.5;
 
-  auto activationAt = [&](Real y, Real t) -> Real
-  {
+  auto activationAt = [&](Real y, Real t) -> Real {
     Real activation = 0.0;
     for (size_t k = 0; k < nWaves; ++k)
     {
@@ -236,12 +235,10 @@ int main(int argc, char** argv)
                                                 // negative at rest
   };
 
-  const Real   dtStep = 0.02;
+  const Real dtStep = 0.02;
   const Real traversalTime = (1.0 - wave.start) / wave.speed;
   const Real tEnd =
-    static_cast<Real>(nWaves - 1) * wave.gap
-    + traversalTime
-    + 0.4 / wave.speed;
+    static_cast<Real>(nWaves - 1) * wave.gap + traversalTime + 0.4 / wave.speed;
   const size_t fullSteps = static_cast<size_t>(tEnd / dtStep) + 1;
   const size_t nSteps =
     requestedSteps == 0 ? fullSteps : std::min(requestedSteps, fullSteps);
@@ -251,9 +248,8 @@ int main(int argc, char** argv)
   // ---- per-quadrature-point state buffer ----------------------------------
   StateBuffer state(mesh.getCellCount());
 
-  auto activeInput = [&](Solid::ConstitutivePoint& cp)
-  {
-    const Index cellIdx   = cp.get<Solid::Tags::CellIndex>();
+  auto activeInput = [&](Solid::ConstitutivePoint& cp) {
+    const Index cellIdx = cp.get<Solid::Tags::CellIndex>();
     const std::size_t qpIdx = cp.get<Solid::Tags::QuadraturePointIndex>();
 
     if (cellIdx >= state.size())
@@ -283,7 +279,7 @@ int main(int argc, char** argv)
   // ---- solution fields ----------------------------------------------------
   GridFunction u(Vh);
   u.setName("Displacement");
-  u = VectorFunction{ Zero(), Zero() };
+  u = VectorFunction{Zero(), Zero()};
 
   GridFunction uPrevious(Vh);
   uPrevious = u;
@@ -293,14 +289,13 @@ int main(int argc, char** argv)
 
   GridFunction activationField(Sh);
   activationField.setName("Activation");
-  activationField = [&](const Geometry::Point& p)
-  {
+  activationField = [&](const Geometry::Point& p) {
     return activationAt(p.getPhysicalCoordinates()(1), currentTime);
   };
 
   GridFunction fiberField(Vh);
   fiberField.setName("FiberDirection");
-  fiberField = VectorFunction{ RealFunction(1.0), Zero() };
+  fiberField = VectorFunction{RealFunction(1.0), Zero()};
 
   auto computeMaxNodalDisplacement = [&]() -> Real {
     Real maxDisplacement = 0.0;
@@ -325,9 +320,8 @@ int main(int argc, char** argv)
   grid.setMesh(mesh);
   grid.add(u);
   grid.add(activationField);
-  grid.add(fiberField,
-           IO::XDMF::Center::Node,
-           IO::XDMF::AttributePolicy::Static);   // written once, reused
+  grid.add(fiberField, IO::XDMF::Center::Node,
+    IO::XDMF::AttributePolicy::Static);   // written once, reused
   xdmf.write(0.0);
 
   // ---- commit sweep -------------------------------------------------------
@@ -357,8 +351,8 @@ int main(int argc, char** argv)
 
   // ---- time loop ----------------------------------------------------------
   TrialFunction du(Vh);
-  TestFunction  v(Vh);
-  auto zero = VectorFunction{ Zero(), Zero() };
+  TestFunction v(Vh);
+  auto zero = VectorFunction{Zero(), Zero()};
 
   std::cout << std::scientific << std::setprecision(6);
   std::cout << "Time steps: " << nSteps;
@@ -386,7 +380,6 @@ int main(int argc, char** argv)
     else
       u.getData() = uPrevious.getData();
 
-
     Real activationMin = std::numeric_limits<Real>::infinity();
     Real activationMax = -std::numeric_limits<Real>::infinity();
     for (auto it = mesh.getVertex(); it; ++it)
@@ -396,40 +389,31 @@ int main(int argc, char** argv)
       activationMax = std::max(activationMax, a);
     }
 
-    std::cout
-      << "\n[step " << step << " / " << nSteps << "]"
-      << " t = " << currentTime
-      << " scheme = " << (useBDF2 ? "BDF2" : "BE")
-      << " activation = [" << activationMin << ", " << activationMax << "]"
-      << " |u_guess| = " << u.getData().norm()
-      << std::endl;
+    std::cout << "\n[step " << step << " / " << nSteps << "]"
+              << " t = " << currentTime << " scheme = " << (useBDF2 ? "BDF2" : "BE")
+              << " activation = [" << activationMin << ", " << activationMax << "]"
+              << " |u_guess| = " << u.getData().norm() << std::endl;
 
     auto ivw =
       Solid::InternalVirtualWork(law, u).setInput(activeInput).setOutput(commitOutput);
 
     Problem newton(du, v);
-    newton =
-             ivw(du, v)
-           + (rho * bdfA0 / dtStep) * Integral(du, v)
-           + (rho / dtStep)
-             * Integral(bdfA0 * u + bdfA1 * uPrevious
-                        + bdfA2 * uPreviousPrevious, v)
-           + DirichletBC(du, zero).on(topBC);
+    newton = ivw(du, v) + (rho * bdfA0 / dtStep) * Integral(du, v) +
+      (rho / dtStep) *
+        Integral(bdfA0 * u + bdfA1 * uPrevious + bdfA2 * uPreviousPrevious, v) +
+      DirichletBC(du, zero).on(topBC);
 
     CG linearSolver(newton);
     linearSolver.setTolerance(1e-8).setMaxIterations(2000);
     NewtonSolver solver(linearSolver);
-    solver.setMaxIterations(50)
-          .setAbsoluteTolerance(1e-9)
-          .setRelativeTolerance(1e-7);
+    solver.setMaxIterations(50).setAbsoluteTolerance(1e-9).setRelativeTolerance(1e-7);
     Real previousNewtonResidual = std::numeric_limits<Real>::quiet_NaN();
     solver.setMonitor([&](const auto& report) {
       std::cout << "  Newton " << std::setw(2) << report.iterations
                 << " residual = " << report.finalResidual
                 << " step = " << report.finalStepNorm
                 << " damping = " << report.dampingFactor;
-      if (std::isfinite(previousNewtonResidual)
-          && previousNewtonResidual > 0.0)
+      if (std::isfinite(previousNewtonResidual) && previousNewtonResidual > 0.0)
       {
         std::cout << " ratio = " << report.finalResidual / previousNewtonResidual;
       }
@@ -454,10 +438,8 @@ int main(int argc, char** argv)
     const Real maxNodalDisplacement = computeMaxNodalDisplacement();
     peakMaxNodalDisplacement = std::max(peakMaxNodalDisplacement, maxNodalDisplacement);
 
-    const auto bdfData =
-      bdfA0 * u.getData()
-      + bdfA1 * uPrevious.getData()
-      + bdfA2 * uPreviousPrevious.getData();
+    const auto bdfData = bdfA0 * u.getData() + bdfA1 * uPrevious.getData() +
+      bdfA2 * uPreviousPrevious.getData();
 
     std::cout << "  summary:"
               << " converged = " << (report.converged ? "yes" : "no")
@@ -484,8 +466,7 @@ int main(int argc, char** argv)
     uPrevious = u;
 
     // Update activation field from current time and mesh node positions
-    activationField = [&](const Geometry::Point& p)
-    {
+    activationField = [&](const Geometry::Point& p) {
       return activationAt(p.getPhysicalCoordinates()(1), currentTime);
     };
 

--- a/examples/WNGIRExampleParameters.h
+++ b/examples/WNGIRExampleParameters.h
@@ -18,20 +18,17 @@ namespace Rodin::Examples
 {
   struct WNGIRExampleDefaults
   {
-    std::size_t maxIterations = 60;
-    std::size_t quadratureOrder = 4;
-    Real betaMax = 50;
-    Real activeRMSOverHTol = 0;
-    Real activeSupOverHTol = 0;
-    Real gammaSize = 0;
-    bool parseLegacyMaxIterations = false;
+      std::size_t maxIterations = 60;
+      std::size_t quadratureOrder = 4;
+      Real betaMax = 50;
+      Real activeRMSOverHTol = 0;
+      Real activeSupOverHTol = 0;
+      Real gammaSize = 0;
+      bool parseLegacyMaxIterations = false;
   };
 
   inline bool findOption(
-      int argc,
-      char** argv,
-      const std::string& name,
-      std::string* value)
+    int argc, char** argv, const std::string& name, std::string* value)
   {
     const std::string prefix = "--" + name + "=";
     const std::string flag = "--" + name;
@@ -59,11 +56,7 @@ namespace Rodin::Examples
     return false;
   }
 
-  inline Real realOption(
-      int argc,
-      char** argv,
-      const std::string& name,
-      Real fallback)
+  inline Real realOption(int argc, char** argv, const std::string& name, Real fallback)
   {
     std::string value;
     if (!findOption(argc, argv, name, &value) || value.empty())
@@ -72,10 +65,7 @@ namespace Rodin::Examples
   }
 
   inline std::size_t sizeOption(
-      int argc,
-      char** argv,
-      const std::string& name,
-      std::size_t fallback)
+    int argc, char** argv, const std::string& name, std::size_t fallback)
   {
     std::string value;
     if (!findOption(argc, argv, name, &value) || value.empty())
@@ -83,11 +73,7 @@ namespace Rodin::Examples
     return static_cast<std::size_t>(std::strtoull(value.c_str(), nullptr, 10));
   }
 
-  inline bool boolOption(
-      int argc,
-      char** argv,
-      const std::string& name,
-      bool fallback)
+  inline bool boolOption(int argc, char** argv, const std::string& name, bool fallback)
   {
     std::string value;
     if (!findOption(argc, argv, name, &value))
@@ -97,22 +83,15 @@ namespace Rodin::Examples
     return std::strtoull(value.c_str(), nullptr, 10) != 0;
   }
 
-  inline Adaptation::WNGIRParameters makeWNGIRParameters(
-      int argc,
-      char** argv,
-      Real h,
-      Geometry::Attribute interfaceAttribute,
-      const WNGIRExampleDefaults& defaults = {})
+  inline Adaptation::WNGIRParameters makeWNGIRParameters(int argc, char** argv, Real h,
+    Geometry::Attribute interfaceAttribute, const WNGIRExampleDefaults& defaults = {})
   {
     Adaptation::WNGIRParameters p;
     p.h = h;
 
-    const Real gammaMFactor =
-      realOption(argc, argv, "wngir-gamma-m", Real(1));
-    const Real gammaHFactor =
-      realOption(argc, argv, "wngir-gamma-h", Real(1));
-    const Real gammaDivFactor =
-      realOption(argc, argv, "wngir-gamma-div", gammaHFactor);
+    const Real gammaMFactor = realOption(argc, argv, "wngir-gamma-m", Real(1));
+    const Real gammaHFactor = realOption(argc, argv, "wngir-gamma-h", Real(1));
+    const Real gammaDivFactor = realOption(argc, argv, "wngir-gamma-div", gammaHFactor);
     p.gammaM = gammaMFactor / h;
     p.gammaH = gammaHFactor / h;
     p.gammaDiv = gammaDivFactor / h;
@@ -150,35 +129,25 @@ namespace Rodin::Examples
       realOption(argc, argv, "wngir-rms-h-tol", defaults.activeRMSOverHTol);
     p.activeSupOverHTol =
       realOption(argc, argv, "wngir-sup-h-tol", defaults.activeSupOverHTol);
-    p.energyStagTol =
-      realOption(argc, argv, "wngir-energy-stag-tol", Real(1e-4));
+    p.energyStagTol = realOption(argc, argv, "wngir-energy-stag-tol", Real(1e-4));
     p.stepTol = realOption(argc, argv, "wngir-step-tol", Real(1e-4) * h);
 
-    p.quadratureOrder =
-      sizeOption(argc, argv, "quad-order", defaults.quadratureOrder);
-    p.maxIterations =
-      sizeOption(argc, argv, "wngir-steps", defaults.maxIterations);
+    p.quadratureOrder = sizeOption(argc, argv, "quad-order", defaults.quadratureOrder);
+    p.maxIterations = sizeOption(argc, argv, "wngir-steps", defaults.maxIterations);
     if (defaults.parseLegacyMaxIterations)
-      p.maxIterations =
-        sizeOption(argc, argv, "wngir-max-iters", p.maxIterations);
+      p.maxIterations = sizeOption(argc, argv, "wngir-max-iters", p.maxIterations);
 
     p.cgRelativeTolerance =
       realOption(argc, argv, "wngir-cg-rtol", p.cgRelativeTolerance);
-    p.cgMaxIterations =
-      sizeOption(argc, argv, "wngir-cg-max-iters", p.cgMaxIterations);
-    p.andersonMemory =
-      sizeOption(argc, argv, "wngir-aa-memory", p.andersonMemory);
-    p.andersonStart =
-      sizeOption(argc, argv, "wngir-aa-start", p.andersonStart);
-    p.andersonDamping =
-      realOption(argc, argv, "wngir-aa-damping", p.andersonDamping);
+    p.cgMaxIterations = sizeOption(argc, argv, "wngir-cg-max-iters", p.cgMaxIterations);
+    p.andersonMemory = sizeOption(argc, argv, "wngir-aa-memory", p.andersonMemory);
+    p.andersonStart = sizeOption(argc, argv, "wngir-aa-start", p.andersonStart);
+    p.andersonDamping = realOption(argc, argv, "wngir-aa-damping", p.andersonDamping);
     p.andersonMinDamping =
       realOption(argc, argv, "wngir-aa-min-damping", p.andersonMinDamping);
 
-    p.includeQualityGradient =
-      boolOption(argc, argv, "wngir-quality-energy", false);
-    p.includeQualityMetric =
-      boolOption(argc, argv, "wngir-quality-metric", true);
+    p.includeQualityGradient = boolOption(argc, argv, "wngir-quality-energy", false);
+    p.includeQualityMetric = boolOption(argc, argv, "wngir-quality-metric", true);
     p.includeAdmissibilityMetric =
       boolOption(argc, argv, "wngir-admissibility-metric", true);
     p.includeAdmissibilityGradient =
@@ -187,8 +156,7 @@ namespace Rodin::Examples
     p.hasInterfaceAttribute = true;
     p.interfaceAttribute = interfaceAttribute;
     p.trace =
-      boolOption(argc, argv, "trace",
-        boolOption(argc, argv, "wngir-trace", false));
+      boolOption(argc, argv, "trace", boolOption(argc, argv, "wngir-trace", false));
     return p;
   }
 }

--- a/src/Rodin/Adaptation/AnalyticFunctionAdapters.h
+++ b/src/Rodin/Adaptation/AnalyticFunctionAdapters.h
@@ -63,11 +63,14 @@ namespace Rodin::Adaptation
         Variational::VectorFunctionBase<ScalarType, AnalyticVectorFunction<F>>;
 
       AnalyticVectorFunction(F f, std::size_t dimension)
-        : m_f(std::move(f)), m_dimension(dimension)
+        : m_f(std::move(f)),
+          m_dimension(dimension)
       {}
 
       AnalyticVectorFunction(const AnalyticVectorFunction& other)
-        : Parent(other), m_f(other.m_f), m_dimension(other.m_dimension)
+        : Parent(other),
+          m_f(other.m_f),
+          m_dimension(other.m_dimension)
       {}
 
       AnalyticVectorFunction(AnalyticVectorFunction&& other)
@@ -82,14 +85,19 @@ namespace Rodin::Adaptation
       }
 
       std::size_t getDimension() const noexcept
-      { return m_dimension; }
+      {
+        return m_dimension;
+      }
 
-      Optional<std::size_t>
-      getOrder(const Geometry::Polytope&) const noexcept
-      { return std::nullopt; }
+      Optional<std::size_t> getOrder(const Geometry::Polytope&) const noexcept
+      {
+        return std::nullopt;
+      }
 
       AnalyticVectorFunction* copy() const noexcept override
-      { return new AnalyticVectorFunction(*this); }
+      {
+        return new AnalyticVectorFunction(*this);
+      }
 
     private:
       F m_f;
@@ -115,18 +123,23 @@ namespace Rodin::Adaptation
         Variational::MatrixFunctionBase<ScalarType, AnalyticMatrixFunction<F>>;
 
       AnalyticMatrixFunction(F f, std::size_t rows, std::size_t cols)
-        : m_f(std::move(f)), m_rows(rows), m_cols(cols)
+        : m_f(std::move(f)),
+          m_rows(rows),
+          m_cols(cols)
       {}
 
       AnalyticMatrixFunction(const AnalyticMatrixFunction& other)
         : Parent(other),
-          m_f(other.m_f), m_rows(other.m_rows), m_cols(other.m_cols)
+          m_f(other.m_f),
+          m_rows(other.m_rows),
+          m_cols(other.m_cols)
       {}
 
       AnalyticMatrixFunction(AnalyticMatrixFunction&& other)
         : Parent(std::move(other)),
           m_f(std::move(other.m_f)),
-          m_rows(other.m_rows), m_cols(other.m_cols)
+          m_rows(other.m_rows),
+          m_cols(other.m_cols)
       {}
 
       RangeType getValue(const Geometry::Point& p) const
@@ -134,15 +147,24 @@ namespace Rodin::Adaptation
         return m_f(p);
       }
 
-      std::size_t getRows() const noexcept { return m_rows; }
-      std::size_t getColumns() const noexcept { return m_cols; }
+      std::size_t getRows() const noexcept
+      {
+        return m_rows;
+      }
+      std::size_t getColumns() const noexcept
+      {
+        return m_cols;
+      }
 
-      Optional<std::size_t>
-      getOrder(const Geometry::Polytope&) const noexcept
-      { return std::nullopt; }
+      Optional<std::size_t> getOrder(const Geometry::Polytope&) const noexcept
+      {
+        return std::nullopt;
+      }
 
       AnalyticMatrixFunction* copy() const noexcept override
-      { return new AnalyticMatrixFunction(*this); }
+      {
+        return new AnalyticMatrixFunction(*this);
+      }
 
     private:
       F m_f;
@@ -151,8 +173,7 @@ namespace Rodin::Adaptation
   };
 
   template <class F>
-  AnalyticMatrixFunction(F, std::size_t, std::size_t)
-    -> AnalyticMatrixFunction<F>;
+  AnalyticMatrixFunction(F, std::size_t, std::size_t) -> AnalyticMatrixFunction<F>;
 }
 
 #endif

--- a/src/Rodin/Adaptation/CellGeomCache.h
+++ b/src/Rodin/Adaptation/CellGeomCache.h
@@ -56,17 +56,17 @@ namespace Rodin::Adaptation
    */
   struct CellGeomCache
   {
-    Index index = 0;
-    Real area = 0;                    ///< |K|
-    Real detAK = 0;                   ///< signed det(A_K), constant on K
-    Real Jscale = 0;                  ///< (1/|Khat|) integral |det A_K| dxhat
-    int  sigmaK = 1;                  ///< verified sign(det A_K(xhat_q))
-    Math::SpatialMatrix<Real> A;      ///< A_K = D F_K
-    Math::SpatialMatrix<Real> Ainv;   ///< A_K^{-1}
-    Math::SpatialMatrix<Real> AinvT;  ///< A_K^{-T}
-    Math::SpatialMatrix<Real> C;      ///< A_K A_K^T
-    Math::Matrix<Real> gradN;         ///< 3x2: rows are spatial grads of P1 basis
-    std::array<Index, 3> vertices = {{ 0, 0, 0 }};
+      Index index = 0;
+      Real area = 0;                    ///< |K|
+      Real detAK = 0;                   ///< signed det(A_K), constant on K
+      Real Jscale = 0;                  ///< (1/|Khat|) integral |det A_K| dxhat
+      int sigmaK = 1;                  ///< verified sign(det A_K(xhat_q))
+      Math::SpatialMatrix<Real> A;      ///< A_K = D F_K
+      Math::SpatialMatrix<Real> Ainv;   ///< A_K^{-1}
+      Math::SpatialMatrix<Real> AinvT;  ///< A_K^{-T}
+      Math::SpatialMatrix<Real> C;      ///< A_K A_K^T
+      Math::Matrix<Real> gradN;         ///< 3x2: rows are spatial grads of P1 basis
+      std::array<Index, 3> vertices = {{0, 0, 0}};
   };
 
   /**
@@ -82,8 +82,7 @@ namespace Rodin::Adaptation
    * (which would mean a curved or inverted element; this 2D affine
    * prototype rejects them).
    */
-  inline std::pair<std::vector<CellGeomCache>,
-                   std::unordered_map<Index, size_t>>
+  inline std::pair<std::vector<CellGeomCache>, std::unordered_map<Index, size_t>>
   precomputeCellGeometry(const Geometry::Mesh<Rodin::Context::Local>& mesh)
   {
     std::vector<CellGeomCache> cache;
@@ -100,13 +99,11 @@ namespace Rodin::Adaptation
       for (size_t i = 0; i < 3; ++i)
         c.vertices[i] = vertices[i];
 
-      const auto& qf =
-        QF::PolytopeQuadratureFormula::get(2, cell.getGeometry());
+      const auto& qf = QF::PolytopeQuadratureFormula::get(2, cell.getGeometry());
       const auto& quadrature = cell.getQuadrature(qf);
       const size_t nqp = quadrature.getSize();
       if (nqp == 0)
-        throw std::runtime_error(
-            "precomputeCellGeometry: cell quadrature is empty.");
+        throw std::runtime_error("precomputeCellGeometry: cell quadrature is empty.");
 
       Real khatMeasure = 0;
       Real integralAbsDetA = 0;
@@ -122,16 +119,16 @@ namespace Rodin::Adaptation
         const Real detAq = Aq.determinant();
         if (detAq == Real(0))
           throw std::runtime_error(
-              "precomputeCellGeometry: degenerate A_K(xhat_q) at cell "
-              + std::to_string(c.index));
+            "precomputeCellGeometry: degenerate A_K(xhat_q) at cell " +
+            std::to_string(c.index));
         const int sigmaq = detAq > 0 ? 1 : -1;
         if (q == 0)
           sigmaFirst = sigmaq;
         else if (sigmaq != sigmaFirst)
-          throw std::runtime_error(
-              "precomputeCellGeometry: sigma_Kq inconsistent across "
-              "quadrature points at cell " + std::to_string(c.index)
-              + " (the 2D affine prototype rejects curved/inverted cells).");
+          throw std::runtime_error("precomputeCellGeometry: sigma_Kq inconsistent across "
+                                   "quadrature points at cell " +
+            std::to_string(c.index) +
+            " (the 2D affine prototype rejects curved/inverted cells).");
         integralAbsDetA += wq * std::abs(detAq);
       }
       c.sigmaK = sigmaFirst;

--- a/src/Rodin/Adaptation/WNGIRAdmissibility.h
+++ b/src/Rodin/Adaptation/WNGIRAdmissibility.h
@@ -24,23 +24,19 @@ namespace Rodin::Adaptation
 {
   struct WNGIRAdmissibilityReport
   {
-    Real minJ = std::numeric_limits<Real>::infinity();
-    std::size_t inadmissibleCount = 0;
-    Real maxQRel = Real(0);
+      Real minJ = std::numeric_limits<Real>::infinity();
+      std::size_t inadmissibleCount = 0;
+      Real maxQRel = Real(0);
   };
 
-  inline std::size_t wngirAdmissibilityQuadratureOrder(
-      std::size_t feOrder)
+  inline std::size_t wngirAdmissibilityQuadratureOrder(std::size_t feOrder)
   {
     return std::max<std::size_t>(2, 2 * feOrder);
   }
 
   template <class Displacement>
-  WNGIRAdmissibilityReport evaluateWNGIRAdmissibilitySampled(
-      Displacement& u,
-      const Math::Vector<Real>& uData,
-      Real jMin,
-      std::size_t quadratureOrder = 0)
+  WNGIRAdmissibilityReport evaluateWNGIRAdmissibilitySampled(Displacement& u,
+    const Math::Vector<Real>& uData, Real jMin, std::size_t quadratureOrder = 0)
   {
     using Variational::IntegrationPoint;
     using Variational::Jacobian;
@@ -55,29 +51,25 @@ namespace Rodin::Adaptation
     const std::size_t vdim = fes.getVectorDimension();
     if (dim != vdim)
       throw std::runtime_error(
-          "evaluateWNGIRAdmissibilitySampled: displacement dimension "
-          "must equal mesh dimension.");
+        "evaluateWNGIRAdmissibilitySampled: displacement dimension "
+        "must equal mesh dimension.");
 
     auto gradU = Jacobian(uMutable);
     for (auto cellIt = mesh.getCell(); cellIt; ++cellIt)
     {
       const auto& cell = *cellIt;
-      const auto& fe =
-        fes.getFiniteElement(cell.getDimension(), cell.getIndex());
-      const auto& qf =
-        QF::PolytopeQuadratureFormula::get(
-            quadratureOrder > 0
-              ? quadratureOrder
-              : wngirAdmissibilityQuadratureOrder(fe.getOrder()),
-            cell.getGeometry());
+      const auto& fe = fes.getFiniteElement(cell.getDimension(), cell.getIndex());
+      const auto& qf = QF::PolytopeQuadratureFormula::get(quadratureOrder > 0
+          ? quadratureOrder
+          : wngirAdmissibilityQuadratureOrder(fe.getOrder()),
+        cell.getGeometry());
       const auto& quadrature = cell.getQuadrature(qf);
       for (std::size_t q = 0; q < quadrature.getSize(); ++q)
       {
         const auto& pt = quadrature.getPoint(q);
         const IntegrationPoint ip(pt, &qf, q);
         const Math::SpatialMatrix<Real> F =
-          Math::SpatialMatrix<Real>::Identity(dim, dim)
-          + gradU.getValue(ip);
+          Math::SpatialMatrix<Real>::Identity(dim, dim) + gradU.getValue(ip);
         const Real j = F.determinant();
 
         rep.minJ = std::min(rep.minJ, j);
@@ -86,10 +78,8 @@ namespace Rodin::Adaptation
 
         if (j > Real(0))
         {
-          const Real qRel =
-            F.squaredNorm()
-            / (static_cast<Real>(dim)
-               * std::pow(j, Real(2) / static_cast<Real>(dim)));
+          const Real qRel = F.squaredNorm() /
+            (static_cast<Real>(dim) * std::pow(j, Real(2) / static_cast<Real>(dim)));
           rep.maxQRel = std::max(rep.maxQRel, qRel);
         }
       }

--- a/src/Rodin/Adaptation/WNGIRAdmissibilityGradient.h
+++ b/src/Rodin/Adaptation/WNGIRAdmissibilityGradient.h
@@ -12,170 +12,157 @@
 
 namespace Rodin::Adaptation::Detail
 {
-    template <class TestFunction, class Displacement>
-    class WNGIRAdmissibilityGradient final
-      : public Variational::LinearFormIntegratorBase<
-          typename TestFunction::ScalarType>
-    {
-      public:
-        using ScalarType = typename TestFunction::ScalarType;
-        using Parent = Variational::LinearFormIntegratorBase<ScalarType>;
+  template <class TestFunction, class Displacement>
+  class WNGIRAdmissibilityGradient final
+    : public Variational::LinearFormIntegratorBase<typename TestFunction::ScalarType>
+  {
+    public:
+      using ScalarType = typename TestFunction::ScalarType;
+      using Parent = Variational::LinearFormIntegratorBase<ScalarType>;
 
-        WNGIRAdmissibilityGradient(
-            const TestFunction& v,
-            const Displacement& current,
-            const WNGIRParameters& parameters)
-          : Parent(v.getLeaf()),
-            m_v(v),
-            m_current(current),
-            m_parameters(parameters)
-        {}
+      WNGIRAdmissibilityGradient(const TestFunction& v, const Displacement& current,
+        const WNGIRParameters& parameters)
+        : Parent(v.getLeaf()),
+          m_v(v),
+          m_current(current),
+          m_parameters(parameters)
+      {}
 
-        WNGIRAdmissibilityGradient(
-            const WNGIRAdmissibilityGradient&) = default;
+      WNGIRAdmissibilityGradient(const WNGIRAdmissibilityGradient&) = default;
 
-        const Geometry::Polytope& getPolytope() const final override
+      const Geometry::Polytope& getPolytope() const final override
+      {
+        assert(m_polytope);
+        return *m_polytope;
+      }
+
+      WNGIRAdmissibilityGradient& setPolytope(
+        const Geometry::Polytope& polytope) final override
+      {
+        m_polytope = &polytope;
+
+        const std::size_t dim = polytope.getDimension();
+        const Real d = static_cast<Real>(dim);
+        const auto geometry = polytope.getGeometry();
+        const auto idx = polytope.getIndex();
+
+        const auto& testFES = m_v.getFiniteElementSpace();
+        const auto& testFE = testFES.getFiniteElement(dim, idx);
+        const std::size_t qOrder = m_parameters.get().quadratureOrder > 0
+          ? m_parameters.get().quadratureOrder
+          : std::max<std::size_t>(2, 2 * testFE.getOrder());
+        const auto& qf = QF::PolytopeQuadratureFormula::get(qOrder, geometry);
+        const auto& quad = polytope.getQuadrature(qf);
+
+        const std::size_t nte = testFE.getCount();
+        m_vector.resize(static_cast<Eigen::Index>(nte));
+        m_vector.setZero();
+
+        for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
         {
-          assert(m_polytope);
-          return *m_polytope;
-        }
-
-        WNGIRAdmissibilityGradient& setPolytope(
-            const Geometry::Polytope& polytope) final override
-        {
-          m_polytope = &polytope;
-
-          const std::size_t dim = polytope.getDimension();
-          const Real d = static_cast<Real>(dim);
-          const auto geometry = polytope.getGeometry();
-          const auto idx = polytope.getIndex();
-
-          const auto& testFES = m_v.getFiniteElementSpace();
-          const auto& testFE = testFES.getFiniteElement(dim, idx);
-          const std::size_t qOrder = m_parameters.get().quadratureOrder > 0
-            ? m_parameters.get().quadratureOrder
-            : std::max<std::size_t>(2, 2 * testFE.getOrder());
-          const auto& qf =
-            QF::PolytopeQuadratureFormula::get(qOrder, geometry);
-          const auto& quad = polytope.getQuadrature(qf);
-
-          const std::size_t nte = testFE.getCount();
-          m_vector.resize(static_cast<Eigen::Index>(nte));
-          m_vector.setZero();
-
-          for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
-          {
-            const auto& pt = quad.getPoint(qp);
-            const Variational::IntegrationPoint ip(pt, &qf, qp);
-            const Real w = qf.getWeight(qp) * pt.getDistortion();
-            const auto F =
-              deformationGradient(m_current.get(), polytope, ip, dim);
-            const Real jK = F.determinant();
-            if (std::abs(jK) < Real(1e-14))
-              continue;
-            const auto& params = m_parameters.get();
+          const auto& pt = quad.getPoint(qp);
+          const Variational::IntegrationPoint ip(pt, &qf, qp);
+          const Real w = qf.getWeight(qp) * pt.getDistortion();
+          const auto F = deformationGradient(m_current.get(), polytope, ip, dim);
+          const Real jK = F.determinant();
+          if (std::abs(jK) < Real(1e-14))
+            continue;
+          const auto& params = m_parameters.get();
             // Shape/Q terms need j > 0; size terms run for ALL j.
-            const bool shapeOK = jK > Real(0);
-            Real frob2 = 0, qK = 0, sJ0 = 0, sQ0 = 0;
-            bool jBarrierActive = false, qBarrierActive = false;
-            bool qualHingeActive = false;
-            if (shapeOK)
-            {
-              frob2 = F.squaredNorm();
-              qK = frob2 / (d * std::pow(jK, Real(2) / d));
-              sJ0 = jK - params.jSafe;
-              sQ0 = params.qMax - qK;
-              jBarrierActive =
-                (params.includeAdmissibilityGradient
-                 || params.includeQualityGradient)
-                && params.gammaJ > Real(0)
-                && sJ0 > Real(0) && sJ0 < params.s0J;
-              qBarrierActive = params.includeAdmissibilityGradient
-                && params.gammaQ > Real(0)
-                && sQ0 > Real(0) && sQ0 < params.s0Q;
-              qualHingeActive =
-                params.includeQualityGradient
-                && params.gammaQual > Real(0) && qK > params.qStar;
-            }
-            const bool sizeHingeActive =
-              params.includeQualityGradient
-              && params.gammaSize > Real(0) && jK < params.jStar;
-            if (!jBarrierActive && !qBarrierActive
-                && !qualHingeActive && !sizeHingeActive)
-              continue;
-
-            const auto Jinv = pt.getJacobianInverse();
-            const auto& rc = pt.getReferenceCoordinates();
-            const auto FinvT = F.inverse().transpose();
-            const auto dQdF = shapeOK
-              ? Math::SpatialMatrix<Real>(
-                  (Real(2) / d) * std::pow(jK, -Real(2) / d)
-                  * (F - (frob2 / d) * FinvT))
-              : makeZeroMatrix(dim);
-
-            for (std::size_t te = 0; te < nte; ++te)
-            {
-              const auto jp = physicalJacobian(testFE, te, rc, Jinv, dim);
-              Real aJ = 0;
-              Real aQ = 0;
-              for (std::size_t r = 0; r < dim; ++r)
-                for (std::size_t c = 0; c < dim; ++c)
-                {
-                  const auto rr = static_cast<Eigen::Index>(r);
-                  const auto cc = static_cast<Eigen::Index>(c);
-                  aJ += jK * FinvT(rr, cc) * jp(rr, cc);
-                  aQ += dQdF(rr, cc) * jp(rr, cc);
-                }
-
-              Real val = 0;
-              if (jBarrierActive)
-              {
-                const Real bp = -Real(1) / sJ0 + Real(1) / params.s0J;
-                val += -params.gammaJ * bp * aJ;
-              }
-              if (qBarrierActive)
-              {
-                const Real bp = -Real(1) / sQ0 + Real(1) / params.s0Q;
-                val += params.gammaQ * bp * aQ;
-              }
-              if (qualHingeActive)
-              {
-                const Real excess = qK - params.qStar;
-                val += -params.gammaQual * excess * aQ;
-              }
-              if (sizeHingeActive)
-              {
-                const Real deficit = params.jStar - jK;
-                val += params.gammaSize * deficit * aJ;
-              }
-              m_vector(static_cast<Eigen::Index>(te)) += w * val;
-            }
+          const bool shapeOK = jK > Real(0);
+          Real frob2 = 0, qK = 0, sJ0 = 0, sQ0 = 0;
+          bool jBarrierActive = false, qBarrierActive = false;
+          bool qualHingeActive = false;
+          if (shapeOK)
+          {
+            frob2 = F.squaredNorm();
+            qK = frob2 / (d * std::pow(jK, Real(2) / d));
+            sJ0 = jK - params.jSafe;
+            sQ0 = params.qMax - qK;
+            jBarrierActive =
+              (params.includeAdmissibilityGradient || params.includeQualityGradient) &&
+              params.gammaJ > Real(0) && sJ0 > Real(0) && sJ0 < params.s0J;
+            qBarrierActive = params.includeAdmissibilityGradient &&
+              params.gammaQ > Real(0) && sQ0 > Real(0) && sQ0 < params.s0Q;
+            qualHingeActive = params.includeQualityGradient &&
+              params.gammaQual > Real(0) && qK > params.qStar;
           }
-          return *this;
-        }
+          const bool sizeHingeActive = params.includeQualityGradient &&
+            params.gammaSize > Real(0) && jK < params.jStar;
+          if (!jBarrierActive && !qBarrierActive && !qualHingeActive && !sizeHingeActive)
+            continue;
 
-        ScalarType integrate(std::size_t local) final override
-        {
-          return m_vector(static_cast<Eigen::Index>(local));
-        }
+          const auto Jinv = pt.getJacobianInverse();
+          const auto& rc = pt.getReferenceCoordinates();
+          const auto FinvT = F.inverse().transpose();
+          const auto dQdF = shapeOK
+            ? Math::SpatialMatrix<Real>(
+                (Real(2) / d) * std::pow(jK, -Real(2) / d) * (F - (frob2 / d) * FinvT))
+            : makeZeroMatrix(dim);
 
-        Geometry::Region getRegion() const final override
-        {
-          return Geometry::Region::Cells;
-        }
+          for (std::size_t te = 0; te < nte; ++te)
+          {
+            const auto jp = physicalJacobian(testFE, te, rc, Jinv, dim);
+            Real aJ = 0;
+            Real aQ = 0;
+            for (std::size_t r = 0; r < dim; ++r)
+              for (std::size_t c = 0; c < dim; ++c)
+              {
+                const auto rr = static_cast<Eigen::Index>(r);
+                const auto cc = static_cast<Eigen::Index>(c);
+                aJ += jK * FinvT(rr, cc) * jp(rr, cc);
+                aQ += dQdF(rr, cc) * jp(rr, cc);
+              }
 
-        WNGIRAdmissibilityGradient* copy() const noexcept final override
-        {
-          return new WNGIRAdmissibilityGradient(*this);
+            Real val = 0;
+            if (jBarrierActive)
+            {
+              const Real bp = -Real(1) / sJ0 + Real(1) / params.s0J;
+              val += -params.gammaJ * bp * aJ;
+            }
+            if (qBarrierActive)
+            {
+              const Real bp = -Real(1) / sQ0 + Real(1) / params.s0Q;
+              val += params.gammaQ * bp * aQ;
+            }
+            if (qualHingeActive)
+            {
+              const Real excess = qK - params.qStar;
+              val += -params.gammaQual * excess * aQ;
+            }
+            if (sizeHingeActive)
+            {
+              const Real deficit = params.jStar - jK;
+              val += params.gammaSize * deficit * aJ;
+            }
+            m_vector(static_cast<Eigen::Index>(te)) += w * val;
+          }
         }
+        return *this;
+      }
 
-      private:
-        TestFunction m_v;
-        std::reference_wrapper<const Displacement> m_current;
-        std::reference_wrapper<const WNGIRParameters> m_parameters;
-        const Geometry::Polytope* m_polytope = nullptr;
-        Math::Vector<Real> m_vector;
-    };
+      ScalarType integrate(std::size_t local) final override
+      {
+        return m_vector(static_cast<Eigen::Index>(local));
+      }
+
+      Geometry::Region getRegion() const final override
+      {
+        return Geometry::Region::Cells;
+      }
+
+      WNGIRAdmissibilityGradient* copy() const noexcept final override
+      {
+        return new WNGIRAdmissibilityGradient(*this);
+      }
+
+    private:
+      TestFunction m_v;
+      std::reference_wrapper<const Displacement> m_current;
+      std::reference_wrapper<const WNGIRParameters> m_parameters;
+      const Geometry::Polytope* m_polytope = nullptr;
+      Math::Vector<Real> m_vector;
+  };
 }
 
 #endif

--- a/src/Rodin/Adaptation/WNGIRAdmissibilityMetric.h
+++ b/src/Rodin/Adaptation/WNGIRAdmissibilityMetric.h
@@ -12,213 +12,185 @@
 
 namespace Rodin::Adaptation::Detail
 {
-    template <class TrialFunction, class TestFunction, class Displacement>
-    class WNGIRAdmissibilityMetric final
-      : public Variational::LocalBilinearFormIntegratorBase<
-          typename TrialFunction::ScalarType>
-    {
-      public:
-        using ScalarType = typename TrialFunction::ScalarType;
-        using Parent =
-          Variational::LocalBilinearFormIntegratorBase<ScalarType>;
+  template <class TrialFunction, class TestFunction, class Displacement>
+  class WNGIRAdmissibilityMetric final
+    : public Variational::LocalBilinearFormIntegratorBase<
+        typename TrialFunction::ScalarType>
+  {
+    public:
+      using ScalarType = typename TrialFunction::ScalarType;
+      using Parent = Variational::LocalBilinearFormIntegratorBase<ScalarType>;
 
-        WNGIRAdmissibilityMetric(
-            const TrialFunction& du,
-            const TestFunction& v,
-            const Displacement& current,
-            const WNGIRParameters& parameters)
-          : Parent(du.getLeaf(), v.getLeaf()),
-            m_du(du),
-            m_v(v),
-            m_current(current),
-            m_parameters(parameters)
-        {}
+      WNGIRAdmissibilityMetric(const TrialFunction& du, const TestFunction& v,
+        const Displacement& current, const WNGIRParameters& parameters)
+        : Parent(du.getLeaf(), v.getLeaf()),
+          m_du(du),
+          m_v(v),
+          m_current(current),
+          m_parameters(parameters)
+      {}
 
-        WNGIRAdmissibilityMetric(
-            const WNGIRAdmissibilityMetric&) = default;
+      WNGIRAdmissibilityMetric(const WNGIRAdmissibilityMetric&) = default;
 
-        const Geometry::Polytope& getPolytope() const final override
+      const Geometry::Polytope& getPolytope() const final override
+      {
+        assert(m_polytope);
+        return *m_polytope;
+      }
+
+      WNGIRAdmissibilityMetric& setPolytope(
+        const Geometry::Polytope& polytope) final override
+      {
+        m_polytope = &polytope;
+
+        const std::size_t dim = polytope.getDimension();
+        const Real d = static_cast<Real>(dim);
+        const auto geometry = polytope.getGeometry();
+        const auto idx = polytope.getIndex();
+
+        const auto& trialFES = m_du.getFiniteElementSpace();
+        const auto& testFES = m_v.getFiniteElementSpace();
+        const auto& trialFE = trialFES.getFiniteElement(dim, idx);
+        const auto& testFE = testFES.getFiniteElement(dim, idx);
+        const auto& params = m_parameters.get();
+        const std::size_t qOrder = params.quadratureOrder > 0
+          ? params.quadratureOrder
+          : std::max<std::size_t>(2, 2 * trialFE.getOrder());
+        const auto& qf = QF::PolytopeQuadratureFormula::get(qOrder, geometry);
+        const auto& quad = polytope.getQuadrature(qf);
+
+        const std::size_t ntr = trialFE.getCount();
+        const std::size_t nte = testFE.getCount();
+        m_matrix.resize(static_cast<Eigen::Index>(nte), static_cast<Eigen::Index>(ntr));
+        m_matrix.setZero();
+
+        for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
         {
-          assert(m_polytope);
-          return *m_polytope;
-        }
-
-        WNGIRAdmissibilityMetric& setPolytope(
-            const Geometry::Polytope& polytope) final override
-        {
-          m_polytope = &polytope;
-
-          const std::size_t dim = polytope.getDimension();
-          const Real d = static_cast<Real>(dim);
-          const auto geometry = polytope.getGeometry();
-          const auto idx = polytope.getIndex();
-
-          const auto& trialFES = m_du.getFiniteElementSpace();
-          const auto& testFES = m_v.getFiniteElementSpace();
-          const auto& trialFE = trialFES.getFiniteElement(dim, idx);
-          const auto& testFE = testFES.getFiniteElement(dim, idx);
-          const auto& params = m_parameters.get();
-          const std::size_t qOrder = params.quadratureOrder > 0
-            ? params.quadratureOrder
-            : std::max<std::size_t>(2, 2 * trialFE.getOrder());
-          const auto& qf =
-            QF::PolytopeQuadratureFormula::get(qOrder, geometry);
-          const auto& quad = polytope.getQuadrature(qf);
-
-          const std::size_t ntr = trialFE.getCount();
-          const std::size_t nte = testFE.getCount();
-          m_matrix.resize(
-              static_cast<Eigen::Index>(nte),
-              static_cast<Eigen::Index>(ntr));
-          m_matrix.setZero();
-
-          for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
-          {
-            const auto& pt = quad.getPoint(qp);
-            const Variational::IntegrationPoint ip(pt, &qf, qp);
-            const Real w = qf.getWeight(qp) * pt.getDistortion();
-            const auto F =
-              deformationGradient(m_current.get(), polytope, ip, dim);
-            const Real jK = F.determinant();
+          const auto& pt = quad.getPoint(qp);
+          const Variational::IntegrationPoint ip(pt, &qf, qp);
+          const Real w = qf.getWeight(qp) * pt.getDistortion();
+          const auto F = deformationGradient(m_current.get(), polytope, ip, dim);
+          const Real jK = F.determinant();
             // Near-singular: cofactor via inverse is unreliable; skip.
-            if (std::abs(jK) < Real(1e-14))
-              continue;
+          if (std::abs(jK) < Real(1e-14))
+            continue;
             // Shape terms (Q_rel and its barriers/hinge) need j > 0; the
             // size hinge needs only j and a_j, so it runs for ALL j —
             // including inverted cells, which it pulls back to validity.
-            const bool shapeOK = jK > Real(0);
-            Real frob2 = 0;
-            Real qK = 0;
-            Real sJ0 = 0, sQ0 = 0;
-            bool jActive = false, qActive = false, qualActive = false;
-            if (shapeOK)
-            {
-              frob2 = F.squaredNorm();
-              qK = frob2 / (d * std::pow(jK, Real(2) / d));
-              sJ0 = jK - params.jSafe;
-              sQ0 = params.qMax - qK;
-              jActive = params.includeAdmissibilityMetric
-                && params.gammaJ > Real(0)
-                && sJ0 > Real(0) && sJ0 < params.s0J;
-              qActive = params.includeAdmissibilityMetric
-                && params.gammaQ > Real(0)
-                && sQ0 > Real(0) && sQ0 < params.s0Q;
-              qualActive = params.includeQualityMetric
-                && params.gammaQual > Real(0) && qK > params.qStar;
-            }
-            const bool sizeActive =
-              params.includeQualityMetric
-              && params.gammaSize > Real(0) && jK < params.jStar;
-            if (!jActive && !qActive && !qualActive && !sizeActive)
-              continue;
-
-            const auto Jinv = pt.getJacobianInverse();
-            const auto& rc = pt.getReferenceCoordinates();
-            const auto FinvT = F.inverse().transpose();
-            const auto dQdF = shapeOK
-              ? Math::SpatialMatrix<Real>(
-                  (Real(2) / d) * std::pow(jK, -Real(2) / d)
-                  * (F - (frob2 / d) * FinvT))
-              : makeZeroMatrix(dim);
-
-            std::vector<Real> aJTrial(ntr), aQTrial(ntr);
-            std::vector<Real> aJTest(nte), aQTest(nte);
-            auto fillActions =
-              [&](const auto& fe, std::vector<Real>& aJ, std::vector<Real>& aQ)
-            {
-              for (std::size_t l = 0; l < fe.getCount(); ++l)
-              {
-                const auto jp = physicalJacobian(fe, l, rc, Jinv, dim);
-                Real accJ = 0;
-                Real accQ = 0;
-                for (std::size_t r = 0; r < dim; ++r)
-                  for (std::size_t c = 0; c < dim; ++c)
-                  {
-                    const auto rr = static_cast<Eigen::Index>(r);
-                    const auto cc = static_cast<Eigen::Index>(c);
-                    accJ += jK * FinvT(rr, cc) * jp(rr, cc);
-                    accQ += dQdF(rr, cc) * jp(rr, cc);
-                  }
-                aJ[l] = accJ;
-                aQ[l] = accQ;
-              }
-            };
-            fillActions(trialFE, aJTrial, aQTrial);
-            fillActions(testFE, aJTest, aQTest);
-
-            if (jActive)
-            {
-              const Real bpp = Real(1) / (sJ0 * sJ0);
-              for (std::size_t te = 0; te < nte; ++te)
-                for (std::size_t tr = 0; tr < ntr; ++tr)
-                  m_matrix(
-                      static_cast<Eigen::Index>(te),
-                      static_cast<Eigen::Index>(tr))
-                    += w * params.gammaJ * bpp
-                    * aJTrial[tr] * aJTest[te];
-            }
-            if (qActive)
-            {
-              const Real bpp = Real(1) / (sQ0 * sQ0);
-              for (std::size_t te = 0; te < nte; ++te)
-                for (std::size_t tr = 0; tr < ntr; ++tr)
-                  m_matrix(
-                      static_cast<Eigen::Index>(te),
-                      static_cast<Eigen::Index>(tr))
-                    += w * params.gammaQ * bpp
-                    * aQTrial[tr] * aQTest[te];
-            }
-            if (qualActive)
-            {
-              // Gauss–Newton Hessian of the quality hinge: ρ''(Q)=1.
-              for (std::size_t te = 0; te < nte; ++te)
-                for (std::size_t tr = 0; tr < ntr; ++tr)
-                  m_matrix(
-                      static_cast<Eigen::Index>(te),
-                      static_cast<Eigen::Index>(tr))
-                    += w * params.gammaQual
-                    * aQTrial[tr] * aQTest[te];
-            }
-            if (sizeActive)
-            {
-              // GN Hessian of the size hinge: ρ''(j)=1 for j < jStar.
-              for (std::size_t te = 0; te < nte; ++te)
-                for (std::size_t tr = 0; tr < ntr; ++tr)
-                  m_matrix(
-                      static_cast<Eigen::Index>(te),
-                      static_cast<Eigen::Index>(tr))
-                    += w * params.gammaSize
-                    * aJTrial[tr] * aJTest[te];
-            }
+          const bool shapeOK = jK > Real(0);
+          Real frob2 = 0;
+          Real qK = 0;
+          Real sJ0 = 0, sQ0 = 0;
+          bool jActive = false, qActive = false, qualActive = false;
+          if (shapeOK)
+          {
+            frob2 = F.squaredNorm();
+            qK = frob2 / (d * std::pow(jK, Real(2) / d));
+            sJ0 = jK - params.jSafe;
+            sQ0 = params.qMax - qK;
+            jActive = params.includeAdmissibilityMetric && params.gammaJ > Real(0) &&
+              sJ0 > Real(0) && sJ0 < params.s0J;
+            qActive = params.includeAdmissibilityMetric && params.gammaQ > Real(0) &&
+              sQ0 > Real(0) && sQ0 < params.s0Q;
+            qualActive = params.includeQualityMetric && params.gammaQual > Real(0) &&
+              qK > params.qStar;
           }
-          return *this;
-        }
+          const bool sizeActive = params.includeQualityMetric &&
+            params.gammaSize > Real(0) && jK < params.jStar;
+          if (!jActive && !qActive && !qualActive && !sizeActive)
+            continue;
 
-        ScalarType integrate(std::size_t tr, std::size_t te) final override
-        {
-          return m_matrix(
-              static_cast<Eigen::Index>(te),
-              static_cast<Eigen::Index>(tr));
-        }
+          const auto Jinv = pt.getJacobianInverse();
+          const auto& rc = pt.getReferenceCoordinates();
+          const auto FinvT = F.inverse().transpose();
+          const auto dQdF = shapeOK
+            ? Math::SpatialMatrix<Real>(
+                (Real(2) / d) * std::pow(jK, -Real(2) / d) * (F - (frob2 / d) * FinvT))
+            : makeZeroMatrix(dim);
 
-        Geometry::Region getRegion() const final override
-        {
-          return Geometry::Region::Cells;
-        }
+          std::vector<Real> aJTrial(ntr), aQTrial(ntr);
+          std::vector<Real> aJTest(nte), aQTest(nte);
+          auto fillActions = [&](const auto& fe, std::vector<Real>& aJ,
+                               std::vector<Real>& aQ) {
+            for (std::size_t l = 0; l < fe.getCount(); ++l)
+            {
+              const auto jp = physicalJacobian(fe, l, rc, Jinv, dim);
+              Real accJ = 0;
+              Real accQ = 0;
+              for (std::size_t r = 0; r < dim; ++r)
+                for (std::size_t c = 0; c < dim; ++c)
+                {
+                  const auto rr = static_cast<Eigen::Index>(r);
+                  const auto cc = static_cast<Eigen::Index>(c);
+                  accJ += jK * FinvT(rr, cc) * jp(rr, cc);
+                  accQ += dQdF(rr, cc) * jp(rr, cc);
+                }
+              aJ[l] = accJ;
+              aQ[l] = accQ;
+            }
+          };
+          fillActions(trialFE, aJTrial, aQTrial);
+          fillActions(testFE, aJTest, aQTest);
 
-        WNGIRAdmissibilityMetric* copy() const noexcept final override
-        {
-          return new WNGIRAdmissibilityMetric(*this);
+          if (jActive)
+          {
+            const Real bpp = Real(1) / (sJ0 * sJ0);
+            for (std::size_t te = 0; te < nte; ++te)
+              for (std::size_t tr = 0; tr < ntr; ++tr)
+                m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr)) +=
+                  w * params.gammaJ * bpp * aJTrial[tr] * aJTest[te];
+          }
+          if (qActive)
+          {
+            const Real bpp = Real(1) / (sQ0 * sQ0);
+            for (std::size_t te = 0; te < nte; ++te)
+              for (std::size_t tr = 0; tr < ntr; ++tr)
+                m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr)) +=
+                  w * params.gammaQ * bpp * aQTrial[tr] * aQTest[te];
+          }
+          if (qualActive)
+          {
+              // Gauss–Newton Hessian of the quality hinge: ρ''(Q)=1.
+            for (std::size_t te = 0; te < nte; ++te)
+              for (std::size_t tr = 0; tr < ntr; ++tr)
+                m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr)) +=
+                  w * params.gammaQual * aQTrial[tr] * aQTest[te];
+          }
+          if (sizeActive)
+          {
+              // GN Hessian of the size hinge: ρ''(j)=1 for j < jStar.
+            for (std::size_t te = 0; te < nte; ++te)
+              for (std::size_t tr = 0; tr < ntr; ++tr)
+                m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr)) +=
+                  w * params.gammaSize * aJTrial[tr] * aJTest[te];
+          }
         }
+        return *this;
+      }
 
-      private:
-        TrialFunction m_du;
-        TestFunction m_v;
-        std::reference_wrapper<const Displacement> m_current;
-        std::reference_wrapper<const WNGIRParameters> m_parameters;
-        const Geometry::Polytope* m_polytope = nullptr;
-        Math::Matrix<Real> m_matrix;
-    };
+      ScalarType integrate(std::size_t tr, std::size_t te) final override
+      {
+        return m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr));
+      }
+
+      Geometry::Region getRegion() const final override
+      {
+        return Geometry::Region::Cells;
+      }
+
+      WNGIRAdmissibilityMetric* copy() const noexcept final override
+      {
+        return new WNGIRAdmissibilityMetric(*this);
+      }
+
+    private:
+      TrialFunction m_du;
+      TestFunction m_v;
+      std::reference_wrapper<const Displacement> m_current;
+      std::reference_wrapper<const WNGIRParameters> m_parameters;
+      const Geometry::Polytope* m_polytope = nullptr;
+      Math::Matrix<Real> m_matrix;
+  };
 }
 
 #endif

--- a/src/Rodin/Adaptation/WNGIRDetail.h
+++ b/src/Rodin/Adaptation/WNGIRDetail.h
@@ -15,10 +15,8 @@ namespace Rodin::Adaptation
 {
   namespace Detail
   {
-    inline Real referenceCellMargin(
-        Geometry::Polytope::Type geometry,
-        const Math::SpatialPoint& rc,
-        std::size_t& mostViolatedFace)
+    inline Real referenceCellMargin(Geometry::Polytope::Type geometry,
+      const Math::SpatialPoint& rc, std::size_t& mostViolatedFace)
     {
       const Geometry::Polytope::Traits traits(geometry);
       const auto& hs = traits.getHalfSpace();
@@ -36,30 +34,24 @@ namespace Rodin::Adaptation
       return margin;
     }
 
-    inline Geometry::Point makeTranslatedPoint(
-        const Geometry::Point& source,
-        const Math::SpatialVector<Real>& yPhysical,
-        Real tolerance)
+    inline Geometry::Point makeTranslatedPoint(const Geometry::Point& source,
+      const Math::SpatialVector<Real>& yPhysical, Real tolerance)
     {
       const auto& sourcePolytope = source.getPolytope();
       const auto& mesh = sourcePolytope.getMesh();
       const std::size_t cd = mesh.getDimension();
       const auto& conn = mesh.getConnectivity();
-      const Real tol = tolerance > Real(0)
-        ? tolerance
-        : Real(64) * std::numeric_limits<Real>::epsilon();
+      const Real tol =
+        tolerance > Real(0) ? tolerance : Real(64) * std::numeric_limits<Real>::epsilon();
 
       Index cell = Index(-1);
       Math::SpatialPoint rc;
 
-      auto cellMargin =
-        [&](Index candidate, Math::SpatialPoint& out) -> Real
-        {
-          mesh.getPolytopeTransformation(cd, candidate).inverse(
-              out, yPhysical);
-          std::size_t face = 0;
-          return referenceCellMargin(mesh.getGeometry(cd, candidate), out, face);
-        };
+      auto cellMargin = [&](Index candidate, Math::SpatialPoint& out) -> Real {
+        mesh.getPolytopeTransformation(cd, candidate).inverse(out, yPhysical);
+        std::size_t face = 0;
+        return referenceCellMargin(mesh.getGeometry(cd, candidate), out, face);
+      };
 
       if (sourcePolytope.getDimension() == cd)
       {
@@ -72,7 +64,7 @@ namespace Rodin::Adaptation
         const auto& adjacent = conn.getIncidence(cd - 1, cd).at(face);
         if (adjacent.empty())
           throw std::runtime_error(
-              "WNGIR translated-point evaluation failed: face has no adjacent cell.");
+            "WNGIR translated-point evaluation failed: face has no adjacent cell.");
 
         Real bestMargin = -std::numeric_limits<Real>::infinity();
         Math::SpatialPoint bestRc;
@@ -92,7 +84,7 @@ namespace Rodin::Adaptation
       else
       {
         throw std::runtime_error(
-            "WNGIR translated-point evaluation requires a cell or face source point.");
+          "WNGIR translated-point evaluation requires a cell or face source point.");
       }
 
       for (std::size_t hop = 0; hop < 64; ++hop)
@@ -100,8 +92,8 @@ namespace Rodin::Adaptation
         mesh.getPolytopeTransformation(cd, cell).inverse(rc, yPhysical);
 
         std::size_t mostViolatedFace = 0;
-        const Real margin = referenceCellMargin(
-            mesh.getGeometry(cd, cell), rc, mostViolatedFace);
+        const Real margin =
+          referenceCellMargin(mesh.getGeometry(cd, cell), rc, mostViolatedFace);
         if (margin >= -tol)
         {
           const auto it = mesh.getPolytope(cd, cell);
@@ -132,18 +124,14 @@ namespace Rodin::Adaptation
     }
 
     template <class Function, class Vector>
-    decltype(auto) evaluateTranslatedPoint(
-        const Function& f,
-        const Geometry::Point& source,
-        const Vector& displacement,
-        Real tolerance)
+    decltype(auto) evaluateTranslatedPoint(const Function& f,
+      const Geometry::Point& source, const Vector& displacement, Real tolerance)
     {
       Math::SpatialVector<Real> y(source.getPolytope().getMesh().getDimension());
       const auto& x = source.getPhysicalCoordinates();
       for (std::size_t r = 0; r < static_cast<std::size_t>(y.size()); ++r)
         y(static_cast<Eigen::Index>(r)) =
-          x(static_cast<Eigen::Index>(r))
-          + displacement(static_cast<Eigen::Index>(r));
+          x(static_cast<Eigen::Index>(r)) + displacement(static_cast<Eigen::Index>(r));
       const auto p = makeTranslatedPoint(source, y, tolerance);
       if constexpr (requires { f.getValue(p); })
         return f.getValue(p);
@@ -159,20 +147,16 @@ namespace Rodin::Adaptation
     }
 
     template <class FE, class ReferencePoint, class JacobianInverse>
-    Math::SpatialMatrix<Real> physicalJacobian(
-        const FE& fe,
-        std::size_t local,
-        const ReferencePoint& rc,
-        const JacobianInverse& Jinv,
-        std::size_t dim)
+    Math::SpatialMatrix<Real> physicalJacobian(const FE& fe, std::size_t local,
+      const ReferencePoint& rc, const JacobianInverse& Jinv, std::size_t dim)
     {
       const auto jref = fe.getBasis(local).getJacobian()(rc);
       auto jp = makeZeroMatrix(dim);
       for (std::size_t r = 0; r < dim; ++r)
         for (std::size_t c = 0; c < dim; ++c)
           for (std::size_t a = 0; a < dim; ++a)
-            jp(static_cast<Eigen::Index>(r), static_cast<Eigen::Index>(c))
-              += jref(r, a) * Jinv(a, c);
+            jp(static_cast<Eigen::Index>(r), static_cast<Eigen::Index>(c)) +=
+              jref(r, a) * Jinv(a, c);
       return jp;
     }
 
@@ -180,15 +164,12 @@ namespace Rodin::Adaptation
     // gradient so it is backend-independent (Eigen or PETSc-backed coefficients
     // alike); the cached interpolation matches the explicit basis contraction.
     template <class Displacement>
-    Math::SpatialMatrix<Real> deformationGradient(
-        const Displacement& u,
-        const Geometry::Polytope& polytope,
-        const Variational::IntegrationPoint& ip,
-        std::size_t dim)
+    Math::SpatialMatrix<Real> deformationGradient(const Displacement& u,
+      const Geometry::Polytope& polytope, const Variational::IntegrationPoint& ip,
+      std::size_t dim)
     {
-      (void) polytope;
-      Math::SpatialMatrix<Real> F =
-        Math::SpatialMatrix<Real>::Identity(dim, dim);
+      (void)polytope;
+      Math::SpatialMatrix<Real> F = Math::SpatialMatrix<Real>::Identity(dim, dim);
       F += Variational::Jacobian(u).getValue(ip);
       return F;
     }

--- a/src/Rodin/Adaptation/WNGIRParameters.h
+++ b/src/Rodin/Adaptation/WNGIRParameters.h
@@ -13,71 +13,71 @@ namespace Rodin::Adaptation
 {
   struct WNGIRParameters
   {
-    Real h = 0;                 ///< reference mesh size (required).
-    Real gammaM = 0;            ///< L² weight; ≤0 ⇒ 1/h.
-    Real gammaH = 0;            ///< deviatoric-strain weight; ≤0 ⇒ 1/h.
-    Real gammaDiv = 0;          ///< divergence weight; ≤0 ⇒ gammaH.
-    Real ellM = 0;              ///< Sobolev length; ≤0 ⇒ 3h.
-    Real gammaObs = 1;          ///< surface observation metric weight.
-    bool residualStabilizedObservationMetric = true;
-    Real gammaJ = 1;            ///< j-barrier weight.
-    Real gammaQ = 1;            ///< Q-barrier weight.
-    Real jSafe = 1e-2;          ///< barrier floor on j.
-    Real qMax = 10;             ///< barrier + line-search ceiling on Q.
-    Real s0J = 0.25;            ///< j-barrier activation width.
-    Real s0Q = 2;               ///< Q-barrier activation width.
+      Real h = 0;                 ///< reference mesh size (required).
+      Real gammaM = 0;            ///< L² weight; ≤0 ⇒ 1/h.
+      Real gammaH = 0;            ///< deviatoric-strain weight; ≤0 ⇒ 1/h.
+      Real gammaDiv = 0;          ///< divergence weight; ≤0 ⇒ gammaH.
+      Real ellM = 0;              ///< Sobolev length; ≤0 ⇒ 3h.
+      Real gammaObs = 1;          ///< surface observation metric weight.
+      bool residualStabilizedObservationMetric = true;
+      Real gammaJ = 1;            ///< j-barrier weight.
+      Real gammaQ = 1;            ///< Q-barrier weight.
+      Real jSafe = 1e-2;          ///< barrier floor on j.
+      Real qMax = 10;             ///< barrier + line-search ceiling on Q.
+      Real s0J = 0.25;            ///< j-barrier activation width.
+      Real s0Q = 2;               ///< Q-barrier activation width.
     /// One-sided relative-distortion quality hinge:
     ///   E_Q(u) = gammaQual/2 ∫ max(Q_rel(F_u)-qStar,0)^2 dX.
     /// By default this contributes to the energy/RHS only, not to the metric.
     /// Set includeQualityMetric=true to also add the Gauss--Newton metric
     ///   K_Q(v,z) = gammaQual ∫_{Q_rel>qStar} a_Q(v) a_Q(z) dX.
     /// gammaQual ≤ 0 disables the Q hinge.
-    Real gammaQual = 1;
-    Real qStar = Real(1.75);
+      Real gammaQual = 1;
+      Real qStar = Real(1.75);
     /// Optional one-sided size hinge:
     ///   K_j(v,z) = gammaSize ∫_{j<jStar} a_j(v) a_j(z) dX.
     /// Disabled by default. Inversion is handled by the near-zero j barrier
     /// and the true-geometry line search, allowing small well-shaped cells.
-    Real gammaSize = 0;
-    Real jStar = Real(0.3);
-    Real omegaMin = 0.1;        ///< active-set threshold on ω.
-    Real alphaMin = 1e-4;       ///< line-search floor.
-    bool energyLineSearch = true;
-    Real jMinRatio = 1e-8;      ///< hard inadmissibility floor.
-    Real jLineSearchRatio = 1e-2;
-    Real activeRMSTol = 0;      ///< ≤0 ⇒ 4h².
-    Real activeSupTol = 0;      ///< ≤0 ⇒ 10h².
-    Real activeRMSOverHTol = 0; ///< >0 enables scale-aware RMS stopping.
-    Real activeSupOverHTol = 0; ///< >0 enables scale-aware sup stopping.
-    Real energyStagTol = 1e-4;
-    Real stepTol = 0;           ///< ≤0 ⇒ 1e-4·h.
-    Real pointLocationTolerance = 0; ///< ≤0 ⇒ 1e-10 for moved FE evaluation.
-    Real cgRelativeTolerance = 1e-6; ///< relative residual tolerance for CG.
-    std::size_t cgMaxIterations = 0; ///< 0 ⇒ min(2000, max(100, 2*ndofs)).
-    std::size_t andersonMemory = 3;  ///< 0 disables safeguarded Anderson.
-    std::size_t andersonStart = 2;   ///< first iteration where AA may be used.
-    Real andersonDamping = 1;        ///< first AA damping trial.
-    Real andersonMinDamping = 0.125; ///< smallest AA damping trial.
-    std::size_t maxIterations = 200;
-    std::size_t quadratureOrder = 0; ///< 0 ⇒ 2·(FE order).
-    bool hasInterfaceAttribute = false;
-    Geometry::Attribute interfaceAttribute = 0;
-    bool trace = false;
+      Real gammaSize = 0;
+      Real jStar = Real(0.3);
+      Real omegaMin = 0.1;        ///< active-set threshold on ω.
+      Real alphaMin = 1e-4;       ///< line-search floor.
+      bool energyLineSearch = true;
+      Real jMinRatio = 1e-8;      ///< hard inadmissibility floor.
+      Real jLineSearchRatio = 1e-2;
+      Real activeRMSTol = 0;      ///< ≤0 ⇒ 4h².
+      Real activeSupTol = 0;      ///< ≤0 ⇒ 10h².
+      Real activeRMSOverHTol = 0; ///< >0 enables scale-aware RMS stopping.
+      Real activeSupOverHTol = 0; ///< >0 enables scale-aware sup stopping.
+      Real energyStagTol = 1e-4;
+      Real stepTol = 0;           ///< ≤0 ⇒ 1e-4·h.
+      Real pointLocationTolerance = 0; ///< ≤0 ⇒ 1e-10 for moved FE evaluation.
+      Real cgRelativeTolerance = 1e-6; ///< relative residual tolerance for CG.
+      std::size_t cgMaxIterations = 0; ///< 0 ⇒ min(2000, max(100, 2*ndofs)).
+      std::size_t andersonMemory = 3;  ///< 0 disables safeguarded Anderson.
+      std::size_t andersonStart = 2;   ///< first iteration where AA may be used.
+      Real andersonDamping = 1;        ///< first AA damping trial.
+      Real andersonMinDamping = 0.125; ///< smallest AA damping trial.
+      std::size_t maxIterations = 200;
+      std::size_t quadratureOrder = 0; ///< 0 ⇒ 2·(FE order).
+      bool hasInterfaceAttribute = false;
+      Geometry::Attribute interfaceAttribute = 0;
+      bool trace = false;
     /// If true, also add the nonlinear Q-barrier first variation to the RHS.
     /// The j-barrier first variation is part of the quality energy when
     /// includeQualityGradient=true.
-    bool includeAdmissibilityGradient = false;
+      bool includeAdmissibilityGradient = false;
     /// If true, add near-boundary admissibility barriers to the metric.
     /// Default false for the energy-quality model: admissibility is enforced
     /// by the true-geometry line search.
-    bool includeAdmissibilityMetric = true;
+      bool includeAdmissibilityMetric = true;
     /// If true, add E_qual to the main WNGIR RHS:
     ///   E_qual = Q_rel positive-part hinge + near-zero j barrier.
     /// Default false: quality is not an energy force.
-    bool includeQualityGradient = false;
+      bool includeQualityGradient = false;
     /// If true, add the Q_rel and optional j-size hinge Gauss--Newton terms
     /// to the metric.
-    bool includeQualityMetric = true;
+      bool includeQualityMetric = true;
     /// Optimal 1-D rescale of the lifted step along itself:
     ///   β = ⟨d, v⟩_Γ / ⟨v, v⟩_Γ  (surface inner products),
     /// clamped to [1, betaMax]; line search starts at β·v instead of
@@ -88,7 +88,7 @@ namespace Rodin::Adaptation
     /// smooth admissibility-aware shape. Since β only scales the same
     /// descent direction, the nonlinear line search remains the final
     /// admissibility and energy-decrease guard.
-    Real betaMax = 50;
+      Real betaMax = 50;
   };
 }
 

--- a/src/Rodin/Adaptation/WNGIRReport.h
+++ b/src/Rodin/Adaptation/WNGIRReport.h
@@ -13,27 +13,27 @@ namespace Rodin::Adaptation
 {
   struct WNGIRReport
   {
-    std::size_t iterations = 0;
-    Real sigma = 0;
-    Real lastAlpha = 0;
-    Real acceptedStep = 0;
-    Real minJ = 1;
-    Real maxQRel = 1;
-    Real activeRMS = 0;
-    Real activeSup = 0;
-    Real activeFraction = 0;
-    Real energy = 0;
-    const char* exitReason = "iter-budget";
+      std::size_t iterations = 0;
+      Real sigma = 0;
+      Real lastAlpha = 0;
+      Real acceptedStep = 0;
+      Real minJ = 1;
+      Real maxQRel = 1;
+      Real activeRMS = 0;
+      Real activeSup = 0;
+      Real activeFraction = 0;
+      Real energy = 0;
+      const char* exitReason = "iter-budget";
     // Wall-clock breakdown (seconds, accumulated over iterations).
-    Real tAssembly = 0;   ///< WNGIR variational problem assembly.
-    Real tFactor = 0;     ///< CG setup/preconditioner.
-    Real tSolve = 0;      ///< CG iterations.
-    Real tLineSearch = 0; ///< true-geometry admissibility + energy LS.
-    std::size_t linearIterations = 0;
-    Real linearError = 0;
-    std::size_t andersonTried = 0;
-    std::size_t andersonAccepted = 0;
-    Real lastAndersonTheta = 0;
+      Real tAssembly = 0;   ///< WNGIR variational problem assembly.
+      Real tFactor = 0;     ///< CG setup/preconditioner.
+      Real tSolve = 0;      ///< CG iterations.
+      Real tLineSearch = 0; ///< true-geometry admissibility + energy LS.
+      std::size_t linearIterations = 0;
+      Real linearError = 0;
+      std::size_t andersonTried = 0;
+      std::size_t andersonAccepted = 0;
+      Real lastAndersonTheta = 0;
   };
 }
 

--- a/src/Rodin/Adaptation/WNGIRSolver.h
+++ b/src/Rodin/Adaptation/WNGIRSolver.h
@@ -52,11 +52,9 @@ namespace Rodin::Adaptation
       using FESType = std::remove_reference_t<
         decltype(std::declval<Displacement&>().getFiniteElementSpace())>;
       using ProblemType = std::decay_t<decltype(Variational::Problem(
-          std::declval<TrialFunctionType&>(),
-          std::declval<TestFunctionType&>()))>;
+        std::declval<TrialFunctionType&>(), std::declval<TestFunctionType&>()))>;
       using BilinearFormType = std::decay_t<decltype(Variational::BilinearForm(
-          std::declval<TrialFunctionType&>(),
-          std::declval<TestFunctionType&>()))>;
+        std::declval<TrialFunctionType&>(), std::declval<TestFunctionType&>()))>;
 
       using SpatialVec = Math::SpatialVector<Real>;
       using SpatialMat = Math::SpatialMatrix<Real>;
@@ -88,11 +86,10 @@ namespace Rodin::Adaptation
       }
 
       template <class Mesh, class PhiDerived, class GradDerived>
-      WNGIRReport solve(
-          const Mesh& mesh,
-          const std::vector<Rodin::Index>& interfaceFacets,
-          const Variational::RealFunctionBase<PhiDerived>& phi,
-          const Variational::VectorFunctionBase<Real, GradDerived>& grad)
+      WNGIRReport solve(const Mesh& mesh,
+        const std::vector<Rodin::Index>& interfaceFacets,
+        const Variational::RealFunctionBase<PhiDerived>& phi,
+        const Variational::VectorFunctionBase<Real, GradDerived>& grad)
       {
         using Rodin::Index;
         const WNGIRParameters& p = m_parameters;
@@ -123,14 +120,14 @@ namespace Rodin::Adaptation
         // ============================================================
         struct FacetQP
         {
-          Real w = 0;
-          SpatialVec X;
-          Math::SpatialPoint rc;
+            Real w = 0;
+            SpatialVec X;
+            Math::SpatialPoint rc;
         };
         struct FacetTable
         {
-          Index facet = 0;
-          std::vector<FacetQP> qps;
+            Index facet = 0;
+            std::vector<FacetQP> qps;
         };
         std::vector<FacetTable> facetTables;
         facetTables.reserve(interfaceFacets.size());
@@ -163,8 +160,7 @@ namespace Rodin::Adaptation
           facetTables.push_back(std::move(ft));
         }
 
-        auto facetPoint = [&](const FacetTable& ft, const FacetQP& fq)
-        {
+        auto facetPoint = [&](const FacetTable& ft, const FacetQP& fq) {
           const auto face = mesh.getFace(ft.facet);
           return Geometry::Point(*face, fq.rc, fq.X);
         };
@@ -176,14 +172,14 @@ namespace Rodin::Adaptation
           {
             SpatialVec zero = SpatialVec::Zero(meshDim);
             const auto src = facetPoint(ft, fq);
-            r0abs.push_back(std::abs(Detail::evaluateTranslatedPoint(
-                phi, src, zero, p.pointLocationTolerance)));
+            r0abs.push_back(std::abs(
+              Detail::evaluateTranslatedPoint(phi, src, zero, p.pointLocationTolerance)));
           }
         Real sigma = Real(3) * h;
         if (!r0abs.empty())
         {
-          const std::size_t k90 = static_cast<std::size_t>(
-              Real(0.9) * static_cast<Real>(r0abs.size() - 1));
+          const std::size_t k90 =
+            static_cast<std::size_t>(Real(0.9) * static_cast<Real>(r0abs.size() - 1));
           std::nth_element(r0abs.begin(), r0abs.begin() + k90, r0abs.end());
           sigma = std::max(sigma, r0abs[k90]);
         }
@@ -198,14 +194,14 @@ namespace Rodin::Adaptation
 
         struct CellQP
         {
-          Real w = 0;
-          Math::SpatialPoint rc;
-          SpatialVec X;
+            Real w = 0;
+            Math::SpatialPoint rc;
+            SpatialVec X;
         };
         struct CellTable
         {
-          Index cell = 0;
-          std::vector<CellQP> qps;
+            Index cell = 0;
+            std::vector<CellQP> qps;
         };
         std::vector<CellTable> cellTables;
         cellTables.reserve(mesh.getCellCount());
@@ -241,17 +237,13 @@ namespace Rodin::Adaptation
         // ============================================================
         // Per-iteration field evaluations through the GridFunction.
         // ============================================================
-        auto fieldAtFacetQP =
-          [&](const Displacement& gf, const FacetTable& ft, const FacetQP& fq)
-          -> SpatialVec
-        {
+        auto fieldAtFacetQP = [&](const Displacement& gf, const FacetTable& ft,
+                                const FacetQP& fq) -> SpatialVec {
           return gf.getValue(facetPoint(ft, fq));
         };
 
-        auto deformationAtCellQP =
-          [&](const Displacement& gf, const CellTable& ct, const CellQP& cq)
-          -> SpatialMat
-        {
+        auto deformationAtCellQP = [&](const Displacement& gf, const CellTable& ct,
+                                     const CellQP& cq) -> SpatialMat {
           const auto cell = mesh.getCell(ct.cell);
           const Geometry::Point pt(*cell, cq.rc, cq.X);
           SpatialMat F = SpatialMat::Identity(meshDim, meshDim);
@@ -261,24 +253,26 @@ namespace Rodin::Adaptation
 
         struct FastAdm
         {
-          Real minJ = std::numeric_limits<Real>::infinity();
-          Real maxQ = 0;
-          std::size_t inadmissibleCount = 0;
+            Real minJ = std::numeric_limits<Real>::infinity();
+            Real maxQ = 0;
+            std::size_t inadmissibleCount = 0;
         };
-        auto fastAdmissibility = [&](const Displacement& gf)
-        {
+        auto fastAdmissibility = [&](const Displacement& gf) {
           FastAdm a;
           for (const auto& ct : cellTables)
             for (const auto& cq : ct.qps)
             {
               const SpatialMat F = deformationAtCellQP(gf, ct, cq);
               const Real j = F.determinant();
-              if (j < a.minJ) a.minJ = j;
-              if (j <= p.jMinRatio) ++a.inadmissibleCount;
+              if (j < a.minJ)
+                a.minJ = j;
+              if (j <= p.jMinRatio)
+                ++a.inadmissibleCount;
               if (j > Real(0))
               {
                 const Real q = F.squaredNorm() / (d * std::pow(j, Real(2) / d));
-                if (q > a.maxQ) a.maxQ = q;
+                if (q > a.maxQ)
+                  a.maxQ = q;
               }
             }
           return a;
@@ -286,12 +280,11 @@ namespace Rodin::Adaptation
 
         struct SurfaceState
         {
-          Real energy = 0;
-          Real activeLen = 0, totalLen = 0;
-          Real activeRMS = 0, activeSup = 0;
+            Real energy = 0;
+            Real activeLen = 0, totalLen = 0;
+            Real activeRMS = 0, activeSup = 0;
         };
-        auto surfaceState = [&](const Displacement& gf)
-        {
+        auto surfaceState = [&](const Displacement& gf) {
           SurfaceState s;
           Real sq = 0;
           for (const auto& ft : facetTables)
@@ -301,7 +294,7 @@ namespace Rodin::Adaptation
               const auto src = facetPoint(ft, fq);
               const SpatialVec displacement = y - fq.X;
               const Real r = Detail::evaluateTranslatedPoint(
-                  phi, src, displacement, p.pointLocationTolerance);
+                phi, src, displacement, p.pointLocationTolerance);
               const Real omega = std::exp(-r * r / sigma2);
               s.totalLen += fq.w;
               s.energy += fq.w * Real(0.5) * sigma2 * (Real(1) - omega);
@@ -312,15 +305,13 @@ namespace Rodin::Adaptation
                 s.activeSup = std::max(s.activeSup, std::abs(r));
               }
             }
-          s.activeRMS =
-            s.activeLen > Real(0) ? std::sqrt(sq / s.activeLen) : Real(0);
+          s.activeRMS = s.activeLen > Real(0) ? std::sqrt(sq / s.activeLen) : Real(0);
           return s;
         };
 
         Real ePrev = surfaceState(u).energy;
         using Clock = std::chrono::steady_clock;
-        auto secondsSince = [](Clock::time_point t0) -> Real
-        {
+        auto secondsSince = [](Clock::time_point t0) -> Real {
           return std::chrono::duration<Real>(Clock::now() - t0).count();
         };
 
@@ -329,22 +320,19 @@ namespace Rodin::Adaptation
         // ============================================================
         if (!m_bulkFormAssembled)
         {
-          const auto epsTrial = Real(0.5)
-            * (Variational::Jacobian(m_duStep)
-               + Variational::Jacobian(m_duStep).T());
-          const auto epsTest = Real(0.5)
-            * (Variational::Jacobian(m_vStep)
-               + Variational::Jacobian(m_vStep).T());
+          const auto epsTrial = Real(0.5) *
+            (Variational::Jacobian(m_duStep) + Variational::Jacobian(m_duStep).T());
+          const auto epsTest = Real(0.5) *
+            (Variational::Jacobian(m_vStep) + Variational::Jacobian(m_vStep).T());
           const auto divTrial = Variational::Trace(epsTrial);
           const auto divTest = Variational::Trace(epsTest);
-          const auto devTrial = epsTrial
-            - (Real(1) / d) * divTrial * Variational::IdentityMatrix(meshDim);
-          const auto devTest = epsTest
-            - (Real(1) / d) * divTest * Variational::IdentityMatrix(meshDim);
-          m_bulkForm =
-              Variational::Integral(gammaM * m_duStep, m_vStep)
-            + Variational::Integral(gammaH * ellM * ellM * devTrial, devTest)
-            + Variational::Integral(gammaDiv * ellM * ellM * divTrial, divTest);
+          const auto devTrial =
+            epsTrial - (Real(1) / d) * divTrial * Variational::IdentityMatrix(meshDim);
+          const auto devTest =
+            epsTest - (Real(1) / d) * divTest * Variational::IdentityMatrix(meshDim);
+          m_bulkForm = Variational::Integral(gammaM * m_duStep, m_vStep) +
+            Variational::Integral(gammaH * ellM * ellM * devTrial, devTest) +
+            Variational::Integral(gammaDiv * ellM * ellM * divTrial, divTest);
           m_bulkForm.assemble();
           m_bulkFormAssembled = true;
         }
@@ -360,31 +348,29 @@ namespace Rodin::Adaptation
         {
           auto tic = Clock::now();
           auto zeroBoundary = Variational::VectorFunction(
-              meshDim,
-              [&](const Geometry::Point&) { return SpatialVec::Zero(meshDim); });
+            meshDim, [&](const Geometry::Point&) { return SpatialVec::Zero(meshDim); });
 
           Detail::WNGIRAdmissibilityMetric admMetric(m_duStep, m_vStep, u, p);
           Detail::WNGIRAdmissibilityGradient admGradient(m_vStep, u, p);
           Detail::WNGIRSurfaceObservationMetric obsMetric(
-              phi, grad, m_duStep, m_vStep, u, p, sigma2);
+            phi, grad, m_duStep, m_vStep, u, p, sigma2);
           obsMetric.over(p.interfaceAttribute);
-          Detail::WNGIRSurfaceForce surfaceForce(
-              phi, grad, m_vStep, u, p, sigma2);
+          Detail::WNGIRSurfaceForce surfaceForce(phi, grad, m_vStep, u, p, sigma2);
           surfaceForce.over(p.interfaceAttribute);
 
           const bool useGradientForce =
-               p.includeAdmissibilityGradient || p.includeQualityGradient;
+            p.includeAdmissibilityGradient || p.includeQualityGradient;
 
           std::size_t linearIterations = 0;
           Real linearError = std::numeric_limits<Real>::infinity();
 
           typename ProblemType::ProblemBodyType body(m_bulkForm);
           if (useGradientForce)
-            body = body + obsMetric + admMetric - surfaceForce - admGradient
-                 + Variational::DirichletBC(m_duStep, zeroBoundary);
+            body = body + obsMetric + admMetric - surfaceForce - admGradient +
+              Variational::DirichletBC(m_duStep, zeroBoundary);
           else
-            body = body + obsMetric + admMetric - surfaceForce
-                 + Variational::DirichletBC(m_duStep, zeroBoundary);
+            body = body + obsMetric + admMetric - surfaceForce +
+              Variational::DirichletBC(m_duStep, zeroBoundary);
           m_stepProblem = body;
           m_stepProblem.assemble();
           rep.tAssembly += secondsSince(tic);
@@ -392,7 +378,11 @@ namespace Rodin::Adaptation
           tic = Clock::now();
           const bool solveOk = solveStep(vK, linearIterations, linearError);
           rep.tSolve += secondsSince(tic);
-          if (!solveOk) { rep.exitReason = "solve-linear-failed"; break; }
+          if (!solveOk)
+          {
+            rep.exitReason = "solve-linear-failed";
+            break;
+          }
 
           rep.linearIterations += linearIterations;
           rep.linearError = linearError;
@@ -417,12 +407,11 @@ namespace Rodin::Adaptation
                 const auto src = facetPoint(ft, fq);
                 const SpatialVec disp = y - fq.X;
                 const Real r = Detail::evaluateTranslatedPoint(
-                    phi, src, disp, p.pointLocationTolerance);
+                  phi, src, disp, p.pointLocationTolerance);
                 const SpatialVec g = Detail::evaluateTranslatedPoint(
-                    grad, src, disp, p.pointLocationTolerance);
-                const Real obsWeight = g.dot(g) + epsG
-                  + (p.residualStabilizedObservationMetric
-                      ? (r * r) / sigma2 : Real(0));
+                  grad, src, disp, p.pointLocationTolerance);
+                const Real obsWeight = g.dot(g) + epsG +
+                  (p.residualStabilizedObservationMetric ? (r * r) / sigma2 : Real(0));
                 const Real omega = std::exp(-r * r / sigma2);
                 const SpatialVec dVec = (-omega * r / obsWeight) * g;
                 const SpatialVec v = fieldAtFacetQP(vK, ft, fq);
@@ -433,10 +422,8 @@ namespace Rodin::Adaptation
               }
             if (gammaMeasure > Real(0))
             {
-              rawDemonsRMS =
-                std::sqrt(std::max<Real>(Real(0), dDen) / gammaMeasure);
-              liftedTraceRMS =
-                std::sqrt(std::max<Real>(Real(0), bDen) / gammaMeasure);
+              rawDemonsRMS = std::sqrt(std::max<Real>(Real(0), dDen) / gammaMeasure);
+              liftedTraceRMS = std::sqrt(std::max<Real>(Real(0), bDen) / gammaMeasure);
             }
             if (p.betaMax > Real(1) && bDen > Real(0) && std::isfinite(bNum))
             {
@@ -446,8 +433,7 @@ namespace Rodin::Adaptation
             scaledTraceRMS = beta * liftedTraceRMS;
           }
 
-          const Real maxStep =
-            std::max(std::abs(vK.max()), std::abs(vK.min()));
+          const Real maxStep = std::max(std::abs(vK.max()), std::abs(vK.min()));
           if (maxStep <= stepTol)
           {
             rep.exitReason = "best-effort-step-stagnation";
@@ -469,8 +455,7 @@ namespace Rodin::Adaptation
             uTrial *= alpha;
             uTrial += previousU;
             adm = fastAdmissibility(uTrial);
-            const bool jOK =
-              adm.inadmissibleCount == 0 && adm.minJ > p.jLineSearchRatio;
+            const bool jOK = adm.inadmissibleCount == 0 && adm.minJ > p.jLineSearchRatio;
             const bool qOK = adm.maxQ < p.qMax;
             bool eOK = true;
             if (jOK && qOK && p.energyLineSearch)
@@ -497,15 +482,14 @@ namespace Rodin::Adaptation
 
           FastAdm acceptedAdm = adm;
           SurfaceState acceptedSurf = surfaceState(u);
-          Real acceptedEnergy = p.energyLineSearch && std::isfinite(eTrial)
-            ? eTrial : acceptedSurf.energy;
+          Real acceptedEnergy =
+            p.energyLineSearch && std::isfinite(eTrial) ? eTrial : acceptedSurf.energy;
 
           rep.lastAlpha = alpha;
           // acceptedStep = max_i |u_i - previousU_i|
           scratch = u;
           scratch -= previousU;
-          rep.acceptedStep =
-            std::max(std::abs(scratch.max()), std::abs(scratch.min()));
+          rep.acceptedStep = std::max(std::abs(scratch.max()), std::abs(scratch.min()));
           rep.minJ = acceptedAdm.minJ;
           rep.maxQRel = acceptedAdm.maxQ;
 
@@ -518,38 +502,46 @@ namespace Rodin::Adaptation
           rep.energy = eNow;
           if (p.trace)
             std::cout << "      wngir it=" << std::setw(3) << rep.iterations
-                      << "  E=" << std::scientific << std::setprecision(3)
-                      << eNow
+                      << "  E=" << std::scientific << std::setprecision(3) << eNow
                       << "  actRMS=" << surf.activeRMS
-                      << "  actRMS/h="
-                      << (h > Real(0) ? surf.activeRMS / h : Real(0))
+                      << "  actRMS/h=" << (h > Real(0) ? surf.activeRMS / h : Real(0))
                       << "  actSup=" << surf.activeSup
                       << "  actFrac=" << rep.activeFraction
                       << "  dΓ/h=" << (h > Real(0) ? rawDemonsRMS / h : Real(0))
-                      << "  vΓ/h="
-                      << (h > Real(0) ? liftedTraceRMS / h : Real(0))
+                      << "  vΓ/h=" << (h > Real(0) ? liftedTraceRMS / h : Real(0))
                       << "  β=" << beta
-                      << "  step/h="
-                      << (h > Real(0) ? rep.acceptedStep / h : Real(0))
-                      << "  linIt=" << rep.linearIterations
-                      << "  α=" << alpha
-                      << "  bt=" << backtracks
-                      << "  min_j=" << rep.minJ
-                      << "  max_Q=" << rep.maxQRel
-                      << '\n';
+                      << "  step/h=" << (h > Real(0) ? rep.acceptedStep / h : Real(0))
+                      << "  linIt=" << rep.linearIterations << "  α=" << alpha
+                      << "  bt=" << backtracks << "  min_j=" << rep.minJ
+                      << "  max_Q=" << rep.maxQRel << '\n';
 
           if (surf.activeRMS <= activeRMSTol)
-          { rep.exitReason = "numerical-rms-converged"; ++rep.iterations; break; }
+          {
+            rep.exitReason = "numerical-rms-converged";
+            ++rep.iterations;
+            break;
+          }
           if (surf.activeSup <= activeSupTol)
-          { rep.exitReason = "numerical-sup-converged"; ++rep.iterations; break; }
-          if (activeRMSOverHTol > Real(0) && h > Real(0)
-              && surf.activeRMS / h <= activeRMSOverHTol)
-          { rep.exitReason = "geometric-rms-converged"; ++rep.iterations; break; }
-          if (activeSupOverHTol > Real(0) && h > Real(0)
-              && surf.activeSup / h <= activeSupOverHTol)
-          { rep.exitReason = "geometric-sup-converged"; ++rep.iterations; break; }
-          const Real eRel =
-            std::abs(ePrev - eNow) / std::max(ePrev, Real(1e-30));
+          {
+            rep.exitReason = "numerical-sup-converged";
+            ++rep.iterations;
+            break;
+          }
+          if (activeRMSOverHTol > Real(0) && h > Real(0) &&
+            surf.activeRMS / h <= activeRMSOverHTol)
+          {
+            rep.exitReason = "geometric-rms-converged";
+            ++rep.iterations;
+            break;
+          }
+          if (activeSupOverHTol > Real(0) && h > Real(0) &&
+            surf.activeSup / h <= activeSupOverHTol)
+          {
+            rep.exitReason = "geometric-sup-converged";
+            ++rep.iterations;
+            break;
+          }
+          const Real eRel = std::abs(ePrev - eNow) / std::max(ePrev, Real(1e-30));
           if (eRel < p.energyStagTol)
           {
             rep.exitReason = "best-effort-energy-stagnation";

--- a/src/Rodin/Adaptation/WNGIRSurfaceForce.h
+++ b/src/Rodin/Adaptation/WNGIRSurfaceForce.h
@@ -12,127 +12,117 @@
 
 namespace Rodin::Adaptation::Detail
 {
-    template <class PhiDerived, class GradDerived,
-              class TestFunction, class Displacement>
-    class WNGIRSurfaceForce final
-      : public Variational::LinearFormIntegratorBase<
-          typename TestFunction::ScalarType>
-    {
-      public:
-        using ScalarType = typename TestFunction::ScalarType;
-        using Parent = Variational::LinearFormIntegratorBase<ScalarType>;
-        using PhiType = Variational::RealFunctionBase<PhiDerived>;
-        using GradType = Variational::VectorFunctionBase<Real, GradDerived>;
+  template <class PhiDerived, class GradDerived, class TestFunction, class Displacement>
+  class WNGIRSurfaceForce final
+    : public Variational::LinearFormIntegratorBase<typename TestFunction::ScalarType>
+  {
+    public:
+      using ScalarType = typename TestFunction::ScalarType;
+      using Parent = Variational::LinearFormIntegratorBase<ScalarType>;
+      using PhiType = Variational::RealFunctionBase<PhiDerived>;
+      using GradType = Variational::VectorFunctionBase<Real, GradDerived>;
 
-        WNGIRSurfaceForce(
-            const PhiType& phi,
-            const GradType& grad,
-            const TestFunction& v,
-            const Displacement& current,
-            const WNGIRParameters& parameters,
-            Real sigma2)
-          : Parent(v.getLeaf()),
-            m_phi(phi.copy()),
-            m_grad(grad.copy()),
-            m_v(v),
-            m_current(current),
-            m_parameters(parameters),
-            m_sigma2(sigma2)
-        {}
+      WNGIRSurfaceForce(const PhiType& phi, const GradType& grad, const TestFunction& v,
+        const Displacement& current, const WNGIRParameters& parameters, Real sigma2)
+        : Parent(v.getLeaf()),
+          m_phi(phi.copy()),
+          m_grad(grad.copy()),
+          m_v(v),
+          m_current(current),
+          m_parameters(parameters),
+          m_sigma2(sigma2)
+      {}
 
-        WNGIRSurfaceForce(const WNGIRSurfaceForce& other)
-          : Parent(other),
-            m_phi(other.m_phi ? other.m_phi->copy() : nullptr),
-            m_grad(other.m_grad ? other.m_grad->copy() : nullptr),
-            m_v(other.m_v),
-            m_current(other.m_current),
-            m_parameters(other.m_parameters),
-            m_sigma2(other.m_sigma2),
-            m_polytope(other.m_polytope)
-        {}
+      WNGIRSurfaceForce(const WNGIRSurfaceForce& other)
+        : Parent(other),
+          m_phi(other.m_phi ? other.m_phi->copy() : nullptr),
+          m_grad(other.m_grad ? other.m_grad->copy() : nullptr),
+          m_v(other.m_v),
+          m_current(other.m_current),
+          m_parameters(other.m_parameters),
+          m_sigma2(other.m_sigma2),
+          m_polytope(other.m_polytope)
+      {}
 
-        const Geometry::Polytope& getPolytope() const final override
+      const Geometry::Polytope& getPolytope() const final override
+      {
+        assert(m_polytope);
+        return *m_polytope;
+      }
+
+      WNGIRSurfaceForce& setPolytope(const Geometry::Polytope& polytope) final override
+      {
+        m_polytope = &polytope;
+
+        const std::size_t faceDim = polytope.getDimension();
+        const Index faceIdx = polytope.getIndex();
+        const auto& testFES = m_v.getFiniteElementSpace();
+        const auto& testFE = testFES.getFiniteElement(faceDim, faceIdx);
+        const auto& params = m_parameters.get();
+        const std::size_t qOrder = params.quadratureOrder > 0
+          ? params.quadratureOrder
+          : std::max<std::size_t>(2, 2 * testFE.getOrder());
+        const auto& qf =
+          QF::PolytopeQuadratureFormula::get(qOrder, polytope.getGeometry());
+        const auto& quad = polytope.getQuadrature(qf);
+
+        const std::size_t nte = testFE.getCount();
+        m_vector.resize(static_cast<Eigen::Index>(nte));
+        m_vector.setZero();
+
+        for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
         {
-          assert(m_polytope);
-          return *m_polytope;
-        }
+          const auto& pt = quad.getPoint(qp);
+          const Variational::IntegrationPoint ip(pt, &qf, qp);
+          const Real w = qf.getWeight(qp) * pt.getDistortion();
+          const auto uq = m_current.get().getValue(ip);
+          Math::SpatialVector<Real> displacement(polytope.getMesh().getDimension());
+          displacement.setZero();
+          for (std::size_t r = 0; r < static_cast<std::size_t>(displacement.size()); ++r)
+            displacement(static_cast<Eigen::Index>(r)) = uq(r);
 
-        WNGIRSurfaceForce& setPolytope(
-            const Geometry::Polytope& polytope) final override
-        {
-          m_polytope = &polytope;
+          const auto moved = makeTranslatedPoint(pt,
+            pt.getPhysicalCoordinates() + displacement, params.pointLocationTolerance);
+          const Real r = m_phi->getValue(moved);
+          const auto g = m_grad->getValue(moved);
+          const Real omega = std::exp(-r * r / m_sigma2);
+          const auto dGamma = (-omega * r) * g;
 
-          const std::size_t faceDim = polytope.getDimension();
-          const Index faceIdx = polytope.getIndex();
-          const auto& testFES = m_v.getFiniteElementSpace();
-          const auto& testFE = testFES.getFiniteElement(faceDim, faceIdx);
-          const auto& params = m_parameters.get();
-          const std::size_t qOrder = params.quadratureOrder > 0
-            ? params.quadratureOrder
-            : std::max<std::size_t>(2, 2 * testFE.getOrder());
-          const auto& qf =
-            QF::PolytopeQuadratureFormula::get(qOrder, polytope.getGeometry());
-          const auto& quad = polytope.getQuadrature(qf);
-
-          const std::size_t nte = testFE.getCount();
-          m_vector.resize(static_cast<Eigen::Index>(nte));
-          m_vector.setZero();
-
-          for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
+          const auto& rc = pt.getReferenceCoordinates();
+          for (std::size_t te = 0; te < nte; ++te)
           {
-            const auto& pt = quad.getPoint(qp);
-            const Variational::IntegrationPoint ip(pt, &qf, qp);
-            const Real w = qf.getWeight(qp) * pt.getDistortion();
-            const auto uq = m_current.get().getValue(ip);
-            Math::SpatialVector<Real> displacement(polytope.getMesh().getDimension());
-            displacement.setZero();
-            for (std::size_t r = 0; r < static_cast<std::size_t>(displacement.size()); ++r)
-              displacement(static_cast<Eigen::Index>(r)) = uq(r);
-
-            const auto moved =
-              makeTranslatedPoint(pt, pt.getPhysicalCoordinates() + displacement,
-                                  params.pointLocationTolerance);
-            const Real r = m_phi->getValue(moved);
-            const auto g = m_grad->getValue(moved);
-            const Real omega = std::exp(-r * r / m_sigma2);
-            const auto dGamma = (-omega * r) * g;
-
-            const auto& rc = pt.getReferenceCoordinates();
-            for (std::size_t te = 0; te < nte; ++te)
-            {
-              const auto testValue = testFE.getBasis(te)(rc);
-              m_vector(static_cast<Eigen::Index>(te))
-                += w * dGamma.dot(testValue);
-            }
+            const auto testValue = testFE.getBasis(te)(rc);
+            m_vector(static_cast<Eigen::Index>(te)) += w * dGamma.dot(testValue);
           }
-          return *this;
         }
+        return *this;
+      }
 
-        ScalarType integrate(std::size_t local) final override
-        {
-          return m_vector(static_cast<Eigen::Index>(local));
-        }
+      ScalarType integrate(std::size_t local) final override
+      {
+        return m_vector(static_cast<Eigen::Index>(local));
+      }
 
-        Geometry::Region getRegion() const final override
-        {
-          return Geometry::Region::Faces;
-        }
+      Geometry::Region getRegion() const final override
+      {
+        return Geometry::Region::Faces;
+      }
 
-        WNGIRSurfaceForce* copy() const noexcept final override
-        {
-          return new WNGIRSurfaceForce(*this);
-        }
+      WNGIRSurfaceForce* copy() const noexcept final override
+      {
+        return new WNGIRSurfaceForce(*this);
+      }
 
-      private:
-        std::unique_ptr<PhiType> m_phi;
-        std::unique_ptr<GradType> m_grad;
-        TestFunction m_v;
-        std::reference_wrapper<const Displacement> m_current;
-        std::reference_wrapper<const WNGIRParameters> m_parameters;
-        Real m_sigma2;
-        const Geometry::Polytope* m_polytope = nullptr;
-        Math::Vector<Real> m_vector;
-    };
+    private:
+      std::unique_ptr<PhiType> m_phi;
+      std::unique_ptr<GradType> m_grad;
+      TestFunction m_v;
+      std::reference_wrapper<const Displacement> m_current;
+      std::reference_wrapper<const WNGIRParameters> m_parameters;
+      Real m_sigma2;
+      const Geometry::Polytope* m_polytope = nullptr;
+      Math::Vector<Real> m_vector;
+  };
 }
 
 #endif

--- a/src/Rodin/Adaptation/WNGIRSurfaceObservationMetric.h
+++ b/src/Rodin/Adaptation/WNGIRSurfaceObservationMetric.h
@@ -12,151 +12,133 @@
 
 namespace Rodin::Adaptation::Detail
 {
-    template <class PhiDerived, class GradDerived,
-              class TrialFunction, class TestFunction, class Displacement>
-    class WNGIRSurfaceObservationMetric final
-      : public Variational::LocalBilinearFormIntegratorBase<
-          typename TrialFunction::ScalarType>
-    {
-      public:
-        using ScalarType = typename TrialFunction::ScalarType;
-        using Parent =
-          Variational::LocalBilinearFormIntegratorBase<ScalarType>;
-        using PhiType = Variational::RealFunctionBase<PhiDerived>;
-        using GradType = Variational::VectorFunctionBase<Real, GradDerived>;
+  template <class PhiDerived, class GradDerived, class TrialFunction, class TestFunction,
+    class Displacement>
+  class WNGIRSurfaceObservationMetric final
+    : public Variational::LocalBilinearFormIntegratorBase<
+        typename TrialFunction::ScalarType>
+  {
+    public:
+      using ScalarType = typename TrialFunction::ScalarType;
+      using Parent = Variational::LocalBilinearFormIntegratorBase<ScalarType>;
+      using PhiType = Variational::RealFunctionBase<PhiDerived>;
+      using GradType = Variational::VectorFunctionBase<Real, GradDerived>;
 
-        WNGIRSurfaceObservationMetric(
-            const PhiType& phi,
-            const GradType& grad,
-            const TrialFunction& du,
-            const TestFunction& v,
-            const Displacement& current,
-            const WNGIRParameters& parameters,
-            Real sigma2)
-          : Parent(du.getLeaf(), v.getLeaf()),
-            m_phi(phi.copy()),
-            m_grad(grad.copy()),
-            m_du(du),
-            m_v(v),
-            m_current(current),
-            m_parameters(parameters),
-            m_sigma2(sigma2)
-        {}
+      WNGIRSurfaceObservationMetric(const PhiType& phi, const GradType& grad,
+        const TrialFunction& du, const TestFunction& v, const Displacement& current,
+        const WNGIRParameters& parameters, Real sigma2)
+        : Parent(du.getLeaf(), v.getLeaf()),
+          m_phi(phi.copy()),
+          m_grad(grad.copy()),
+          m_du(du),
+          m_v(v),
+          m_current(current),
+          m_parameters(parameters),
+          m_sigma2(sigma2)
+      {}
 
-        WNGIRSurfaceObservationMetric(
-            const WNGIRSurfaceObservationMetric& other)
-          : Parent(other),
-            m_phi(other.m_phi ? other.m_phi->copy() : nullptr),
-            m_grad(other.m_grad ? other.m_grad->copy() : nullptr),
-            m_du(other.m_du),
-            m_v(other.m_v),
-            m_current(other.m_current),
-            m_parameters(other.m_parameters),
-            m_sigma2(other.m_sigma2),
-            m_polytope(other.m_polytope)
-        {}
+      WNGIRSurfaceObservationMetric(const WNGIRSurfaceObservationMetric& other)
+        : Parent(other),
+          m_phi(other.m_phi ? other.m_phi->copy() : nullptr),
+          m_grad(other.m_grad ? other.m_grad->copy() : nullptr),
+          m_du(other.m_du),
+          m_v(other.m_v),
+          m_current(other.m_current),
+          m_parameters(other.m_parameters),
+          m_sigma2(other.m_sigma2),
+          m_polytope(other.m_polytope)
+      {}
 
-        const Geometry::Polytope& getPolytope() const final override
+      const Geometry::Polytope& getPolytope() const final override
+      {
+        assert(m_polytope);
+        return *m_polytope;
+      }
+
+      WNGIRSurfaceObservationMetric& setPolytope(
+        const Geometry::Polytope& polytope) final override
+      {
+        m_polytope = &polytope;
+
+        const std::size_t faceDim = polytope.getDimension();
+        const Index faceIdx = polytope.getIndex();
+        const auto& trialFES = m_du.getFiniteElementSpace();
+        const auto& testFES = m_v.getFiniteElementSpace();
+        const auto& trialFE = trialFES.getFiniteElement(faceDim, faceIdx);
+        const auto& testFE = testFES.getFiniteElement(faceDim, faceIdx);
+        const auto& params = m_parameters.get();
+        const std::size_t qOrder = params.quadratureOrder > 0
+          ? params.quadratureOrder
+          : std::max<std::size_t>(2, 2 * std::max(trialFE.getOrder(), testFE.getOrder()));
+        const auto& qf =
+          QF::PolytopeQuadratureFormula::get(qOrder, polytope.getGeometry());
+        const auto& quad = polytope.getQuadrature(qf);
+
+        const std::size_t ntr = trialFE.getCount();
+        const std::size_t nte = testFE.getCount();
+        m_matrix.resize(static_cast<Eigen::Index>(nte), static_cast<Eigen::Index>(ntr));
+        m_matrix.setZero();
+
+        constexpr Real epsG = Real(1e-12);
+        for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
         {
-          assert(m_polytope);
-          return *m_polytope;
-        }
+          const auto& pt = quad.getPoint(qp);
+          const Variational::IntegrationPoint ip(pt, &qf, qp);
+          const Real w = qf.getWeight(qp) * pt.getDistortion();
+          const auto uq = m_current.get().getValue(ip);
+          Math::SpatialVector<Real> displacement(polytope.getMesh().getDimension());
+          displacement.setZero();
+          for (std::size_t r = 0; r < static_cast<std::size_t>(displacement.size()); ++r)
+            displacement(static_cast<Eigen::Index>(r)) = uq(r);
 
-        WNGIRSurfaceObservationMetric& setPolytope(
-            const Geometry::Polytope& polytope) final override
-        {
-          m_polytope = &polytope;
+          const auto moved = makeTranslatedPoint(pt,
+            pt.getPhysicalCoordinates() + displacement, params.pointLocationTolerance);
+          const Real r = m_phi->getValue(moved);
+          const auto g = m_grad->getValue(moved);
+          const Real obsWeight = g.dot(g) + epsG +
+            (params.residualStabilizedObservationMetric ? (r * r) / m_sigma2 : Real(0));
 
-          const std::size_t faceDim = polytope.getDimension();
-          const Index faceIdx = polytope.getIndex();
-          const auto& trialFES = m_du.getFiniteElementSpace();
-          const auto& testFES = m_v.getFiniteElementSpace();
-          const auto& trialFE = trialFES.getFiniteElement(faceDim, faceIdx);
-          const auto& testFE = testFES.getFiniteElement(faceDim, faceIdx);
-          const auto& params = m_parameters.get();
-          const std::size_t qOrder = params.quadratureOrder > 0
-            ? params.quadratureOrder
-            : std::max<std::size_t>(
-                2, 2 * std::max(trialFE.getOrder(), testFE.getOrder()));
-          const auto& qf =
-            QF::PolytopeQuadratureFormula::get(qOrder, polytope.getGeometry());
-          const auto& quad = polytope.getQuadrature(qf);
-
-          const std::size_t ntr = trialFE.getCount();
-          const std::size_t nte = testFE.getCount();
-          m_matrix.resize(
-              static_cast<Eigen::Index>(nte),
-              static_cast<Eigen::Index>(ntr));
-          m_matrix.setZero();
-
-          constexpr Real epsG = Real(1e-12);
-          for (std::size_t qp = 0; qp < quad.getSize(); ++qp)
+          const auto& rc = pt.getReferenceCoordinates();
+          for (std::size_t te = 0; te < nte; ++te)
           {
-            const auto& pt = quad.getPoint(qp);
-            const Variational::IntegrationPoint ip(pt, &qf, qp);
-            const Real w = qf.getWeight(qp) * pt.getDistortion();
-            const auto uq = m_current.get().getValue(ip);
-            Math::SpatialVector<Real> displacement(polytope.getMesh().getDimension());
-            displacement.setZero();
-            for (std::size_t r = 0; r < static_cast<std::size_t>(displacement.size()); ++r)
-              displacement(static_cast<Eigen::Index>(r)) = uq(r);
-
-            const auto moved =
-              makeTranslatedPoint(pt, pt.getPhysicalCoordinates() + displacement,
-                                  params.pointLocationTolerance);
-            const Real r = m_phi->getValue(moved);
-            const auto g = m_grad->getValue(moved);
-            const Real obsWeight =
-                g.dot(g) + epsG
-              + (params.residualStabilizedObservationMetric
-                  ? (r * r) / m_sigma2 : Real(0));
-
-            const auto& rc = pt.getReferenceCoordinates();
-            for (std::size_t te = 0; te < nte; ++te)
+            const auto testValue = testFE.getBasis(te)(rc);
+            for (std::size_t tr = 0; tr < ntr; ++tr)
             {
-              const auto testValue = testFE.getBasis(te)(rc);
-              for (std::size_t tr = 0; tr < ntr; ++tr)
-              {
-                const auto trialValue = trialFE.getBasis(tr)(rc);
-                m_matrix(
-                    static_cast<Eigen::Index>(te),
-                    static_cast<Eigen::Index>(tr))
-                  += w * params.gammaObs * obsWeight
-                   * trialValue.dot(testValue);
-              }
+              const auto trialValue = trialFE.getBasis(tr)(rc);
+              m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr)) +=
+                w * params.gammaObs * obsWeight * trialValue.dot(testValue);
             }
           }
-          return *this;
         }
+        return *this;
+      }
 
-        ScalarType integrate(std::size_t tr, std::size_t te) final override
-        {
-          return m_matrix(
-              static_cast<Eigen::Index>(te),
-              static_cast<Eigen::Index>(tr));
-        }
+      ScalarType integrate(std::size_t tr, std::size_t te) final override
+      {
+        return m_matrix(static_cast<Eigen::Index>(te), static_cast<Eigen::Index>(tr));
+      }
 
-        Geometry::Region getRegion() const final override
-        {
-          return Geometry::Region::Faces;
-        }
+      Geometry::Region getRegion() const final override
+      {
+        return Geometry::Region::Faces;
+      }
 
-        WNGIRSurfaceObservationMetric* copy() const noexcept final override
-        {
-          return new WNGIRSurfaceObservationMetric(*this);
-        }
+      WNGIRSurfaceObservationMetric* copy() const noexcept final override
+      {
+        return new WNGIRSurfaceObservationMetric(*this);
+      }
 
-      private:
-        std::unique_ptr<PhiType> m_phi;
-        std::unique_ptr<GradType> m_grad;
-        TrialFunction m_du;
-        TestFunction m_v;
-        std::reference_wrapper<const Displacement> m_current;
-        std::reference_wrapper<const WNGIRParameters> m_parameters;
-        Real m_sigma2;
-        const Geometry::Polytope* m_polytope = nullptr;
-        Math::Matrix<Real> m_matrix;
-    };
+    private:
+      std::unique_ptr<PhiType> m_phi;
+      std::unique_ptr<GradType> m_grad;
+      TrialFunction m_du;
+      TestFunction m_v;
+      std::reference_wrapper<const Displacement> m_current;
+      std::reference_wrapper<const WNGIRParameters> m_parameters;
+      Real m_sigma2;
+      const Geometry::Polytope* m_polytope = nullptr;
+      Math::Matrix<Real> m_matrix;
+  };
 }
 
 #endif

--- a/src/Rodin/Advection/Lagrangian.h
+++ b/src/Rodin/Advection/Lagrangian.h
@@ -164,7 +164,8 @@ namespace Rodin::Advection
         Geometry::Point qface(cell, r, x);
         const auto JinvT = qface.getJacobianInverse().transpose();
 
-        Math::SpatialVector<Real> nu = (JinvT * nref).col(0); // unnormalized physical normal
+        Math::SpatialVector<Real> nu =
+          (JinvT * nref).col(0); // unnormalized physical normal
         Real nn = nu.dot(nu);
         if (!(nn > Real(0)) || !std::isfinite(nn))
         {
@@ -332,7 +333,8 @@ namespace Rodin::Advection
         Geometry::Point qHit(cell, r, xHit);
         const auto JinvT = qHit.getJacobianInverse().transpose();
 
-        Math::SpatialVector<Real> nu = (JinvT * nref).col(0); // unnormalized physical normal
+        Math::SpatialVector<Real> nu =
+          (JinvT * nref).col(0); // unnormalized physical normal
         const Real nn = nu.dot(nu);
         if (!(nn > Real(0)) || !std::isfinite(nn))
         {

--- a/src/Rodin/Assembly/AssemblyBase.h
+++ b/src/Rodin/Assembly/AssemblyBase.h
@@ -262,15 +262,11 @@ namespace Rodin::Assembly
    * Output type encodes, for each slave DOF, the master DOF index array and
    * the matching scalar coefficient vector.
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
-  class AssemblyBase<
-    IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-    Variational::DirichletBC<
-      Variational::TrialFunction<Sol1, FES1>,
-      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
-    : public FormLanguage::Base
+  template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+    Variational::ShapeFunctionSpaceType Sp>
+  class AssemblyBase<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+    Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>> : public FormLanguage::Base
   {
     public:
       /// @brief Scalar value type.

--- a/src/Rodin/Assembly/ConstraintMap.h
+++ b/src/Rodin/Assembly/ConstraintMap.h
@@ -78,7 +78,7 @@ namespace Rodin::Assembly
         m_identifiedRows.clear();
 
         for (Index i = 0; i < static_cast<Index>(size); i++)
-          m_expansions[static_cast<size_t>(i)].push_back({ i, Scalar(1) });
+          m_expansions[static_cast<size_t>(i)].push_back({i, Scalar(1)});
       }
 
       /**
@@ -96,8 +96,8 @@ namespace Rodin::Assembly
        */
       bool isFixed(Index i) const
       {
-        return static_cast<size_t>(i) < m_fixed.size()
-            && m_fixed[static_cast<size_t>(i)].has_value();
+        return static_cast<size_t>(i) < m_fixed.size() &&
+          m_fixed[static_cast<size_t>(i)].has_value();
       }
 
       /**
@@ -106,8 +106,8 @@ namespace Rodin::Assembly
        */
       bool isIdentified(Index i) const
       {
-        return static_cast<size_t>(i) < m_expansions.size()
-            && m_isIdentified[static_cast<size_t>(i)];
+        return static_cast<size_t>(i) < m_expansions.size() &&
+          m_isIdentified[static_cast<size_t>(i)];
       }
 
       /**
@@ -246,14 +246,13 @@ namespace Rodin::Assembly
 
         std::vector<State> state(size(), State::Unvisited);
 
-        auto flatten = [&] (auto&& self, Index i) -> Expansion
-        {
+        auto flatten = [&](auto&& self, Index i) -> Expansion {
           check(i);
 
           const size_t idx = static_cast<size_t>(i);
 
           if (!m_isIdentified[idx])
-            return Expansion{ Entry{ i, Scalar(1) } };
+            return Expansion{Entry{i, Scalar(1)}};
 
           if (state[idx] == State::Visiting)
           {
@@ -281,10 +280,7 @@ namespace Rodin::Assembly
               if (me.coefficient == Scalar(0))
                 continue;
 
-              accumulate(
-                  flattened,
-                  me.index,
-                  e.coefficient * me.coefficient);
+              accumulate(flattened, me.index, e.coefficient * me.coefficient);
             }
           }
 
@@ -310,9 +306,8 @@ namespace Rodin::Assembly
         if (static_cast<size_t>(i) >= m_expansions.size())
         {
           Alert::MemberFunctionException(*this, __func__)
-            << "ConstraintMap index out of range: " << i
-            << " is not in [0, " << m_expansions.size() << ")."
-            << Alert::Raise;
+            << "ConstraintMap index out of range: " << i << " is not in [0, "
+            << m_expansions.size() << ")." << Alert::Raise;
         }
       }
 
@@ -321,17 +316,12 @@ namespace Rodin::Assembly
         if (coefficient == Scalar(0))
           return;
 
-        auto it = std::find_if(
-            expansion.begin(),
-            expansion.end(),
-            [&] (const Entry& entry)
-            {
-              return entry.index == index;
-            });
+        auto it = std::find_if(expansion.begin(), expansion.end(),
+          [&](const Entry& entry) { return entry.index == index; });
 
         if (it == expansion.end())
         {
-          expansion.push_back({ index, coefficient });
+          expansion.push_back({index, coefficient});
         }
         else
         {
@@ -341,15 +331,9 @@ namespace Rodin::Assembly
 
       static void prune(Expansion& expansion)
       {
-        expansion.erase(
-            std::remove_if(
-              expansion.begin(),
-              expansion.end(),
-              [] (const Entry& e)
-              {
-                return e.coefficient == Scalar(0);
-              }),
-            expansion.end());
+        expansion.erase(std::remove_if(expansion.begin(), expansion.end(),
+                          [](const Entry& e) { return e.coefficient == Scalar(0); }),
+          expansion.end());
       }
 
       template <class Entries>
@@ -429,8 +413,7 @@ namespace Rodin::Assembly
 
             Alert::MemberFunctionException(*this, __func__)
               << "Invalid affine identification: slave DOF " << slave
-              << " is constrained by x_s = x_s + d with nonzero d."
-              << Alert::Raise;
+              << " is constrained by x_s = x_s + d with nonzero d." << Alert::Raise;
           }
 
           Alert::MemberFunctionException(*this, __func__)
@@ -472,7 +455,7 @@ namespace Rodin::Assembly
         if (canonical.empty())
         {
           m_expansions[static_cast<size_t>(slave)].clear();
-          m_expansions[static_cast<size_t>(slave)].push_back({ slave, Scalar(1) });
+          m_expansions[static_cast<size_t>(slave)].push_back({slave, Scalar(1)});
           m_isIdentified[static_cast<size_t>(slave)] = false;
           m_identificationValues[static_cast<size_t>(slave)] = Scalar(0);
           return;

--- a/src/Rodin/Assembly/ForwardDecls.h
+++ b/src/Rodin/Assembly/ForwardDecls.h
@@ -111,9 +111,8 @@ namespace Rodin::Assembly
    * shape-function expression @f$ A(v) @f$, and the essential boundary
    * attributes.
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
+  template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+    Variational::ShapeFunctionSpaceType Sp>
   class DirichletBCShapeFunctionAssemblyInput;
 
   /**

--- a/src/Rodin/Assembly/Input.h
+++ b/src/Rodin/Assembly/Input.h
@@ -477,9 +477,8 @@ namespace Rodin::Assembly
    * @tparam FES2 Finite element space of @f$ v @f$
    * @tparam Sp Shape function space type (Trial / Test) of @f$ A(v) @f$
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
+  template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+    Variational::ShapeFunctionSpaceType Sp>
   class DirichletBCShapeFunctionAssemblyInput
   {
     public:
@@ -487,11 +486,10 @@ namespace Rodin::Assembly
       using OperandType = Variational::TrialFunction<Sol1, FES1>;
 
       /// @brief Shape-function expression type on the right-hand side.
-      using ValueType   = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
+      using ValueType = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
 
       /// @brief Dirichlet condition represented by this input.
-      using DirichletBCType =
-        Variational::DirichletBC<OperandType, ValueType>;
+      using DirichletBCType = Variational::DirichletBC<OperandType, ValueType>;
 
       /**
        * @brief Constructs identification Dirichlet BC assembly input.
@@ -500,23 +498,30 @@ namespace Rodin::Assembly
        * @param v Shape-function expression used as the master value.
        * @param essBdr Boundary attributes where the condition applies.
        */
-      DirichletBCShapeFunctionAssemblyInput(
-          const OperandType& u, const ValueType& v,
-          const FlatSet<Geometry::Attribute>& essBdr)
-        : m_u(u), m_v(v), m_essBdr(essBdr)
+      DirichletBCShapeFunctionAssemblyInput(const OperandType& u, const ValueType& v,
+        const FlatSet<Geometry::Attribute>& essBdr)
+        : m_u(u),
+          m_v(v),
+          m_essBdr(essBdr)
       {}
 
       /**
        * @brief Gets the slave trial function operand.
        * @return Reference to the constrained trial function.
        */
-      const OperandType& getOperand() const { return m_u.get(); }
+      const OperandType& getOperand() const
+      {
+        return m_u.get();
+      }
 
       /**
        * @brief Gets the shape-function expression on the right-hand side.
        * @return Reference to the master expression.
        */
-      const ValueType& getShapeFunction() const { return m_v.get(); }
+      const ValueType& getShapeFunction() const
+      {
+        return m_v.get();
+      }
 
       /**
        * @brief Gets the essential boundary attributes.
@@ -529,7 +534,7 @@ namespace Rodin::Assembly
 
     private:
       std::reference_wrapper<const OperandType> m_u;
-      std::reference_wrapper<const ValueType>   m_v;
+      std::reference_wrapper<const ValueType> m_v;
       std::reference_wrapper<const FlatSet<Geometry::Attribute>> m_essBdr;
   };
 

--- a/src/Rodin/Assembly/OpenMP.h
+++ b/src/Rodin/Assembly/OpenMP.h
@@ -879,7 +879,8 @@ namespace Rodin::Assembly
 #pragma omp for
           for (Index i = 0; i < faceCount; ++i)
           {
-            if (essBdr.empty() && !mesh.isBoundary(i)) continue;
+            if (essBdr.empty() && !mesh.isBoundary(i))
+              continue;
             if (!essBdr.empty())
             {
               const auto a = mesh.getAttribute(faceDim, i);
@@ -1049,45 +1050,43 @@ namespace Rodin::Assembly
             continue;
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
               {
-                constraints.setFixed(
-                    static_cast<Index>(local),
-                    static_cast<ScalarType>(value));
-              }
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              // Single-FES path: master = same FES as slave, no offset.
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
-              {
-                const auto& masters = pair.first;
-                const auto& coeffs  = pair.second;
-                const Index n =
-                    static_cast<Index>(masters.size());
-                std::vector<typename ConstraintMap<ScalarType>::Entry> entries;
-                entries.reserve(static_cast<size_t>(n));
-                for (Index k = 0; k < n; k++)
+                for (const auto& [local, value] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(masters[k]),
-                      static_cast<ScalarType>(coeffs[k]) });
+                  constraints.setFixed(
+                    static_cast<Index>(local), static_cast<ScalarType>(value));
                 }
-                const auto valueIt = affineValues.find(slave);
-                const ScalarType value =
-                  valueIt == affineValues.end()
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
+              {
+                // Single-FES path: master = same FES as slave, no offset.
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
+                {
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  const Index n = static_cast<Index>(masters.size());
+                  std::vector<typename ConstraintMap<ScalarType>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(n));
+                  for (Index k = 0; k < n; k++)
+                  {
+                    entries.push_back({static_cast<Index>(masters[k]),
+                      static_cast<ScalarType>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const ScalarType value = valueIt == affineValues.end()
                     ? ScalarType(0)
                     : static_cast<ScalarType>(valueIt->second);
-                constraints.setIdentification(static_cast<Index>(slave), entries, value);
+                  constraints.setIdentification(
+                    static_cast<Index>(slave), entries, value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if constexpr (IsSparse)
@@ -1103,10 +1102,9 @@ namespace Rodin::Assembly
             if (val == ScalarType(0))
               return;
 
-            const ScalarType colValue =
-              constraints.isIdentified(col)
-                ? constraints.getIdentificationValue(col)
-                : ScalarType(0);
+            const ScalarType colValue = constraints.isIdentified(col)
+              ? constraints.getIdentificationValue(col)
+              : ScalarType(0);
 
             for (const auto& r : constraints.expand(row))
             {
@@ -1114,7 +1112,7 @@ namespace Rodin::Assembly
                 localRhs.emplace_back(r.index, -r.coefficient * val * colValue);
               for (const auto& c : constraints.expand(col))
                 localT.emplace_back(
-                    r.index, c.index, r.coefficient * val * c.coefficient);
+                  r.index, c.index, r.coefficient * val * c.coefficient);
             }
           };
 
@@ -1354,8 +1352,7 @@ namespace Rodin::Assembly
             if (constraints.isFixed(i))
             {
               all.emplace_back(i, i, ScalarType(1));
-              b.coeffRef(static_cast<size_t>(i)) =
-                constraints.getFixedValue(i);
+              b.coeffRef(static_cast<size_t>(i)) = constraints.getFixedValue(i);
             }
           }
 
@@ -1421,18 +1418,16 @@ namespace Rodin::Assembly
                     const ScalarType val = Math::conj(integrator->integrate(j, i));
                     if (val != ScalarType(0))
                     {
-                      const ScalarType colValue =
-                        constraints.isIdentified(J)
-                          ? constraints.getIdentificationValue(J)
-                          : ScalarType(0);
+                      const ScalarType colValue = constraints.isIdentified(J)
+                        ? constraints.getIdentificationValue(J)
+                        : ScalarType(0);
                       for (const auto& r : constraints.expand(I))
                       {
                         if (colValue != ScalarType(0))
                           localRhs[static_cast<size_t>(r.index)] -=
                             r.coefficient * val * colValue;
                         for (const auto& c : constraints.expand(J))
-                          Alocal(r.index, c.index) +=
-                            r.coefficient * val * c.coefficient;
+                          Alocal(r.index, c.index) += r.coefficient * val * c.coefficient;
                       }
                     }
                   }
@@ -1500,10 +1495,9 @@ namespace Rodin::Assembly
                       const ScalarType val = Math::conj(integrator->integrate(j, i));
                       if (val != ScalarType(0))
                       {
-                        const ScalarType colValue =
-                          constraints.isIdentified(J)
-                            ? constraints.getIdentificationValue(J)
-                            : ScalarType(0);
+                        const ScalarType colValue = constraints.isIdentified(J)
+                          ? constraints.getIdentificationValue(J)
+                          : ScalarType(0);
                         for (const auto& r : constraints.expand(I))
                         {
                           if (colValue != ScalarType(0))
@@ -1535,15 +1529,14 @@ namespace Rodin::Assembly
                 {
                   const ScalarType colValue =
                     constraints.isIdentified(static_cast<Index>(j))
-                      ? constraints.getIdentificationValue(static_cast<Index>(j))
-                      : ScalarType(0);
+                    ? constraints.getIdentificationValue(static_cast<Index>(j))
+                    : ScalarType(0);
                   for (const auto& r : constraints.expand(static_cast<Index>(i)))
                   {
                     if (colValue != ScalarType(0))
                       b.coeffRef(r.index) -= r.coefficient * val * colValue;
                     for (const auto& c : constraints.expand(static_cast<Index>(j)))
-                      A(r.index, c.index) +=
-                        r.coefficient * val * c.coefficient;
+                      A(r.index, c.index) += r.coefficient * val * c.coefficient;
                   }
                 }
               }
@@ -1588,8 +1581,7 @@ namespace Rodin::Assembly
                   const ScalarType val =
                     -static_cast<ScalarType>(integrator->integrate(l));
                   for (const auto& r : constraints.expand(I))
-                    localRhs[static_cast<size_t>(r.index)] +=
-                      r.coefficient * val;
+                    localRhs[static_cast<size_t>(r.index)] += r.coefficient * val;
                 }
               }
             }
@@ -1825,52 +1817,47 @@ namespace Rodin::Assembly
           const size_t uOff   = trialOffsets[uBlock];
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
               {
-                const Index I = static_cast<Index>(
-                    uOff + static_cast<size_t>(local));
-                constraints.setFixed(I, static_cast<ScalarType>(value));
-              }
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto vUUIDOpt = dbc.getValueUUID();
-              assert(vUUIDOpt
-                  && "Identification DBC missing value UUID");
-              const size_t vBlock = findTrialBlock(*vUUIDOpt);
-              const size_t vOff   = trialOffsets[vBlock];
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
-              {
-                const auto& masters = pair.first;
-                const auto& coeffs  = pair.second;
-                const Index gs = static_cast<Index>(
-                    uOff + static_cast<size_t>(slave));
-                const Index n =
-                    static_cast<Index>(masters.size());
-                std::vector<typename ConstraintMap<ScalarType>::Entry> entries;
-                entries.reserve(static_cast<size_t>(n));
-                for (Index k = 0; k < n; k++)
+                for (const auto& [local, value] : dofs)
                 {
-                  const Index gm = static_cast<Index>(
-                      vOff + static_cast<size_t>(masters[k]));
-                  entries.push_back(
-                      { gm, static_cast<ScalarType>(coeffs[k]) });
+                  const Index I = static_cast<Index>(uOff + static_cast<size_t>(local));
+                  constraints.setFixed(I, static_cast<ScalarType>(value));
                 }
-                const auto valueIt = affineValues.find(slave);
-                const ScalarType value =
-                  valueIt == affineValues.end()
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
+              {
+                const auto vUUIDOpt = dbc.getValueUUID();
+                assert(vUUIDOpt && "Identification DBC missing value UUID");
+                const size_t vBlock = findTrialBlock(*vUUIDOpt);
+                const size_t vOff = trialOffsets[vBlock];
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
+                {
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  const Index gs = static_cast<Index>(uOff + static_cast<size_t>(slave));
+                  const Index n = static_cast<Index>(masters.size());
+                  std::vector<typename ConstraintMap<ScalarType>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(n));
+                  for (Index k = 0; k < n; k++)
+                  {
+                    const Index gm =
+                      static_cast<Index>(vOff + static_cast<size_t>(masters[k]));
+                    entries.push_back({gm, static_cast<ScalarType>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const ScalarType value = valueIt == affineValues.end()
                     ? ScalarType(0)
                     : static_cast<ScalarType>(valueIt->second);
-                constraints.setIdentification(gs, entries, value);
+                  constraints.setIdentification(gs, entries, value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         // ------------------------------------------------------------------
@@ -1900,10 +1887,9 @@ namespace Rodin::Assembly
           if (val == ScalarType(0))
             return;
 
-          const ScalarType colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : ScalarType(0);
+          const ScalarType colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : ScalarType(0);
 
           for (const auto& r : constraints.expand(row))
           {
@@ -1912,7 +1898,7 @@ namespace Rodin::Assembly
                 r.index, -r.coefficient * val * colValue);
             for (const auto& c : constraints.expand(col))
               tchunks[static_cast<size_t>(tid)].emplace_back(
-                  r.index, c.index, r.coefficient * val * c.coefficient);
+                r.index, c.index, r.coefficient * val * c.coefficient);
           }
         };
 
@@ -1984,10 +1970,9 @@ namespace Rodin::Assembly
                         sparseEntry(tid, I, J, val);
                       else
                       {
-                        const ScalarType colValue =
-                          constraints.isIdentified(J)
-                            ? constraints.getIdentificationValue(J)
-                            : ScalarType(0);
+                        const ScalarType colValue = constraints.isIdentified(J)
+                          ? constraints.getIdentificationValue(J)
+                          : ScalarType(0);
                         for (const auto& r : constraints.expand(I))
                         {
                           if (colValue != ScalarType(0))
@@ -2092,10 +2077,9 @@ namespace Rodin::Assembly
                           sparseEntry(tid, I, J, val);
                         else
                         {
-                          const ScalarType colValue =
-                            constraints.isIdentified(J)
-                              ? constraints.getIdentificationValue(J)
-                              : ScalarType(0);
+                          const ScalarType colValue = constraints.isIdentified(J)
+                            ? constraints.getIdentificationValue(J)
+                            : ScalarType(0);
                           for (const auto& r : constraints.expand(I))
                           {
                             if (colValue != ScalarType(0))
@@ -2282,8 +2266,7 @@ namespace Rodin::Assembly
             if (constraints.isFixed(I))
             {
               all.emplace_back(I, I, ScalarType(1));
-              b.coeffRef(static_cast<size_t>(I)) =
-                constraints.getFixedValue(I);
+              b.coeffRef(static_cast<size_t>(I)) = constraints.getFixedValue(I);
             }
           }
 
@@ -2321,17 +2304,15 @@ namespace Rodin::Assembly
                 {
                   const Index I = static_cast<Index>(vOff) + i;
                   const Index J = static_cast<Index>(uOff) + j;
-                  const ScalarType colValue =
-                    constraints.isIdentified(J)
-                      ? constraints.getIdentificationValue(J)
-                      : ScalarType(0);
+                  const ScalarType colValue = constraints.isIdentified(J)
+                    ? constraints.getIdentificationValue(J)
+                    : ScalarType(0);
                   for (const auto& r : constraints.expand(I))
                   {
                     if (colValue != ScalarType(0))
                       b.coeffRef(r.index) -= r.coefficient * val * colValue;
                     for (const auto& c : constraints.expand(J))
-                      A(r.index, c.index) +=
-                        r.coefficient * val * c.coefficient;
+                      A(r.index, c.index) += r.coefficient * val * c.coefficient;
                   }
                 }
               }
@@ -2416,19 +2397,14 @@ namespace Rodin::Assembly
    * The expensive part (the linear-system constraint application) is
    * parallelized inside the problem-level OpenMP assembler above.
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
-  class OpenMP<
-    IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-    Variational::DirichletBC<
-      Variational::TrialFunction<Sol1, FES1>,
-      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>> final
-    : public AssemblyBase<
-        IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-        Variational::DirichletBC<
-          Variational::TrialFunction<Sol1, FES1>,
-          Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+  template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+    Variational::ShapeFunctionSpaceType Sp>
+  class OpenMP<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+    Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+    final : public AssemblyBase<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+              Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+                Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
   {
     public:
       /// @brief Output map type for slave-to-master identifications.
@@ -2441,8 +2417,7 @@ namespace Rodin::Assembly
       using ValueType = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
 
       /// @brief Dirichlet condition type.
-      using DirichletBCType =
-        Variational::DirichletBC<TrialFunctionType, ValueType>;
+      using DirichletBCType = Variational::DirichletBC<TrialFunctionType, ValueType>;
 
       /// @brief Parent class type.
       using Parent = AssemblyBase<OutputType, DirichletBCType>;
@@ -2454,10 +2429,14 @@ namespace Rodin::Assembly
       OpenMP() = default;
 
       /// @brief Copy constructor.
-      OpenMP(const OpenMP& other) : Parent(other) {}
+      OpenMP(const OpenMP& other)
+        : Parent(other)
+      {}
 
       /// @brief Move constructor.
-      OpenMP(OpenMP&& other) : Parent(std::move(other)) {}
+      OpenMP(OpenMP&& other)
+        : Parent(std::move(other))
+      {}
 
       /**
        * @brief Executes identification Dirichlet boundary condition assembly.
@@ -2478,11 +2457,13 @@ namespace Rodin::Assembly
         res.clear();
         for (Index fi = 0; fi < mesh.getFaceCount(); fi++)
         {
-          if (essBdr.empty() && !mesh.isBoundary(fi)) continue;
+          if (essBdr.empty() && !mesh.isBoundary(fi))
+            continue;
           if (!essBdr.empty())
           {
             const auto a = mesh.getAttribute(faceDim, fi);
-            if (!a || !essBdr.count(*a)) continue;
+            if (!a || !essBdr.count(*a))
+              continue;
           }
 
           const auto& feU = fesU.getFiniteElement(faceDim, fi);
@@ -2494,18 +2475,17 @@ namespace Rodin::Assembly
           for (Index s = 0; s < static_cast<Index>(feU.getCount()); s++)
           {
             const Index slave = slaveDOFs[s];
-            if (res.find(slave) != res.end()) continue;
+            if (res.find(slave) != res.end())
+              continue;
 
-            std::vector<Index>  mIdx;
+            std::vector<Index> mIdx;
             std::vector<Scalar> mCoef;
             mIdx.reserve(static_cast<size_t>(nMasters));
             mCoef.reserve(static_cast<size_t>(nMasters));
 
             for (Index j = 0; j < nMasters; j++)
             {
-              auto basisCallable = [&Av, j]
-                                   (const Geometry::Point& p)
-              {
+              auto basisCallable = [&Av, j](const Geometry::Point& p) {
                 const Variational::IntegrationPoint ip(p);
                 Av.setIntegrationPoint(ip);
                 return Av.getBasis(static_cast<size_t>(j));
@@ -2520,17 +2500,17 @@ namespace Rodin::Assembly
               }
             }
 
-            if (mIdx.empty()) continue;
+            if (mIdx.empty())
+              continue;
             const Index n = static_cast<Index>(mIdx.size());
             IndexArray masters(n);
             Math::Vector<Scalar> coeffs(n);
             for (Index k = 0; k < n; k++)
             {
               masters.coeffRef(k) = mIdx[static_cast<size_t>(k)];
-              coeffs.coeffRef(k)  = mCoef[static_cast<size_t>(k)];
+              coeffs.coeffRef(k) = mCoef[static_cast<size_t>(k)];
             }
-            res.emplace(slave,
-                std::pair{ std::move(masters), std::move(coeffs) });
+            res.emplace(slave, std::pair{std::move(masters), std::move(coeffs)});
           }
         }
       }
@@ -2539,7 +2519,10 @@ namespace Rodin::Assembly
        * @brief Creates a polymorphic copy.
        * @return Pointer to a new copy.
        */
-      OpenMP* copy() const noexcept override { return new OpenMP(*this); }
+      OpenMP* copy() const noexcept override
+      {
+        return new OpenMP(*this);
+      }
   };
 }
 

--- a/src/Rodin/Assembly/Sequential.h
+++ b/src/Rodin/Assembly/Sequential.h
@@ -2027,7 +2027,7 @@ namespace Rodin::Assembly
         }
     };
 
-  /**
+    /**
    * @brief Sequential assembler for the identification Dirichlet BC
    *        `u = A(v)`.
    *
@@ -2044,160 +2044,151 @@ namespace Rodin::Assembly
    * basis is evaluated through @f$ A(v) @f$ and then sampled by the slave
    * finite element's DOF functional.
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
-  class Sequential<
-    IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-    Variational::DirichletBC<
-      Variational::TrialFunction<Sol1, FES1>,
-      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>> final
-    : public AssemblyBase<
-        IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-        Variational::DirichletBC<
-          Variational::TrialFunction<Sol1, FES1>,
-          Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
-  {
-    public:
-      /// @brief Output map type for slave-to-master identifications.
-      using OutputType = IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>;
+    template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+      Variational::ShapeFunctionSpaceType Sp>
+    class Sequential<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+      Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+        Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+      final : public AssemblyBase<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+                Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+                  Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+    {
+      public:
+        /// @brief Output map type for slave-to-master identifications.
+        using OutputType = IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>;
 
-      /// @brief Slave trial function type.
-      using TrialFunctionType = Variational::TrialFunction<Sol1, FES1>;
+        /// @brief Slave trial function type.
+        using TrialFunctionType = Variational::TrialFunction<Sol1, FES1>;
 
-      /// @brief Shape-function expression type on the right-hand side.
-      using ValueType = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
+        /// @brief Shape-function expression type on the right-hand side.
+        using ValueType = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
 
-      /// @brief Dirichlet condition type.
-      using DirichletBCType =
-        Variational::DirichletBC<TrialFunctionType, ValueType>;
+        /// @brief Dirichlet condition type.
+        using DirichletBCType = Variational::DirichletBC<TrialFunctionType, ValueType>;
 
-      /// @brief Parent class type.
-      using Parent = AssemblyBase<OutputType, DirichletBCType>;
+        /// @brief Parent class type.
+        using Parent = AssemblyBase<OutputType, DirichletBCType>;
 
-      /// @brief Assembly input data type.
-      using InputType = typename Parent::InputType;
+        /// @brief Assembly input data type.
+        using InputType = typename Parent::InputType;
 
-      /// @brief Default constructor.
-      Sequential() = default;
+        /// @brief Default constructor.
+        Sequential() = default;
 
-      /// @brief Copy constructor.
-      Sequential(const Sequential& other)
-        : Parent(other)
-      {}
+        /// @brief Copy constructor.
+        Sequential(const Sequential& other)
+          : Parent(other)
+        {}
 
-      /// @brief Move constructor.
-      Sequential(Sequential&& other)
-        : Parent(std::move(other))
-      {}
+        /// @brief Move constructor.
+        Sequential(Sequential&& other)
+          : Parent(std::move(other))
+        {}
 
-      /**
+        /**
        * @brief Executes identification Dirichlet boundary condition assembly.
        * @param res Output map from slave DOFs to master DOF coefficients.
        * @param input Boundary condition input.
        */
-      void execute(OutputType& res, const InputType& input) const override
-      {
-        const auto& u = input.getOperand();
-        // setIntegrationPoint mutates internal evaluation state; the input
-        // exposes Av as const, but we need to drive its IP cursor while
-        // probing each basis. The mutation is purely evaluation state, not
-        // semantic.
-        auto& Av = const_cast<ValueType&>(input.getShapeFunction());
-        const auto& essBdr = input.getEssentialBoundary();
-
-        const auto& fesU = u.getFiniteElementSpace();
-        const auto& fesV = Av.getLeaf().getFiniteElementSpace();
-        const auto& mesh = fesU.getMesh();
-        const size_t faceCount = mesh.getFaceCount();
-        const size_t faceDim   = mesh.getDimension() - 1;
-
-        res.clear();
-        for (Index fi = 0; fi < faceCount; fi++)
+        void execute(OutputType& res, const InputType& input) const override
         {
-          if (essBdr.empty() && !mesh.isBoundary(fi))
-            continue;
+          const auto& u = input.getOperand();
+          // setIntegrationPoint mutates internal evaluation state; the input
+          // exposes Av as const, but we need to drive its IP cursor while
+          // probing each basis. The mutation is purely evaluation state, not
+          // semantic.
+          auto& Av = const_cast<ValueType&>(input.getShapeFunction());
+          const auto& essBdr = input.getEssentialBoundary();
 
-          if (!essBdr.empty())
+          const auto& fesU = u.getFiniteElementSpace();
+          const auto& fesV = Av.getLeaf().getFiniteElementSpace();
+          const auto& mesh = fesU.getMesh();
+          const size_t faceCount = mesh.getFaceCount();
+          const size_t faceDim = mesh.getDimension() - 1;
+
+          res.clear();
+          for (Index fi = 0; fi < faceCount; fi++)
           {
-            const auto a = mesh.getAttribute(faceDim, fi);
-            if (!a || !essBdr.count(*a))
-              continue;
-          }
-
-          const auto& feU = fesU.getFiniteElement(faceDim, fi);
-          const auto& feV = fesV.getFiniteElement(faceDim, fi);
-          const auto& slaveDOFs = fesU.getDOFs(faceDim, fi);
-          const auto& masterDOFs = fesV.getDOFs(faceDim, fi);
-
-          const Index nMasters = static_cast<Index>(feV.getCount());
-
-          for (Index s = 0; s < static_cast<Index>(feU.getCount()); s++)
-          {
-            const Index slave = slaveDOFs[s];
-            if (res.find(slave) != res.end())
+            if (essBdr.empty() && !mesh.isBoundary(fi))
               continue;
 
-            // Compute the constraint row C_{sj} = ℓ_s^u(A(φ_j^v)) for each
-            // master j. We construct a callable that, given a Geometry::Point
-            // p, evaluates A(φ_j^v)(p) through a pointwise IntegrationPoint
-            // with no quadrature formula and pulls the j-th basis. The
-            // slave-FES pullback drives this
-            // through whatever evaluation pattern the slave DOF functional
-            // uses (point evaluation for Lagrange, integral for moment-based
-            // elements, etc.) — making this work for any FES whose
-            // FiniteElement::LinearForm operates on a (Geometry::Point ->
-            // value) callable through the FES pullback.
-            std::vector<Index>  mIdx;
-            std::vector<Scalar> mCoef;
-            mIdx.reserve(static_cast<size_t>(nMasters));
-            mCoef.reserve(static_cast<size_t>(nMasters));
-
-            for (Index j = 0; j < nMasters; j++)
+            if (!essBdr.empty())
             {
-              auto basisCallable = [&Av, j]
-                                   (const Geometry::Point& p)
+              const auto a = mesh.getAttribute(faceDim, fi);
+              if (!a || !essBdr.count(*a))
+                continue;
+            }
+
+            const auto& feU = fesU.getFiniteElement(faceDim, fi);
+            const auto& feV = fesV.getFiniteElement(faceDim, fi);
+            const auto& slaveDOFs = fesU.getDOFs(faceDim, fi);
+            const auto& masterDOFs = fesV.getDOFs(faceDim, fi);
+
+            const Index nMasters = static_cast<Index>(feV.getCount());
+
+            for (Index s = 0; s < static_cast<Index>(feU.getCount()); s++)
+            {
+              const Index slave = slaveDOFs[s];
+              if (res.find(slave) != res.end())
+                continue;
+
+              // Compute the constraint row C_{sj} = ℓ_s^u(A(φ_j^v)) for each
+              // master j. We construct a callable that, given a Geometry::Point
+              // p, evaluates A(φ_j^v)(p) through a pointwise IntegrationPoint
+              // with no quadrature formula and pulls the j-th basis. The
+              // slave-FES pullback drives this
+              // through whatever evaluation pattern the slave DOF functional
+              // uses (point evaluation for Lagrange, integral for moment-based
+              // elements, etc.) — making this work for any FES whose
+              // FiniteElement::LinearForm operates on a (Geometry::Point ->
+              // value) callable through the FES pullback.
+              std::vector<Index> mIdx;
+              std::vector<Scalar> mCoef;
+              mIdx.reserve(static_cast<size_t>(nMasters));
+              mCoef.reserve(static_cast<size_t>(nMasters));
+
+              for (Index j = 0; j < nMasters; j++)
               {
-                const Variational::IntegrationPoint ip(p);
-                Av.setIntegrationPoint(ip);
-                return Av.getBasis(static_cast<size_t>(j));
-              };
-              const auto mapping =
-                fesU.getPullback({faceDim, fi}, std::move(basisCallable));
-              const Scalar c = static_cast<Scalar>(feU.getLinearForm(s)(mapping));
-              if (c != Scalar(0))
-              {
-                mIdx.push_back(masterDOFs[j]);
-                mCoef.push_back(c);
+                auto basisCallable = [&Av, j](const Geometry::Point& p) {
+                  const Variational::IntegrationPoint ip(p);
+                  Av.setIntegrationPoint(ip);
+                  return Av.getBasis(static_cast<size_t>(j));
+                };
+                const auto mapping =
+                  fesU.getPullback({faceDim, fi}, std::move(basisCallable));
+                const Scalar c = static_cast<Scalar>(feU.getLinearForm(s)(mapping));
+                if (c != Scalar(0))
+                {
+                  mIdx.push_back(masterDOFs[j]);
+                  mCoef.push_back(c);
+                }
               }
-            }
 
-            if (mIdx.empty())
-              continue;
+              if (mIdx.empty())
+                continue;
 
-            const Index n = static_cast<Index>(mIdx.size());
-            IndexArray masters(n);
-            Math::Vector<Scalar> coeffs(n);
-            for (Index k = 0; k < n; k++)
-            {
-              masters.coeffRef(k) = mIdx[static_cast<size_t>(k)];
-              coeffs.coeffRef(k)  = mCoef[static_cast<size_t>(k)];
+              const Index n = static_cast<Index>(mIdx.size());
+              IndexArray masters(n);
+              Math::Vector<Scalar> coeffs(n);
+              for (Index k = 0; k < n; k++)
+              {
+                masters.coeffRef(k) = mIdx[static_cast<size_t>(k)];
+                coeffs.coeffRef(k) = mCoef[static_cast<size_t>(k)];
+              }
+              res.emplace(slave, std::pair{std::move(masters), std::move(coeffs)});
             }
-            res.emplace(slave,
-                std::pair{ std::move(masters), std::move(coeffs) });
           }
         }
-      }
 
-      /**
+        /**
        * @brief Creates a polymorphic copy.
        * @return Pointer to a new copy.
        */
-      Sequential* copy() const noexcept override
-      {
-        return new Sequential(*this);
-      }
-  };
+        Sequential* copy() const noexcept override
+        {
+          return new Sequential(*this);
+        }
+    };
 }
 
 #endif

--- a/src/Rodin/Geometry/Connectivity.cpp
+++ b/src/Rodin/Geometry/Connectivity.cpp
@@ -664,39 +664,40 @@ namespace Rodin::Geometry
         if (dim == 0)
         {
           out.resize(5);
-          out[0] = { Polytope::Type::Point, Polytope::Key({ p(0) }) };
-          out[1] = { Polytope::Type::Point, Polytope::Key({ p(1) }) };
-          out[2] = { Polytope::Type::Point, Polytope::Key({ p(2) }) };
-          out[3] = { Polytope::Type::Point, Polytope::Key({ p(3) }) };
-          out[4] = { Polytope::Type::Point, Polytope::Key({ p(4) }) };
+          out[0] = {Polytope::Type::Point, Polytope::Key({p(0)})};
+          out[1] = {Polytope::Type::Point, Polytope::Key({p(1)})};
+          out[2] = {Polytope::Type::Point, Polytope::Key({p(2)})};
+          out[3] = {Polytope::Type::Point, Polytope::Key({p(3)})};
+          out[4] = {Polytope::Type::Point, Polytope::Key({p(4)})};
         }
         else if (dim == 1)
         {
           // Base loop, then apex edges.
           out.resize(8);
-          out[0] = { Polytope::Type::Segment, Polytope::Key({ p(0), p(1) }) };
-          out[1] = { Polytope::Type::Segment, Polytope::Key({ p(1), p(2) }) };
-          out[2] = { Polytope::Type::Segment, Polytope::Key({ p(2), p(3) }) };
-          out[3] = { Polytope::Type::Segment, Polytope::Key({ p(3), p(0) }) };
-          out[4] = { Polytope::Type::Segment, Polytope::Key({ p(0), p(4) }) };
-          out[5] = { Polytope::Type::Segment, Polytope::Key({ p(1), p(4) }) };
-          out[6] = { Polytope::Type::Segment, Polytope::Key({ p(2), p(4) }) };
-          out[7] = { Polytope::Type::Segment, Polytope::Key({ p(3), p(4) }) };
+          out[0] = {Polytope::Type::Segment, Polytope::Key({p(0), p(1)})};
+          out[1] = {Polytope::Type::Segment, Polytope::Key({p(1), p(2)})};
+          out[2] = {Polytope::Type::Segment, Polytope::Key({p(2), p(3)})};
+          out[3] = {Polytope::Type::Segment, Polytope::Key({p(3), p(0)})};
+          out[4] = {Polytope::Type::Segment, Polytope::Key({p(0), p(4)})};
+          out[5] = {Polytope::Type::Segment, Polytope::Key({p(1), p(4)})};
+          out[6] = {Polytope::Type::Segment, Polytope::Key({p(2), p(4)})};
+          out[7] = {Polytope::Type::Segment, Polytope::Key({p(3), p(4)})};
         }
         else if (dim == 2)
         {
           // Base quadrilateral, followed by triangular side faces around it.
           out.resize(5);
-          out[0] = { Polytope::Type::Quadrilateral, Polytope::Key({ p(0), p(1), p(2), p(3) }) };
-          out[1] = { Polytope::Type::Triangle,      Polytope::Key({ p(0), p(1), p(4) }) };
-          out[2] = { Polytope::Type::Triangle,      Polytope::Key({ p(1), p(2), p(4) }) };
-          out[3] = { Polytope::Type::Triangle,      Polytope::Key({ p(2), p(3), p(4) }) };
-          out[4] = { Polytope::Type::Triangle,      Polytope::Key({ p(3), p(0), p(4) }) };
+          out[0] = {
+            Polytope::Type::Quadrilateral, Polytope::Key({p(0), p(1), p(2), p(3)})};
+          out[1] = {Polytope::Type::Triangle, Polytope::Key({p(0), p(1), p(4)})};
+          out[2] = {Polytope::Type::Triangle, Polytope::Key({p(1), p(2), p(4)})};
+          out[3] = {Polytope::Type::Triangle, Polytope::Key({p(2), p(3), p(4)})};
+          out[4] = {Polytope::Type::Triangle, Polytope::Key({p(3), p(0), p(4)})};
         }
         else if (dim == 3)
         {
           out.resize(1);
-          out[0] = { Polytope::Type::Pyramid, p };
+          out[0] = {Polytope::Type::Pyramid, p};
         }
         else
         {

--- a/src/Rodin/Geometry/ForwardDecls.h
+++ b/src/Rodin/Geometry/ForwardDecls.h
@@ -20,7 +20,7 @@
 
 #include "Rodin/Context.h"
 #ifdef RODIN_USE_MPI
-#  include "Rodin/MPI/Context/ForwardDecls.h"
+#include "Rodin/MPI/Context/ForwardDecls.h"
 #endif
 #include "Types.h"
 

--- a/src/Rodin/Geometry/Mesh.cpp
+++ b/src/Rodin/Geometry/Mesh.cpp
@@ -985,9 +985,7 @@ namespace Rodin::Geometry
         const size_t gridVertices = w * h * d;
         const size_t cellCount = (w - 1) * (h - 1) * (d - 1);
 
-        build.initialize(dim)
-             .nodes(gridVertices + cellCount)
-             .reserve(dim, 6 * cellCount);
+        build.initialize(dim).nodes(gridVertices + cellCount).reserve(dim, 6 * cellCount);
 
         for (size_t k = 0; k < d; ++k)
         {
@@ -995,9 +993,8 @@ namespace Rodin::Geometry
           {
             for (size_t i = 0; i < w; ++i)
             {
-              build.vertex({ static_cast<Real>(i),
-                             static_cast<Real>(j),
-                             static_cast<Real>(k) });
+              build.vertex(
+                {static_cast<Real>(i), static_cast<Real>(j), static_cast<Real>(k)});
             }
           }
         }
@@ -1008,20 +1005,17 @@ namespace Rodin::Geometry
           {
             for (size_t i = 0; i + 1 < w; ++i)
             {
-              build.vertex({ static_cast<Real>(i) + Real(0.5),
-                             static_cast<Real>(j) + Real(0.5),
-                             static_cast<Real>(k) + Real(0.5) });
+              build.vertex({static_cast<Real>(i) + Real(0.5),
+                static_cast<Real>(j) + Real(0.5), static_cast<Real>(k) + Real(0.5)});
             }
           }
         }
 
-        const auto vid = [w, h](size_t i, size_t j, size_t k) -> Index
-        {
+        const auto vid = [w, h](size_t i, size_t j, size_t k) -> Index {
           return static_cast<Index>(i + j * w + k * w * h);
         };
 
-        const auto cid = [gridVertices, w, h](size_t i, size_t j, size_t k) -> Index
-        {
+        const auto cid = [gridVertices, w, h](size_t i, size_t j, size_t k) -> Index {
           const size_t cw = w - 1;
           const size_t ch = h - 1;
           return static_cast<Index>(gridVertices + i + j * cw + k * cw * ch);
@@ -1033,22 +1027,22 @@ namespace Rodin::Geometry
           {
             for (size_t i = 0; i + 1 < w; ++i)
             {
-              const Index v0 = vid(i,     j,     k);
-              const Index v1 = vid(i + 1, j,     k);
+              const Index v0 = vid(i, j, k);
+              const Index v1 = vid(i + 1, j, k);
               const Index v2 = vid(i + 1, j + 1, k);
-              const Index v3 = vid(i,     j + 1, k);
-              const Index v4 = vid(i,     j,     k + 1);
-              const Index v5 = vid(i + 1, j,     k + 1);
+              const Index v3 = vid(i, j + 1, k);
+              const Index v4 = vid(i, j, k + 1);
+              const Index v5 = vid(i + 1, j, k + 1);
               const Index v6 = vid(i + 1, j + 1, k + 1);
-              const Index v7 = vid(i,     j + 1, k + 1);
-              const Index c  = cid(i, j, k);
+              const Index v7 = vid(i, j + 1, k + 1);
+              const Index c = cid(i, j, k);
 
-              build.polytope(g, { v0, v1, v2, v3, c })
-                   .polytope(g, { v4, v5, v6, v7, c })
-                   .polytope(g, { v0, v4, v5, v1, c })
-                   .polytope(g, { v1, v5, v6, v2, c })
-                   .polytope(g, { v2, v6, v7, v3, c })
-                   .polytope(g, { v3, v7, v4, v0, c });
+              build.polytope(g, {v0, v1, v2, v3, c})
+                .polytope(g, {v4, v5, v6, v7, c})
+                .polytope(g, {v0, v4, v5, v1, c})
+                .polytope(g, {v1, v5, v6, v2, c})
+                .polytope(g, {v2, v6, v7, v3, c})
+                .polytope(g, {v3, v7, v4, v0, c});
             }
           }
         }

--- a/src/Rodin/Geometry/MinSTCut.h
+++ b/src/Rodin/Geometry/MinSTCut.h
@@ -71,27 +71,27 @@ namespace Rodin::Geometry
       {
         /// Multiplicative scale applied to every pairwise capacity
         /// (Potts smoothing strength lambda).
-        Real lambdaScale = 1;
+          Real lambdaScale = 1;
 
         /// Multiplicative scale applied to every unary cost.
-        Real unaryScale = 1;
+          Real unaryScale = 1;
 
         /// If `|moment[i]| >= farFieldThreshold` the cell `i` is pinned
         /// to `sign(-moment[i])` by injecting a large unary on the
         /// opposite terminal. Disabled when negative.
-        Real farFieldThreshold = -1;
+          Real farFieldThreshold = -1;
 
         /// Per-edge multiplier replacing `lambdaScale` on the i-th edge.
         /// Use for zero-level-aware facet weighting (e.g. down-weight
         /// pairwise term where |phi| is small so the cut prefers to
         /// align with the actual interface).
         /// Size must be `edges.size()` or `0` (disabled).
-        std::vector<Real> perEdgeLambda;
+          std::vector<Real> perEdgeLambda;
 
         /// Per-cell free/fixed mask. `cellInBand[i] == false` pins cell
         /// `i` to `sign(-moment[i])` via a large unary. Size must be
         /// `volumes.size()` or `0` (disabled, all cells free).
-        std::vector<Boolean> cellInBand;
+          std::vector<Boolean> cellInBand;
       };
 
       /// @brief Returns the unary cost of labeling a cell Inside, given its

--- a/src/Rodin/Geometry/Point.cpp
+++ b/src/Rodin/Geometry/Point.cpp
@@ -336,7 +336,8 @@ namespace Rodin::Geometry
       m_rc(rc)
   {}
 
-  Point::Point(const Polytope& polytope, const Math::SpatialPoint& rc, const Math::SpatialPoint& pc)
+  Point::Point(
+    const Polytope& polytope, const Math::SpatialPoint& rc, const Math::SpatialPoint& pc)
     : PointBase(polytope, pc),
       m_rc(rc)
   {}

--- a/src/Rodin/Geometry/Polytope.cpp
+++ b/src/Rodin/Geometry/Polytope.cpp
@@ -762,7 +762,7 @@ namespace Rodin::Geometry
       }
       case Geometry::Polytope::Type::Pyramid:
       {
-        static const Math::SpatialVector<Real> s_node{{ 0.375, 0.375, 0.25 }};
+        static const Math::SpatialVector<Real> s_node{{0.375, 0.375, 0.25}};
         return s_node;
       }
       case Geometry::Polytope::Type::Wedge:
@@ -834,14 +834,10 @@ namespace Rodin::Geometry
       }
       case Type::Pyramid:
       {
-        static const std::vector<Math::SpatialPoint> s_nodes =
-        {
-          Math::SpatialPoint{{ 0, 0, 0 }},
-          Math::SpatialPoint{{ 1, 0, 0 }},
-          Math::SpatialPoint{{ 1, 1, 0 }},
-          Math::SpatialPoint{{ 0, 1, 0 }},
-          Math::SpatialPoint{{ 0, 0, 1 }}
-        };
+        static const std::vector<Math::SpatialPoint> s_nodes = {
+          Math::SpatialPoint{{0, 0, 0}}, Math::SpatialPoint{{1, 0, 0}},
+          Math::SpatialPoint{{1, 1, 0}}, Math::SpatialPoint{{0, 1, 0}},
+          Math::SpatialPoint{{0, 0, 1}}};
         return s_nodes[i];
       }
       case Type::Hexahedron:
@@ -1507,8 +1503,7 @@ namespace Rodin::Geometry
       case Type::Pyramid:
       {
         auto sq = [](Real v) { return v * v; };
-        auto projectTri = [](Real u, Real v, Real& ou, Real& ov)
-        {
+        auto projectTri = [](Real u, Real v, Real& ou, Real& ov) {
           u = std::max(u, Real(0));
           v = std::max(v, Real(0));
           const Real s = u + v;
@@ -1526,8 +1521,7 @@ namespace Rodin::Geometry
         Real bestd = std::numeric_limits<Real>::infinity();
         Real bx = 0, by = 0, bz = 0;
 
-        auto consider = [&](Real x, Real y, Real z)
-        {
+        auto consider = [&](Real x, Real y, Real z) {
           const Real d = sq(rc[0] - x) + sq(rc[1] - y) + sq(rc[2] - z);
           if (d < bestd)
           {
@@ -1538,10 +1532,8 @@ namespace Rodin::Geometry
           }
         };
 
-        consider(
-            std::clamp(rc[0], Real(0), Real(1)),
-            std::clamp(rc[1], Real(0), Real(1)),
-            Real(0));
+        consider(std::clamp(rc[0], Real(0), Real(1)), std::clamp(rc[1], Real(0), Real(1)),
+          Real(0));
 
         Real u, v;
         projectTri(rc[0], rc[2], u, v);
@@ -1556,7 +1548,9 @@ namespace Rodin::Geometry
         projectTri(Real(1) - rc[1] - rc[2], rc[2], u, v);
         consider(Real(0), Real(1) - u - v, v);
 
-        out[0] = bx; out[1] = by; out[2] = bz;
+        out[0] = bx;
+        out[1] = by;
+        out[2] = bz;
         return;
       }
       case Type::Wedge:
@@ -1822,8 +1816,7 @@ namespace Rodin::Geometry
         // 4: side x=0        (3,0,4)
         assert(local < 5);
 
-        auto projectTri = [](Real u, Real v, Real& ou, Real& ov)
-        {
+        auto projectTri = [](Real u, Real v, Real& ou, Real& ov) {
           u = std::max(u, Real(0));
           v = std::max(v, Real(0));
           const Real s = u + v;
@@ -1850,24 +1843,32 @@ namespace Rodin::Geometry
         if (local == 1)
         {
           projectTri(rc[0], rc[2], u, v);
-          out[0] = u; out[1] = Real(0); out[2] = v;
+          out[0] = u;
+          out[1] = Real(0);
+          out[2] = v;
           return;
         }
         if (local == 2)
         {
           projectTri(rc[1], rc[2], u, v);
-          out[0] = Real(1) - v; out[1] = u; out[2] = v;
+          out[0] = Real(1) - v;
+          out[1] = u;
+          out[2] = v;
           return;
         }
         if (local == 3)
         {
           projectTri(Real(1) - rc[0] - rc[2], rc[2], u, v);
-          out[0] = Real(1) - u - v; out[1] = Real(1) - v; out[2] = v;
+          out[0] = Real(1) - u - v;
+          out[1] = Real(1) - v;
+          out[2] = v;
           return;
         }
 
         projectTri(Real(1) - rc[1] - rc[2], rc[2], u, v);
-        out[0] = Real(0); out[1] = Real(1) - u - v; out[2] = v;
+        out[0] = Real(0);
+        out[1] = Real(1) - u - v;
+        out[2] = v;
         return;
       }
       case Type::Wedge:

--- a/src/Rodin/Geometry/Polytope.h
+++ b/src/Rodin/Geometry/Polytope.h
@@ -218,7 +218,7 @@ namespace Rodin::Geometry
         Triangle,       ///< 2D triangular element
         Quadrilateral,  ///< 2D quadrilateral element
         Tetrahedron,    ///< 3D tetrahedral element
-        Pyramid,        ///< 3D pyramidal element (quadrilateral base)
+        Pyramid, ///< 3D pyramidal element (quadrilateral base)
         Hexahedron,     ///< 3D hexahedral element
         Wedge           ///< 3D prismatic element (triangular prism)
       };
@@ -352,17 +352,9 @@ namespace Rodin::Geometry
        *
        * Useful for iterating over all geometry types at compile time.
        */
-      static constexpr std::array<Type, 8> Types
-      {
-        Type::Point,
-        Type::Segment,
-        Type::Triangle,
-        Type::Quadrilateral,
-        Type::Tetrahedron,
-        Type::Pyramid,
-        Type::Hexahedron,
-        Type::Wedge
-      };
+      static constexpr std::array<Type, 8> Types{Type::Point, Type::Segment,
+        Type::Triangle, Type::Quadrilateral, Type::Tetrahedron, Type::Pyramid,
+        Type::Hexahedron, Type::Wedge};
 
       /**
        * @brief Constructs a polytope with given dimension and index.

--- a/src/Rodin/Heart/CCMLC2014/Model/State.h
+++ b/src/Rodin/Heart/CCMLC2014/Model/State.h
@@ -37,9 +37,9 @@ namespace Rodin::Heart::CCMLC2014::Model
     VentricularPressure,    ///< @f$ p_v^{n+1} @f$ — left-ventricular pressure.
     ArterialPressure,       ///< @f$ p_{ar}^{n+1} @f$ — proximal arterial pressure.
     DistalPressure,         ///< @f$ p_d^{n+1} @f$ — distal pressure.
-    FiberDeformation,       ///< @f$ e_c^{n+1} @f$ — contractile deformation.
-    ActiveStiffness,        ///< @f$ k_c^{n+1} = \gamma^2 @f$.
-    ActiveStress,           ///< @f$ \tau_c^{n+1} = \gamma\beta @f$.
+    FiberDeformation, ///< @f$ e_c^{n+1} @f$ — contractile deformation.
+    ActiveStiffness, ///< @f$ k_c^{n+1} = \gamma^2 @f$.
+    ActiveStress, ///< @f$ \tau_c^{n+1} = \gamma\beta @f$.
     LoadDependentRelaxation, ///< @f$ w^{n+1} @f$.
     NumberOfVariables       ///< Total number of unknowns in the coupled system.
   };
@@ -50,7 +50,7 @@ namespace Rodin::Heart::CCMLC2014::Model
   enum class TimeScheme
   {
     BackwardEuler, ///< First-order L-stable backward Euler.
-    BDF2           ///< Second-order stiffly-damped BDF2 with BE startup.
+    BDF2 ///< Second-order stiffly-damped BDF2 with BE startup.
   };
 
   /**
@@ -58,8 +58,8 @@ namespace Rodin::Heart::CCMLC2014::Model
    */
   enum class WindkesselRheology
   {
-    Newtonian,              ///< Linear resistance branch flows.
-    CarreauYasuda,           ///< Non-Newtonian Carreau-Yasuda tube flow.
+    Newtonian, ///< Linear resistance branch flows.
+    CarreauYasuda, ///< Non-Newtonian Carreau-Yasuda tube flow.
     Cross,
     PowerLaw,
     Quemada
@@ -86,7 +86,7 @@ namespace Rodin::Heart::CCMLC2014::Model
     Scalar tauc = 0.0;  ///< Active stress-like scalar @f$ \tau_c = \gamma\beta @f$.
     Scalar gamma = 0.0; ///< Active state variable @f$ \gamma @f$.
     Scalar beta = 0.0;  ///< Active state variable @f$ \beta @f$.
-    Scalar w = 1.0;     ///< Load-dependent relaxation multiplier @f$ w @f$.
+    Scalar w = 1.0; ///< Load-dependent relaxation multiplier @f$ w @f$.
 
     Scalar t = 0.0;     ///< Time associated with this state.
   };
@@ -108,7 +108,8 @@ namespace Rodin::Heart::CCMLC2014::Model
     Scalar eta = 0.0;     ///< Viscous coefficient.
     Scalar mu = 0.0;      ///< Active-viscous coupling coefficient.
     Scalar alpha = 0.0;   ///< Active length-rate coupling coefficient.
-    Scalar alphaR = Scalar(0.12); ///< Relaxation time scale @f$ \alpha_r @f$ for @f$ w @f$.
+    Scalar alphaR =
+      Scalar(0.12); ///< Relaxation time scale @f$ \alpha_r @f$ for @f$ w @f$.
     Scalar k0 = 0.0;      ///< Active stiffness rate coefficient.
     Scalar sigma0 = 0.0;  ///< Active stress rate coefficient.
 
@@ -146,7 +147,8 @@ namespace Rodin::Heart::CCMLC2014::Model
     size_t localMaxIterations = 50;         ///< Maximum iterations for local active solve.
     Scalar localDamping = Scalar(1.0);      ///< Damping factor for local active Newton updates.
     Scalar absRegularization = Scalar(1e-14); ///< Regularization scalar for absolute values.
-    TimeScheme timeScheme = TimeScheme::BDF2; ///< Implicit time discretization for dynamic states.
+    TimeScheme timeScheme =
+      TimeScheme::BDF2; ///< Implicit time discretization for dynamic states.
     WindkesselRheology windkesselRheology =
       WindkesselRheology::Newtonian; ///< Rheology for reduced Windkessel branches.
 
@@ -157,11 +159,13 @@ namespace Rodin::Heart::CCMLC2014::Model
     std::function<Scalar(Scalar)> u =
       [](Scalar) { return Scalar(0); }; ///< Active input drive @f$ u(t) @f$.
 
-    std::function<Scalar(Scalar)> m0 =
-      [](Scalar) { return Scalar(1); }; ///< Relaxation target @f$ m_0(e_c) @f$.
+    std::function<Scalar(Scalar)> m0 = [](Scalar) {
+      return Scalar(1);
+    }; ///< Relaxation target @f$ m_0(e_c) @f$.
 
-    std::function<Scalar(Scalar)> dm0 =
-      [](Scalar) { return Scalar(0); }; ///< Derivative @f$ m_0'(e_c) @f$.
+    std::function<Scalar(Scalar)> dm0 = [](Scalar) {
+      return Scalar(0);
+    }; ///< Derivative @f$ m_0'(e_c) @f$.
 
     std::function<Scalar(Scalar)> pAt =
       [](Scalar) { return Scalar(0); }; ///< Atrial pressure boundary condition.
@@ -210,16 +214,17 @@ namespace Rodin::Heart::CCMLC2014::Model
 
     Scalar gammaPrevious = 0.0; ///< Previous global gamma state.
     Scalar betaPrevious = 0.0;  ///< Previous global beta state.
-    Scalar wPrevious = 1.0;     ///< Previous load-dependent relaxation state.
+    Scalar wPrevious = 1.0; ///< Previous load-dependent relaxation state.
     Scalar gammaCurrent = 0.0;  ///< Updated gamma state.
     Scalar betaCurrent = 0.0;   ///< Updated beta state.
-    Scalar wCurrent = 1.0;      ///< Updated load-dependent relaxation state.
+    Scalar wCurrent = 1.0; ///< Updated load-dependent relaxation state.
 
     Scalar activationDrive = 0.0;             ///< Value of @f$ u(t_{n+1}) @f$.
     Scalar activationDrivePositivePart = 0.0; ///< Positive part of activation drive.
-    Scalar activationDriveNegativePart = 0.0; ///< Negative part magnitude of activation drive.
-    Scalar relaxationTarget = 1.0;            ///< Target @f$ m_0(e_c^n) @f$ for @f$ w @f$.
-    Scalar relaxationDrive = 0.0;             ///< Effective decay drive @f$ |u|_+ + w |u|_- @f$.
+    Scalar activationDriveNegativePart =
+      0.0; ///< Negative part magnitude of activation drive.
+    Scalar relaxationTarget = 1.0; ///< Target @f$ m_0(e_c^n) @f$ for @f$ w @f$.
+    Scalar relaxationDrive = 0.0; ///< Effective decay drive @f$ |u|_+ + w |u|_- @f$.
     Scalar recruitmentFraction = 0.0;         ///< Recruitment fraction @f$ n_0 @f$.
 
     Scalar partialResidualWrtDisplacement = 0.0;     ///< Coupling residual derivative wrt displacement.
@@ -252,17 +257,17 @@ namespace Rodin::Heart::CCMLC2014::Model
     Scalar dt = 0.0;   ///< Time-step size.
 
     Scalar y = 0.0;   ///< Candidate @f$ y_{n+1} @f$.
-    Scalar v = 0.0;   ///< Candidate @f$ v_{n+1} @f$.
+    Scalar v = 0.0; ///< Candidate @f$ v_{n+1} @f$.
     Scalar pv = 0.0;  ///< Candidate @f$ p_v^{n+1} @f$.
     Scalar par = 0.0; ///< Candidate @f$ p_{ar}^{n+1} @f$.
     Scalar pd = 0.0;  ///< Candidate @f$ p_d^{n+1} @f$.
-    Scalar ec = 0.0;  ///< Candidate @f$ e_c^{n+1} @f$.
-    Scalar kc = 0.0;  ///< Candidate @f$ k_c^{n+1} @f$.
+    Scalar ec = 0.0; ///< Candidate @f$ e_c^{n+1} @f$.
+    Scalar kc = 0.0; ///< Candidate @f$ k_c^{n+1} @f$.
     Scalar tauc = 0.0; ///< Candidate @f$ \tau_c^{n+1} @f$.
-    Scalar w = 1.0;   ///< Candidate @f$ w^{n+1} @f$.
+    Scalar w = 1.0; ///< Candidate @f$ w^{n+1} @f$.
 
     Scalar yPrev = 0.0;   ///< @f$ y_n @f$.
-    Scalar vPrev = 0.0;   ///< @f$ v_n @f$.
+    Scalar vPrev = 0.0; ///< @f$ v_n @f$.
     Scalar pvPrev = 0.0;  ///< @f$ p_v^n @f$.
     Scalar parPrev = 0.0; ///< @f$ p_{ar}^n @f$.
     Scalar pdPrev = 0.0;  ///< @f$ p_d^n @f$.
@@ -284,7 +289,8 @@ namespace Rodin::Heart::CCMLC2014::Model
     Scalar diffStressPassive = 0.0;  ///< Derivative of passive stress wrt displacement.
     Scalar stressViscous = 0.0;      ///< Viscous stress contribution.
     Scalar diffStressViscous = 0.0;  ///< Derivative of viscous stress wrt displacement.
-    Scalar diffStressViscousWrtVelocity = 0.0; ///< Derivative of viscous stress wrt velocity.
+    Scalar diffStressViscousWrtVelocity =
+      0.0; ///< Derivative of viscous stress wrt velocity.
 
     Scalar pAtCur = 0.0;  ///< Atrial pressure at @f$ t_{n+1} @f$.
     Scalar pAtPrev = 0.0; ///< Atrial pressure at @f$ t_n @f$.
@@ -299,13 +305,12 @@ namespace Rodin::Heart::CCMLC2014::Model
     Scalar dWindkesselOutflow_dPv = 0.0; ///< Derivative of outflow wrt ventricular pressure.
     Scalar dWindkesselOutflow_dPar = 0.0; ///< Derivative of outflow wrt arterial pressure.
 
-    Scalar windkesselflowP = 0.0;    ///< flow term toward Windkessel branch.
-    Scalar windkesselflowD = 0.0;    ///< flow term toward Windkessel branch.
-    Scalar dWindkesselflowP_dPar = 0.0;  ///< Derivative of flow wrt ventricular pressure.
-    Scalar dWindkesselflowP_dPd = 0.0;  ///< Derivative of flow wrt ventricular pressure.
-    Scalar dWindkesselflowD_dPar = 0.0;  ///< Derivative of flow wrt arterial pressure.
-    Scalar dWindkesselflowD_dPd = 0.0;  ///< Derivative of flow wrt arterial pressure.
-
+    Scalar windkesselflowP = 0.0; ///< flow term toward Windkessel branch.
+    Scalar windkesselflowD = 0.0; ///< flow term toward Windkessel branch.
+    Scalar dWindkesselflowP_dPar = 0.0; ///< Derivative of flow wrt ventricular pressure.
+    Scalar dWindkesselflowP_dPd = 0.0; ///< Derivative of flow wrt ventricular pressure.
+    Scalar dWindkesselflowD_dPar = 0.0; ///< Derivative of flow wrt arterial pressure.
+    Scalar dWindkesselflowD_dPd = 0.0; ///< Derivative of flow wrt arterial pressure.
 
     LocalActiveDataT<Scalar> active; ///< Local active-dynamics data.
   };

--- a/src/Rodin/Heart/CCMLC2014/Numerics/DynamicSystem.h
+++ b/src/Rodin/Heart/CCMLC2014/Numerics/DynamicSystem.h
@@ -129,47 +129,38 @@ namespace Rodin::Heart::CCMLC2014::Numerics
           evalData.stressPassive + evalData.stressViscous
           + evalData.active.activeStress;
 
-        residualVector[Model::RadialDisplacement] =
-          yDot - evalData.v;
+        residualVector[Model::RadialDisplacement] = yDot - evalData.v;
 
-        residualVector[Model::RadialVelocity] =
-          m_input.d0 * m_input.rho * vDot
-          + m_input.d0 / m_input.R0 * geometricStretch * totalStress
-          - evalData.pv * geometricStretch * geometricStretch;
+        residualVector[Model::RadialVelocity] = m_input.d0 * m_input.rho * vDot +
+          m_input.d0 / m_input.R0 * geometricStretch * totalStress -
+          evalData.pv * geometricStretch * geometricStretch;
 
-        residualVector[Model::VentricularPressure] =
-          m_input.cavityCapacity * pvDot
-          + evalData.cavityFluxCur
-          + Scalar(4) * std::numbers::pi_v<Scalar>
-            * radius * radius * evalData.v;
+        residualVector[Model::VentricularPressure] = m_input.cavityCapacity * pvDot +
+          evalData.cavityFluxCur +
+          Scalar(4) * std::numbers::pi_v<Scalar> * radius * radius * evalData.v;
 
         residualVector[Model::ArterialPressure] =
-          m_input.Cp * parDot
-          + evalData.windkesselflowP;
+          m_input.Cp * parDot + evalData.windkesselflowP;
 
         residualVector[Model::DistalPressure] =
-          m_input.Cd * pdDot
-          + evalData.windkesselflowD;
+          m_input.Cd * pdDot + evalData.windkesselflowD;
 
         {
           const Scalar h = activeStretch(evalData.ec);
           const Scalar h3 = h * h * h;
           residualVector[Model::FiberDeformation] =
-            (evalData.tauc + m_input.mu * ecDot) * h3
-            - m_input.Es
-              * (evalData.strain1D - evalData.ec)
-              * (Scalar(1) + Scalar(2) * evalData.strain1D);
+            (evalData.tauc + m_input.mu * ecDot) * h3 -
+            m_input.Es * (evalData.strain1D - evalData.ec) *
+              (Scalar(1) + Scalar(2) * evalData.strain1D);
         }
 
         const auto active = evaluateActiveRates(evalData, ecDot);
-        residualVector[Model::ActiveStiffness] =
-          kcDot + active.rate * evalData.kc
-          - active.recruitment * m_input.k0 * active.uPositive;
+        residualVector[Model::ActiveStiffness] = kcDot + active.rate * evalData.kc -
+          active.recruitment * m_input.k0 * active.uPositive;
 
-        residualVector[Model::ActiveStress] =
-          taucDot - evalData.kc * ecDot
-          - active.recruitment * m_input.sigma0 * active.uPositive
-          + active.rate * evalData.tauc;
+        residualVector[Model::ActiveStress] = taucDot - evalData.kc * ecDot -
+          active.recruitment * m_input.sigma0 * active.uPositive +
+          active.rate * evalData.tauc;
 
         if (m_input.alphaR <= std::numeric_limits<Scalar>::epsilon())
         {
@@ -187,10 +178,8 @@ namespace Rodin::Heart::CCMLC2014::Numerics
        * @brief Assemble the exact Jacobian of the coupled residual.
        */
       template <class DenseMatrix, class EvalData>
-      void evaluateJacobian(
-          const EvalData& evalData,
-          DenseMatrix& jacobianMatrix,
-          typename DenseMatrix::Scalar) const
+      void evaluateJacobian(const EvalData& evalData, DenseMatrix& jacobianMatrix,
+        typename DenseMatrix::Scalar) const
       {
         using Scalar = typename DenseMatrix::Scalar;
         jacobianMatrix.resize(Model::NumberOfVariables, Model::NumberOfVariables);
@@ -206,33 +195,29 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         const Scalar F = Scalar(1) + Scalar(2) * evalData.strain1D;
 
         const Scalar totalStress =
-          evalData.stressPassive + evalData.stressViscous
-          + evalData.active.activeStress;
+          evalData.stressPassive + evalData.stressViscous + evalData.active.activeStress;
 
         // Kinematic equation: D(y) - v = 0
         jacobianMatrix(Model::RadialDisplacement, Model::RadialDisplacement) = a0;
         jacobianMatrix(Model::RadialDisplacement, Model::RadialVelocity) = -Scalar(1);
 
         // Wall momentum equation.
-        jacobianMatrix(Model::RadialVelocity, Model::RadialDisplacement) =
-          m_input.d0 / m_input.R0
-          * (dsdy * totalStress
-             + s * (evalData.diffStressPassive
-                    + evalData.diffStressViscous
-                    + evalData.active.dActiveStressWrtDisplacement))
-          - Scalar(2) * evalData.pv * s * dsdy;
+        jacobianMatrix(Model::RadialVelocity, Model::RadialDisplacement) = m_input.d0 /
+            m_input.R0 *
+            (dsdy * totalStress +
+              s *
+                (evalData.diffStressPassive + evalData.diffStressViscous +
+                  evalData.active.dActiveStressWrtDisplacement)) -
+          Scalar(2) * evalData.pv * s * dsdy;
 
         jacobianMatrix(Model::RadialVelocity, Model::RadialVelocity) =
-          m_input.d0 * m_input.rho * a0
-          + m_input.d0 / m_input.R0
-            * s * evalData.diffStressViscousWrtVelocity;
+          m_input.d0 * m_input.rho * a0 +
+          m_input.d0 / m_input.R0 * s * evalData.diffStressViscousWrtVelocity;
 
-        jacobianMatrix(Model::RadialVelocity, Model::VentricularPressure) =
-          -s * s;
+        jacobianMatrix(Model::RadialVelocity, Model::VentricularPressure) = -s * s;
 
-        jacobianMatrix(Model::RadialVelocity, Model::FiberDeformation) =
-          m_input.d0 / m_input.R0
-          * s * evalData.active.partialActiveStressWrtFiberDeformation;
+        jacobianMatrix(Model::RadialVelocity, Model::FiberDeformation) = m_input.d0 /
+          m_input.R0 * s * evalData.active.partialActiveStressWrtFiberDeformation;
 
         // Cavity pressure balance.
         jacobianMatrix(Model::VentricularPressure, Model::RadialDisplacement) =
@@ -262,8 +247,7 @@ namespace Rodin::Heart::CCMLC2014::Numerics
           evalData.dWindkesselflowD_dPar;
 
         jacobianMatrix(Model::DistalPressure, Model::DistalPressure) +=
-          m_input.Cd * a0
-          + evalData.dWindkesselflowD_dPd;
+          m_input.Cd * a0 + evalData.dWindkesselflowD_dPd;
 
         // Fiber-deformation equilibrium.
         const Scalar ecDot =
@@ -277,9 +261,7 @@ namespace Rodin::Heart::CCMLC2014::Numerics
           -m_input.Es * dEdy * (F + Scalar(2) * (evalData.strain1D - evalData.ec));
 
         jacobianMatrix(Model::FiberDeformation, Model::FiberDeformation) =
-          m_input.mu * a0 * h3
-          + Scalar(6) * activeRateStress * h2
-          + m_input.Es * F;
+          m_input.mu * a0 * h3 + Scalar(6) * activeRateStress * h2 + m_input.Es * F;
 
         jacobianMatrix(Model::FiberDeformation, Model::ActiveStress) = h3;
 
@@ -289,26 +271,20 @@ namespace Rodin::Heart::CCMLC2014::Numerics
 
         // Active stiffness evolution.
         jacobianMatrix(Model::ActiveStiffness, Model::FiberDeformation) =
-          evalData.kc * dRateDec
-          - dn0Dec * m_input.k0 * active.uPositive;
+          evalData.kc * dRateDec - dn0Dec * m_input.k0 * active.uPositive;
 
-        jacobianMatrix(Model::ActiveStiffness, Model::ActiveStiffness) =
-          a0 + active.rate;
+        jacobianMatrix(Model::ActiveStiffness, Model::ActiveStiffness) = a0 + active.rate;
 
         jacobianMatrix(Model::ActiveStiffness, Model::LoadDependentRelaxation) =
           evalData.kc * active.uNegative;
 
         // Active stress evolution.
-        jacobianMatrix(Model::ActiveStress, Model::FiberDeformation) =
-          -evalData.kc * a0
-          - dn0Dec * m_input.sigma0 * active.uPositive
-          + evalData.tauc * dRateDec;
+        jacobianMatrix(Model::ActiveStress, Model::FiberDeformation) = -evalData.kc * a0 -
+          dn0Dec * m_input.sigma0 * active.uPositive + evalData.tauc * dRateDec;
 
-        jacobianMatrix(Model::ActiveStress, Model::ActiveStiffness) =
-          -ecDot;
+        jacobianMatrix(Model::ActiveStress, Model::ActiveStiffness) = -ecDot;
 
-        jacobianMatrix(Model::ActiveStress, Model::ActiveStress) =
-          a0 + active.rate;
+        jacobianMatrix(Model::ActiveStress, Model::ActiveStress) = a0 + active.rate;
 
         jacobianMatrix(Model::ActiveStress, Model::LoadDependentRelaxation) =
           evalData.tauc * active.uNegative;
@@ -316,22 +292,16 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         // Load-dependent relaxation.
         if (m_input.alphaR <= std::numeric_limits<Scalar>::epsilon())
         {
-          jacobianMatrix(
-              Model::LoadDependentRelaxation,
-              Model::FiberDeformation) = -m_input.dm0(evalData.ec);
-          jacobianMatrix(
-              Model::LoadDependentRelaxation,
-              Model::LoadDependentRelaxation) = Scalar(1);
+          jacobianMatrix(Model::LoadDependentRelaxation, Model::FiberDeformation) =
+            -m_input.dm0(evalData.ec);
+          jacobianMatrix(Model::LoadDependentRelaxation, Model::LoadDependentRelaxation) =
+            Scalar(1);
         }
         else
         {
-          jacobianMatrix(
-              Model::LoadDependentRelaxation,
-              Model::FiberDeformation) =
+          jacobianMatrix(Model::LoadDependentRelaxation, Model::FiberDeformation) =
             -m_input.dm0(evalData.ec) / m_input.alphaR;
-          jacobianMatrix(
-              Model::LoadDependentRelaxation,
-              Model::LoadDependentRelaxation) =
+          jacobianMatrix(Model::LoadDependentRelaxation, Model::LoadDependentRelaxation) =
             a0 + Scalar(1) / m_input.alphaR;
         }
       }
@@ -340,60 +310,48 @@ namespace Rodin::Heart::CCMLC2014::Numerics
       template <class Scalar>
       struct TimeCoefficients
       {
-        Scalar current = 0.0;
-        Scalar previous = 0.0;
-        Scalar previousPrevious = 0.0;
+          Scalar current = 0.0;
+          Scalar previous = 0.0;
+          Scalar previousPrevious = 0.0;
       };
 
       template <class Scalar>
       struct RecruitmentData
       {
-        Scalar value = 0.0;
-        Scalar derivative = 0.0;
+          Scalar value = 0.0;
+          Scalar derivative = 0.0;
       };
 
       template <class Scalar>
       struct ActiveRateData
       {
-        Scalar uPositive = 0.0;
-        Scalar uNegative = 0.0;
-        Scalar recruitment = 0.0;
-        Scalar dRecruitmentDEc = 0.0;
-        Scalar rate = 0.0;
-        Scalar dRateDEcDot = 0.0;
+          Scalar uPositive = 0.0;
+          Scalar uNegative = 0.0;
+          Scalar recruitment = 0.0;
+          Scalar dRecruitmentDEc = 0.0;
+          Scalar rate = 0.0;
+          Scalar dRateDEcDot = 0.0;
       };
 
       template <class EvalData>
-      TimeCoefficients<decltype(std::declval<EvalData>().y)>
-      getTimeCoefficients(const EvalData& data) const
+      TimeCoefficients<decltype(std::declval<EvalData>().y)> getTimeCoefficients(
+        const EvalData& data) const
       {
         using Scalar = decltype(data.y);
-        if (m_input.timeScheme == Model::TimeScheme::BDF2
-            && data.sn.t > data.snm1.t + Scalar(0.5) * data.dt)
+        if (m_input.timeScheme == Model::TimeScheme::BDF2 &&
+          data.sn.t > data.snm1.t + Scalar(0.5) * data.dt)
         {
-          return {
-            Scalar(1.5) / data.dt,
-            -Scalar(2) / data.dt,
-            Scalar(0.5) / data.dt
-          };
+          return {Scalar(1.5) / data.dt, -Scalar(2) / data.dt, Scalar(0.5) / data.dt};
         }
-        return {
-          Scalar(1) / data.dt,
-          -Scalar(1) / data.dt,
-          Scalar(0)
-        };
+        return {Scalar(1) / data.dt, -Scalar(1) / data.dt, Scalar(0)};
       }
 
       template <class Scalar>
-      static Scalar timeDerivative(
-          Scalar current,
-          Scalar previous,
-          Scalar previousPrevious,
-          const TimeCoefficients<Scalar>& tc)
+      static Scalar timeDerivative(Scalar current, Scalar previous,
+        Scalar previousPrevious, const TimeCoefficients<Scalar>& tc)
       {
-        return tc.current * current
-             + tc.previous * previous
-             + tc.previousPrevious * previousPrevious;
+        return tc.current * current + tc.previous * previous +
+          tc.previousPrevious * previousPrevious;
       }
 
       template <class Scalar>
@@ -470,8 +428,8 @@ namespace Rodin::Heart::CCMLC2014::Numerics
       }
 
       template <class EvalData>
-      ActiveRateData<decltype(std::declval<EvalData>().y)>
-      evaluateActiveRates(const EvalData& data, decltype(std::declval<EvalData>().y) ecDot) const
+      ActiveRateData<decltype(std::declval<EvalData>().y)> evaluateActiveRates(
+        const EvalData& data, decltype(std::declval<EvalData>().y) ecDot) const
       {
         using Scalar = decltype(data.y);
         ActiveRateData<Scalar> result;
@@ -483,11 +441,9 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         result.recruitment = recruitment.value;
         result.dRecruitmentDEc = recruitment.derivative;
 
-        result.rate =
-          result.uPositive + data.w * result.uNegative
-          + m_input.alpha * regularizedAbs(ecDot);
-        result.dRateDEcDot =
-          m_input.alpha * regularizedAbsDerivative(ecDot);
+        result.rate = result.uPositive + data.w * result.uNegative +
+          m_input.alpha * regularizedAbs(ecDot);
+        result.dRateDEcDot = m_input.alpha * regularizedAbsDerivative(ecDot);
         return result;
       }
 
@@ -509,39 +465,29 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         Scalar passiveStress = 0.0;
         Scalar passiveStressDerivativeWrtDisplacement = 0.0;
         PassiveLaw passiveLaw;
-        passiveLaw(
-            m_input.passiveEnergy,
-            data.C,
-            Scalar(2) * data.sqrtC / m_input.R0,
-            passiveStress,
-            passiveStressDerivativeWrtDisplacement);
+        passiveLaw(m_input.passiveEnergy, data.C, Scalar(2) * data.sqrtC / m_input.R0,
+          passiveStress, passiveStressDerivativeWrtDisplacement);
 
         data.stressPassive = passiveStress;
         data.diffStressPassive = passiveStressDerivativeWrtDisplacement;
 
         const Scalar s = data.sqrtC;
         const Scalar eta = m_input.eta;
-        data.stressViscous =
-          eta * data.v / m_input.R0
-          * (Scalar(2) * s + Scalar(4) * std::pow(s, Scalar(-11)));
-        data.diffStressViscous =
-          eta * data.v / (m_input.R0 * m_input.R0)
-          * (Scalar(2) - Scalar(44) * std::pow(s, Scalar(-12)));
+        data.stressViscous = eta * data.v / m_input.R0 *
+          (Scalar(2) * s + Scalar(4) * std::pow(s, Scalar(-11)));
+        data.diffStressViscous = eta * data.v / (m_input.R0 * m_input.R0) *
+          (Scalar(2) - Scalar(44) * std::pow(s, Scalar(-12)));
         data.diffStressViscousWrtVelocity =
-          eta / m_input.R0
-          * (Scalar(2) * s + Scalar(4) * std::pow(s, Scalar(-11)));
+          eta / m_input.R0 * (Scalar(2) * s + Scalar(4) * std::pow(s, Scalar(-11)));
 
         const Scalar h = activeStretch(data.ec);
         const Scalar h2 = h * h;
         const Scalar h3 = h2 * h;
         data.active.activeStressOneDimensional =
           m_input.Es / h2 * (data.strain1D - data.ec);
-        data.active.partialActiveStressWrtDisplacement =
-          m_input.Es / h2 * data.diffGreen;
+        data.active.partialActiveStressWrtDisplacement = m_input.Es / h2 * data.diffGreen;
         data.active.partialActiveStressWrtFiberDeformation =
-          m_input.Es
-          * (-Scalar(1) / h2
-             - Scalar(4) * (data.strain1D - data.ec) / h3);
+          m_input.Es * (-Scalar(1) / h2 - Scalar(4) * (data.strain1D - data.ec) / h3);
 
         data.active.activeStress = data.active.activeStressOneDimensional;
         data.active.dActiveStressWrtDisplacement =
@@ -553,8 +499,7 @@ namespace Rodin::Heart::CCMLC2014::Numerics
       {
         using Scalar = decltype(data.y);
         const auto tc = getTimeCoefficients(data);
-        const Scalar ecDot =
-          timeDerivative(data.ec, data.sn.ec, data.snm1.ec, tc);
+        const Scalar ecDot = timeDerivative(data.ec, data.sn.ec, data.snm1.ec, tc);
         const auto active = evaluateActiveRates(data, ecDot);
 
         data.active.fiberDeformationPrevious = data.sn.ec;
@@ -563,10 +508,8 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         data.active.gammaPrevious = data.sn.gamma;
         data.active.betaPrevious = data.sn.beta;
         data.active.wPrevious = data.sn.w;
-        data.active.gammaCurrent =
-          std::sqrt(std::max<Scalar>(data.kc, Scalar(0)));
-        data.active.betaCurrent =
-          (data.active.gammaCurrent > Scalar(0))
+        data.active.gammaCurrent = std::sqrt(std::max<Scalar>(data.kc, Scalar(0)));
+        data.active.betaCurrent = (data.active.gammaCurrent > Scalar(0))
           ? data.tauc / data.active.gammaCurrent
           : Scalar(0);
         data.active.wCurrent = data.w;
@@ -586,8 +529,7 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         using Scalar = decltype(data.y);
 
         const bool mitralOpenCurrent = data.pv <= data.pAtCur;
-        const bool bothClosedCurrent =
-          data.pAtCur <= data.pv && data.pv <= data.par;
+        const bool bothClosedCurrent = data.pAtCur <= data.pv && data.pv <= data.par;
 
         if (mitralOpenCurrent)
         {
@@ -604,8 +546,7 @@ namespace Rodin::Heart::CCMLC2014::Numerics
         else
         {
           data.cavityFluxCur =
-            m_input.Kar * (data.pv - data.par)
-            + m_input.Kp * (data.par - data.pAtCur);
+            m_input.Kar * (data.pv - data.par) + m_input.Kp * (data.par - data.pAtCur);
           data.dCavityFluxCur_dPv = m_input.Kar;
           data.dCavityFluxCur_dPar = -m_input.Kar + m_input.Kp;
         }
@@ -614,37 +555,32 @@ namespace Rodin::Heart::CCMLC2014::Numerics
 
         if (m_input.windkesselRheology == Model::WindkesselRheology::CarreauYasuda)
         {
-          Physics::WindkesselOutflowEvaluator<
-            Input,
-            Physics::Rheology::CarreauYasuda> windkessel(m_input);
+          Physics::WindkesselOutflowEvaluator<Input, Physics::Rheology::CarreauYasuda>
+            windkessel(m_input);
           windkessel.evaluate(data);
         }
         else if (m_input.windkesselRheology == Model::WindkesselRheology::Cross)
         {
-          Physics::WindkesselOutflowEvaluator<
-            Input,
-            Physics::Rheology::Cross> windkessel(m_input);
+          Physics::WindkesselOutflowEvaluator<Input, Physics::Rheology::Cross> windkessel(
+            m_input);
           windkessel.evaluate(data);
         }
         else if (m_input.windkesselRheology == Model::WindkesselRheology::PowerLaw)
         {
-          Physics::WindkesselOutflowEvaluator<
-            Input,
-            Physics::Rheology::PowerLaw> windkessel(m_input);
+          Physics::WindkesselOutflowEvaluator<Input, Physics::Rheology::PowerLaw>
+            windkessel(m_input);
           windkessel.evaluate(data);
         }
         else if (m_input.windkesselRheology == Model::WindkesselRheology::Quemada)
         {
-          Physics::WindkesselOutflowEvaluator<
-            Input,
-            Physics::Rheology::Quemada> windkessel(m_input);
+          Physics::WindkesselOutflowEvaluator<Input, Physics::Rheology::Quemada>
+            windkessel(m_input);
           windkessel.evaluate(data);
         }
         else
         {
-          Physics::WindkesselOutflowEvaluator<
-            Input,
-            Physics::Rheology::Newtonian> windkessel(m_input);
+          Physics::WindkesselOutflowEvaluator<Input, Physics::Rheology::Newtonian>
+            windkessel(m_input);
           windkessel.evaluate(data);
         }
       }

--- a/src/Rodin/Heart/CCMLC2014/Physics/Windkessel.h
+++ b/src/Rodin/Heart/CCMLC2014/Physics/Windkessel.h
@@ -31,35 +31,35 @@ namespace Rodin::Heart::CCMLC2014::Physics
   struct SolverConfig
   {
     /// @brief Pressure-drop threshold for the Poiseuille fallback.
-    static constexpr Real pressureDropTolerance = 1.0e-12;
+      static constexpr Real pressureDropTolerance = 1.0e-12;
     /// @brief Minimum shear-rate bracket.
-    static constexpr Real minShearRate = 1.0e-8;
+      static constexpr Real minShearRate = 1.0e-8;
     /// @brief Number of RK4 substeps for the WRMS flow integral.
-    static constexpr int integralSteps = 100;
+      static constexpr int integralSteps = 100;
     /// @brief Maximum bracketing expansions for outlet scalar solves.
-    static constexpr int maxBracketIterations = 100;
+      static constexpr int maxBracketIterations = 100;
     /// @brief Wall shear root solver absolute tolerance.
-    static constexpr Real shearAbsoluteTolerance = 1.0e-12;
+      static constexpr Real shearAbsoluteTolerance = 1.0e-12;
     /// @brief Wall shear root solver relative tolerance.
-    static constexpr Real shearRelativeTolerance = 1.0e-10;
+      static constexpr Real shearRelativeTolerance = 1.0e-10;
     /// @brief Wall shear root solver step tolerance.
-    static constexpr Real shearStepTolerance = 1.0e-12;
+      static constexpr Real shearStepTolerance = 1.0e-12;
     /// @brief Wall shear root solver maximum iterations.
-    static constexpr int shearMaxIterations = 50;
+      static constexpr int shearMaxIterations = 50;
     /// @brief Flow inversion root solver absolute tolerance.
-    static constexpr Real flowAbsoluteTolerance = 1.0e-10;
+      static constexpr Real flowAbsoluteTolerance = 1.0e-10;
     /// @brief Flow inversion root solver relative tolerance.
-    static constexpr Real flowRelativeTolerance = 1.0e-9;
+      static constexpr Real flowRelativeTolerance = 1.0e-9;
     /// @brief Flow inversion root solver step tolerance.
-    static constexpr Real flowStepTolerance = 1.0e-12;
+      static constexpr Real flowStepTolerance = 1.0e-12;
     /// @brief Flow inversion root solver maximum iterations.
-    static constexpr int flowMaxIterations = 50;
+      static constexpr int flowMaxIterations = 50;
     /// @brief Flow magnitude treated as zero in pressure-drop inversion.
-    static constexpr Real zeroFlowTolerance = 1.0e-16;
+      static constexpr Real zeroFlowTolerance = 1.0e-16;
     /// @brief Minimum pressure-drop bracket.
-    static constexpr Real pressureDropBracketMin = 1.0;
+      static constexpr Real pressureDropBracketMin = 1.0;
     /// @brief Distal capacitor bracket pressure pad.
-    static constexpr Real distalPressureBracketPad = 1000.0;
+      static constexpr Real distalPressureBracketPad = 1000.0;
   };
 
   namespace Rheology
@@ -85,13 +85,13 @@ namespace Rodin::Heart::CCMLC2014::Physics
         {
           return {dp / fallbackResistance, 1.0 / fallbackResistance};
         }
-  };
+    };
 
   /**
    * @brief Power-law non-Newtonian branch-flow law.
    */
-  struct PowerLaw
-  {
+    struct PowerLaw
+    {
     /**
      * @brief Evaluates flow and derivative with respect to pressure drop.
      * @tparam Input Model input type.
@@ -102,41 +102,41 @@ namespace Rodin::Heart::CCMLC2014::Physics
      * @param input Model input parameters.
      * @return Pair containing flow and derivative.
      */
-      template <typename Input>
-      static std::pair<Real, Real> flowLaw(
-        Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
-      {
-        if (L <= 0.0 || radius <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
+        template <typename Input>
+        static std::pair<Real, Real> flowLaw(
+          Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
+        {
+          if (L <= 0.0 || radius <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-        const Real adp = std::abs(dp);
-        const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
+          const Real adp = std::abs(dp);
+          const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
 
-        if (adp < SolverConfig::pressureDropTolerance)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
+          if (adp < SolverConfig::pressureDropTolerance)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-        const Real m = input.m;
-        const Real n = input.n;
-        const Real invN = 1.0 / n;
-        const Real tauW = (radius * adp) / (2.0 * L);
+          const Real m = input.m;
+          const Real n = input.n;
+          const Real invN = 1.0 / n;
+          const Real tauW = (radius * adp) / (2.0 * L);
 
-        const Real piR3 = std::numbers::pi_v<Real> * std::pow(radius, 3.0);
-        const Real qAbs = (n * piR3 / (3.0 * n + 1.0)) * std::pow(tauW / m, invN);
+          const Real piR3 = std::numbers::pi_v<Real> * std::pow(radius, 3.0);
+          const Real qAbs = (n * piR3 / (3.0 * n + 1.0)) * std::pow(tauW / m, invN);
 
-        const Real dqAbs = invN * (qAbs / adp);
+          const Real dqAbs = invN * (qAbs / adp);
 
-        if (!std::isfinite(qAbs) || dqAbs <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
+          if (!std::isfinite(qAbs) || dqAbs <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-        return {sgn * qAbs, dqAbs};
-      }
-  };
+          return {sgn * qAbs, dqAbs};
+        }
+    };
 
   /**
    * @brief Quemada non-Newtonian branch-flow law.
    */
-  struct Quemada
-  {
+    struct Quemada
+    {
     /**
      * @brief Evaluates flow and derivative with respect to pressure drop.
      * @tparam Input Model input type.
@@ -147,137 +147,138 @@ namespace Rodin::Heart::CCMLC2014::Physics
      * @param input Model input parameters.
      * @return Pair containing flow and derivative.
      */
-      template <typename Input>
-      static std::pair<Real, Real> flowLaw(
-        Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
-      {
-        if (L <= 0.0 || radius <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
-
-        const Real adp = std::abs(dp);
-        const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
-
-        if (adp < SolverConfig::pressureDropTolerance)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
-
-        const Real tauW = (adp * radius) / (2.0 * L);
-        const Real k0 = input.k_0;
-        const Real kInf = input.k_Inf;
-        const Real phi = input.phi_quemada;
-        const Real gammaC = input.gamma_c;
-        const Real muPl = input.mu_plasma;
-        const Real muInfBlood = input.mu_Inf;
-
-        const Real oneMinusHalfKInfPhi = 1.0 - 0.5 * kInf * phi;
-        const Real tau_0 = muInfBlood * gammaC * std::pow(0.5 * phi * (k0 - kInf), 2.0) /
-          std::pow(oneMinusHalfKInfPhi, 4.0);
-        const Real nu_inf = muInfBlood / std::pow(oneMinusHalfKInfPhi, 2.0);
-        const Real lambda =
-          gammaC * std::pow((1.0 - 0.5 * k0 * phi) / oneMinusHalfKInfPhi, 2.0);
-
-        const Real sqrtTau0 = std::sqrt(tau_0);
-        const Real sqrtNuInfLambda = std::sqrt(nu_inf * lambda);
-
-        const Real q =
-          (sqrtTau0 - sqrtNuInfLambda) / std::max(sqrtTau0 + sqrtNuInfLambda, 1e-12);
-        const Real alpha =
-          (sqrtTau0 + sqrtNuInfLambda) / std::max(std::sqrt(tauW), 1e-12);
-
-        Real P[8];
+        template <typename Input>
+        static std::pair<Real, Real> flowLaw(
+          Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
         {
-          const Real q2 = q * q;
-          const Real q3 = q2 * q;
-          const Real q4 = q3 * q;
-          const Real q5 = q4 * q;
-          const Real q6 = q5 * q;
-          const Real q7 = q6 * q;
+          if (L <= 0.0 || radius <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-          P[0] = -(1.0 / 7.0) * (q + 8.0);
-          P[1] = -(1.0 / 42.0) * (13.0 * q2 - 8.0 * q - 7.0);
-          P[2] = -(1.0 / 210.0) * (143.0 * q3 - 88.0 * q2 - 113.0 * q + 48.0);
-          P[3] =
-            -(1.0 / 840.0) * (1287.0 * q4 - 792.0 * q3 - 1342.0 * q2 + 632.0 * q + 175.0);
-          P[4] = -(1.0 / 840.0) *
-            (3003.0 * q5 - 1848.0 * q4 - 3894.0 * q3 + 1944.0 * q2 + 1011.0 * q - 256.0);
-          P[5] = -(1.0 / 1680.0) *
-            (15015.0 * q6 - 9240.0 * q5 - 23331.0 * q4 + 12096.0 * q3 + 9081.0 * q2 -
-              3179.0 * q - 525.0);
-          P[6] = -(1.0 / 1680.0) *
-            (45045.0 * q7 - 27720.0 * q6 - 82005.0 * q5 + 43680.0 * q4 + 42819.0 * q3 -
-              17304.0 * q2 - 5619.0 * q + 1024.0);
-          P[7] = -(1.0 / 16.0) * std::pow(1.0 - q, 2.0) * (1.0 + q) *
-            (429.0 * q5 + 165.0 * q4 - 330.0 * q3 - 90.0 * q2 + 45.0 * q + 5.0);
-        }
+          const Real adp = std::abs(dp);
+          const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
 
-        Real F = 0.0, dFdAlpha = 0.0;
+          if (adp < SolverConfig::pressureDropTolerance)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-        if (alpha > 1.0)
-        {
-          const Real common = (2.0 / 9.0) * std::pow(1.0 - q, 2.0) * (1.0 + q);
-          F = 0.5 * (0.25 * std::pow(1.0 - q, 2.0) + common / alpha);
-          dFdAlpha = 0.5 * (-common / (alpha * alpha));
-        }
-        else
-        {
-          const Real a = std::max(alpha, 1e-10);
-          const Real a2 = a * a;
-          const Real a7 = a2 * a2 * a2 * a;
-          const Real a8 = a7 * a;
+          const Real tauW = (adp * radius) / (2.0 * L);
+          const Real k0 = input.k_0;
+          const Real kInf = input.k_Inf;
+          const Real phi = input.phi_quemada;
+          const Real gammaC = input.gamma_c;
+          const Real muPl = input.mu_plasma;
+          const Real muInfBlood = input.mu_Inf;
 
-          Real S = 0.0, derS = 0.0;
-          Real aPow = a;
-          for (int i = 0; i < 7; ++i)
+          const Real oneMinusHalfKInfPhi = 1.0 - 0.5 * kInf * phi;
+          const Real tau_0 = muInfBlood * gammaC *
+            std::pow(0.5 * phi * (k0 - kInf), 2.0) / std::pow(oneMinusHalfKInfPhi, 4.0);
+          const Real nu_inf = muInfBlood / std::pow(oneMinusHalfKInfPhi, 2.0);
+          const Real lambda =
+            gammaC * std::pow((1.0 - 0.5 * k0 * phi) / oneMinusHalfKInfPhi, 2.0);
+
+          const Real sqrtTau0 = std::sqrt(tau_0);
+          const Real sqrtNuInfLambda = std::sqrt(nu_inf * lambda);
+
+          const Real q =
+            (sqrtTau0 - sqrtNuInfLambda) / std::max(sqrtTau0 + sqrtNuInfLambda, 1e-12);
+          const Real alpha =
+            (sqrtTau0 + sqrtNuInfLambda) / std::max(std::sqrt(tauW), 1e-12);
+
+          Real P[8];
           {
-            S += aPow * P[i];
-            derS += (i + 1) * (aPow / a) * P[i];
-            aPow *= a;
+            const Real q2 = q * q;
+            const Real q3 = q2 * q;
+            const Real q4 = q3 * q;
+            const Real q5 = q4 * q;
+            const Real q6 = q5 * q;
+            const Real q7 = q6 * q;
+
+            P[0] = -(1.0 / 7.0) * (q + 8.0);
+            P[1] = -(1.0 / 42.0) * (13.0 * q2 - 8.0 * q - 7.0);
+            P[2] = -(1.0 / 210.0) * (143.0 * q3 - 88.0 * q2 - 113.0 * q + 48.0);
+            P[3] = -(1.0 / 840.0) *
+              (1287.0 * q4 - 792.0 * q3 - 1342.0 * q2 + 632.0 * q + 175.0);
+            P[4] = -(1.0 / 840.0) *
+              (3003.0 * q5 - 1848.0 * q4 - 3894.0 * q3 + 1944.0 * q2 + 1011.0 * q -
+                256.0);
+            P[5] = -(1.0 / 1680.0) *
+              (15015.0 * q6 - 9240.0 * q5 - 23331.0 * q4 + 12096.0 * q3 + 9081.0 * q2 -
+                3179.0 * q - 525.0);
+            P[6] = -(1.0 / 1680.0) *
+              (45045.0 * q7 - 27720.0 * q6 - 82005.0 * q5 + 43680.0 * q4 + 42819.0 * q3 -
+                17304.0 * q2 - 5619.0 * q + 1024.0);
+            P[7] = -(1.0 / 16.0) * std::pow(1.0 - q, 2.0) * (1.0 + q) *
+              (429.0 * q5 + 165.0 * q4 - 330.0 * q3 - 90.0 * q2 + 45.0 * q + 5.0);
           }
 
-          const Real T = std::max(0.0, 1.0 - 2.0 * a * q + a2);
-          const Real sqrtT = std::sqrt(T);
+          Real F = 0.0, dFdAlpha = 0.0;
 
-          const Real safeDenom = std::max(1.0 - q, 1e-10);
-          const Real argLog = (1.0 - a * q + sqrtT) / (a * safeDenom);
-          const Real logT = (argLog <= 1e-12) ? 0.0 : std::log(argLog);
+          if (alpha > 1.0)
+          {
+            const Real common = (2.0 / 9.0) * std::pow(1.0 - q, 2.0) * (1.0 + q);
+            F = 0.5 * (0.25 * std::pow(1.0 - q, 2.0) + common / alpha);
+            dFdAlpha = 0.5 * (-common / (alpha * alpha));
+          }
+          else
+          {
+            const Real a = std::max(alpha, 1e-10);
+            const Real a2 = a * a;
+            const Real a7 = a2 * a2 * a2 * a;
+            const Real a8 = a7 * a;
 
-          const Real bracket = 1.0 - (8.0 / 7.0) * a * (1.0 + q) + (4.0 / 3.0) * a2 -
-            a8 * P[6] + (1.0 + S) * sqrtT + a8 * P[7] * logT;
-          F = 0.5 * bracket;
+            Real S = 0.0, derS = 0.0;
+            Real aPow = a;
+            for (int i = 0; i < 7; ++i)
+            {
+              S += aPow * P[i];
+              derS += (i + 1) * (aPow / a) * P[i];
+              aPow *= a;
+            }
 
-          const Real eps = 1e-12;
-          const Real dSqrtT = (a - q) / std::max(sqrtT, eps);
-          const Real dLogT =
-            ((dSqrtT - q) / std::max(1.0 - a * q + sqrtT, eps)) - (1.0 / a);
+            const Real T = std::max(0.0, 1.0 - 2.0 * a * q + a2);
+            const Real sqrtT = std::sqrt(T);
 
-          Real dBracket = -(8.0 / 7.0) * (1.0 + q) + (8.0 / 3.0) * a - 8.0 * a7 * P[6];
-          dBracket += (derS * sqrtT + (1.0 + S) * dSqrtT);
-          dBracket += P[7] * (8.0 * a7 * logT + a8 * dLogT);
+            const Real safeDenom = std::max(1.0 - q, 1e-10);
+            const Real argLog = (1.0 - a * q + sqrtT) / (a * safeDenom);
+            const Real logT = (argLog <= 1e-12) ? 0.0 : std::log(argLog);
 
-          dFdAlpha = 0.5 * dBracket;
+            const Real bracket = 1.0 - (8.0 / 7.0) * a * (1.0 + q) + (4.0 / 3.0) * a2 -
+              a8 * P[6] + (1.0 + S) * sqrtT + a8 * P[7] * logT;
+            F = 0.5 * bracket;
+
+            const Real eps = 1e-12;
+            const Real dSqrtT = (a - q) / std::max(sqrtT, eps);
+            const Real dLogT =
+              ((dSqrtT - q) / std::max(1.0 - a * q + sqrtT, eps)) - (1.0 / a);
+
+            Real dBracket = -(8.0 / 7.0) * (1.0 + q) + (8.0 / 3.0) * a - 8.0 * a7 * P[6];
+            dBracket += (derS * sqrtT + (1.0 + S) * dSqrtT);
+            dBracket += P[7] * (8.0 * a7 * logT + a8 * dLogT);
+
+            dFdAlpha = 0.5 * dBracket;
+          }
+
+          const Real constPart = std::pow(oneMinusHalfKInfPhi, 2.0) / (4.0 * muPl);
+          const Real IQ = std::pow(tauW, 4.0) * constPart * F;
+
+          const Real geomFactor =
+            (8.0 * std::numbers::pi_v<Real> * std::pow(L, 3.0)) / std::pow(adp, 3.0);
+          const Real qAbs = geomFactor * IQ;
+
+          const Real dqAbs =
+            (qAbs / adp) * (1.0 - 0.5 * alpha * dFdAlpha / std::max(F, 1e-12));
+
+          if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
+
+          return {sgn * qAbs, dqAbs};
         }
-
-        const Real constPart = std::pow(oneMinusHalfKInfPhi, 2.0) / (4.0 * muPl);
-        const Real IQ = std::pow(tauW, 4.0) * constPart * F;
-
-        const Real geomFactor =
-          (8.0 * std::numbers::pi_v<Real> * std::pow(L, 3.0)) / std::pow(adp, 3.0);
-        const Real qAbs = geomFactor * IQ;
-
-        const Real dqAbs =
-          (qAbs / adp) * (1.0 - 0.5 * alpha * dFdAlpha / std::max(F, 1e-12));
-
-        if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
-
-        return {sgn * qAbs, dqAbs};
-    }
-  };
+    };
 
   /**
    * @brief Cross non-Newtonian branch-flow law.
    */
-  struct Cross
-  {
+    struct Cross
+    {
     /**
      * @brief Evaluates flow and derivative with respect to pressure drop.
      * @tparam Input Model input type.
@@ -288,139 +289,141 @@ namespace Rodin::Heart::CCMLC2014::Physics
      * @param input Model input parameters.
      * @return Pair containing flow and derivative.
      */
-      template <typename Input>
-      static std::pair<Real, Real> flowLaw(
-        Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
-      {
-        if (L <= 0.0 || radius <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
+        template <typename Input>
+        static std::pair<Real, Real> flowLaw(
+          Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
+        {
+          if (L <= 0.0 || radius <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
 
-        const Real mu0 = input.mu_0;
-        const Real muInf = input.mu_Inf;
-        const Real lambda = input.lambda;
+          const Real mu0 = input.mu_0;
+          const Real muInf = input.mu_Inf;
+          const Real lambda = input.lambda;
 
       // In the Cross law, input.n is the Cross transition exponent.
-        const Real n = input.n;
-        const Real delta = mu0 - muInf;
+          const Real n = input.n;
+          const Real delta = mu0 - muInf;
 
-        const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
-        const Real adp = std::abs(dp);
+          const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
+          const Real adp = std::abs(dp);
 
-        const Real R0 =
-          8.0 * mu0 * L / (std::numbers::pi_v<Real> * std::pow(radius, 4.0));
+          const Real R0 =
+            8.0 * mu0 * L / (std::numbers::pi_v<Real> * std::pow(radius, 4.0));
 
-        if (adp < SolverConfig::pressureDropTolerance)
-          return {dp / R0, 1.0 / R0};
+          if (adp < SolverConfig::pressureDropTolerance)
+            return {dp / R0, 1.0 / R0};
 
-        const Real tauW = radius * adp / (2.0 * L);
+          const Real tauW = radius * adp / (2.0 * L);
 
-        auto mu = [&](Real g) -> Real {
-          const Real x = std::pow(lambda * g, n);
-          return muInf + delta / (1.0 + x);
-        };
+          auto mu = [&](Real g) -> Real {
+            const Real x = std::pow(lambda * g, n);
+            return muInf + delta / (1.0 + x);
+          };
 
-        auto dmu = [&](Real g) -> Real {
-          if (g <= 0.0)
-            return 0.0;
+          auto dmu = [&](Real g) -> Real {
+            if (g <= 0.0)
+              return 0.0;
 
-          const Real x = std::pow(lambda * g, n);
-          return -delta * n * std::pow(lambda, n) * std::pow(g, n - 1.0) /
-            std::pow(1.0 + x, 2.0);
-        };
+            const Real x = std::pow(lambda * g, n);
+            return -delta * n * std::pow(lambda, n) * std::pow(g, n - 1.0) /
+              std::pow(1.0 + x, 2.0);
+          };
 
-        auto tauMinusTauW = [&](Real g) -> std::pair<Real, Real> {
-          const Real visc = mu(g);
-          const Real dvisc = dmu(g);
-          return {g * visc - tauW, visc + g * dvisc};
-        };
+          auto tauMinusTauW = [&](Real g) -> std::pair<Real, Real> {
+            const Real visc = mu(g);
+            const Real dvisc = dmu(g);
+            return {g * visc - tauW, visc + g * dvisc};
+          };
 
-        Math::RootFinding::NewtonRaphson<Real> rootFinder(
-          SolverConfig::shearAbsoluteTolerance, SolverConfig::shearRelativeTolerance,
-          SolverConfig::shearStepTolerance, SolverConfig::shearMaxIterations);
+          Math::RootFinding::NewtonRaphson<Real> rootFinder(
+            SolverConfig::shearAbsoluteTolerance, SolverConfig::shearRelativeTolerance,
+            SolverConfig::shearStepTolerance, SolverConfig::shearMaxIterations);
 
-        Real gHi = std::max<Real>(tauW / muInf, SolverConfig::minShearRate);
+          Real gHi = std::max<Real>(tauW / muInf, SolverConfig::minShearRate);
 
-        for (int k = 0;
-             k < SolverConfig::maxBracketIterations && tauMinusTauW(gHi).first < 0.0; ++k)
-          gHi *= 2.0;
+          for (int k = 0;
+               k < SolverConfig::maxBracketIterations && tauMinusTauW(gHi).first < 0.0;
+               ++k)
+            gHi *= 2.0;
 
-        if (tauMinusTauW(gHi).first < 0.0)
-        {
-          std::cerr << "Warning: failed to bracket wall shear rate. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
+          if (tauMinusTauW(gHi).first < 0.0)
+          {
+            std::cerr << "Warning: failed to bracket wall shear rate. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const auto gammaRoot = rootFinder.solve(
+            tauMinusTauW, 0.5 * gHi, SolverConfig::shearStepTolerance, gHi);
+
+          if (!gammaRoot)
+          {
+            std::cerr << "Warning: failed to solve wall shear rate. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const Real gammaW = *gammaRoot;
+
+          auto integrand = [&](Real g) -> Real {
+            if (g <= 0.0)
+              return 0.0;
+
+            const Real visc = mu(g);
+            const Real dvisc = dmu(g);
+            const Real dtau = visc + g * dvisc;
+
+            return std::pow(g, 3.0) * visc * visc * dtau;
+          };
+
+          Math::RungeKutta::RK4 integrator;
+
+          const int steps = SolverConfig::integralSteps;
+          const Real h = gammaW / static_cast<Real>(steps);
+
+          Real I = 0.0;
+
+          auto rhs = [&](Real g, Real y) -> Real {
+            (void)y;
+            return integrand(g);
+          };
+
+          for (int i = 0; i < steps; ++i)
+          {
+            const Real g = static_cast<Real>(i) * h;
+            integrator.step(I, g, h, I, rhs);
+          }
+
+          if (I <= 0.0 || !std::isfinite(I))
+          {
+            std::cerr << "Warning: invalid WRMS integral. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const Real qAbs =
+            std::numbers::pi_v<Real> * std::pow(radius, 3.0) * I / std::pow(tauW, 3.0);
+
+          const Real dqAbs =
+            (std::numbers::pi_v<Real> * std::pow(radius, 3.0) * gammaW - 3.0 * qAbs) /
+            adp;
+
+          if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
+          {
+            std::cerr << "Warning: invalid WRMS flow derivative. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          return {sgn * qAbs, dqAbs};
         }
-
-        const auto gammaRoot = rootFinder.solve(
-          tauMinusTauW, 0.5 * gHi, SolverConfig::shearStepTolerance, gHi);
-
-        if (!gammaRoot)
-        {
-          std::cerr << "Warning: failed to solve wall shear rate. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        const Real gammaW = *gammaRoot;
-
-        auto integrand = [&](Real g) -> Real {
-          if (g <= 0.0)
-            return 0.0;
-
-          const Real visc = mu(g);
-          const Real dvisc = dmu(g);
-          const Real dtau = visc + g * dvisc;
-
-          return std::pow(g, 3.0) * visc * visc * dtau;
-        };
-
-        Math::RungeKutta::RK4 integrator;
-
-        const int steps = SolverConfig::integralSteps;
-        const Real h = gammaW / static_cast<Real>(steps);
-
-        Real I = 0.0;
-
-        auto rhs = [&](Real g, Real y) -> Real {
-          (void)y;
-          return integrand(g);
-        };
-
-        for (int i = 0; i < steps; ++i)
-        {
-          const Real g = static_cast<Real>(i) * h;
-          integrator.step(I, g, h, I, rhs);
-        }
-
-        if (I <= 0.0 || !std::isfinite(I))
-        {
-          std::cerr << "Warning: invalid WRMS integral. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        const Real qAbs =
-          std::numbers::pi_v<Real> * std::pow(radius, 3.0) * I / std::pow(tauW, 3.0);
-
-        const Real dqAbs =
-          (std::numbers::pi_v<Real> * std::pow(radius, 3.0) * gammaW - 3.0 * qAbs) / adp;
-
-        if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
-        {
-          std::cerr << "Warning: invalid WRMS flow derivative. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        return {sgn * qAbs, dqAbs};
-      }
-  };
+    };
 
   /**
    * @brief Carreau-Yasuda non-Newtonian branch-flow law.
    */
-  struct CarreauYasuda
-  {
+    struct CarreauYasuda
+    {
     /**
      * @brief Evaluates flow and derivative with respect to pressure drop.
      * @tparam Input Model input type.
@@ -431,131 +434,133 @@ namespace Rodin::Heart::CCMLC2014::Physics
      * @param input Model input parameters.
      * @return Pair containing flow and derivative.
      */
-      template <typename Input>
-      static std::pair<Real, Real> flowLaw(
-        Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
-      {
-        if (L <= 0.0 || radius <= 0.0)
-          return {dp / fallbackResistance, 1.0 / fallbackResistance};
-
-        const Real mu0 = input.mu_0;
-        const Real muInf = input.mu_Inf;
-        const Real lambda = input.lambda;
-        const Real n = input.n;
-        const Real yasuda = input.yasuda;
-        const Real delta = mu0 - muInf;
-
-        const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
-        const Real adp = std::abs(dp);
-
-        const Real R0 =
-          8.0 * mu0 * L / (std::numbers::pi_v<Real> * std::pow(radius, 4.0));
-
-        if (adp < SolverConfig::pressureDropTolerance)
-          return {dp / R0, 1.0 / R0};
-
-        const Real tauW = radius * adp / (2.0 * L);
-
-        auto mu = [&](Real g) -> Real {
-          return muInf +
-            delta * std::pow(1.0 + std::pow(lambda * g, yasuda), (n - 1.0) / yasuda);
-        };
-
-        auto dmu = [&](Real g) -> Real {
-          const Real base = 1.0 + std::pow(lambda * g, yasuda);
-
-          return delta * (n - 1.0) * std::pow(base, (n - 1.0 - yasuda) / yasuda) *
-            std::pow(lambda, yasuda) * std::pow(g, yasuda - 1.0);
-        };
-
-        auto tauMinusTauW = [&](Real g) -> std::pair<Real, Real> {
-          const Real m = mu(g);
-          const Real dm = dmu(g);
-          return {g * m - tauW, m + g * dm};
-        };
-
-        Math::RootFinding::NewtonRaphson<Real> rootFinder(
-          SolverConfig::shearAbsoluteTolerance, SolverConfig::shearRelativeTolerance,
-          SolverConfig::shearStepTolerance, SolverConfig::shearMaxIterations);
-
-        Real gHi = std::max<Real>(tauW / muInf, SolverConfig::minShearRate);
-
-        for (int k = 0;
-             k < SolverConfig::maxBracketIterations && tauMinusTauW(gHi).first < 0.0; ++k)
-          gHi *= 2.0;
-
-        if (tauMinusTauW(gHi).first < 0.0)
+        template <typename Input>
+        static std::pair<Real, Real> flowLaw(
+          Real dp, Real L, Real radius, Real fallbackResistance, const Input& input)
         {
-          std::cerr << "Warning: failed to bracket wall shear rate. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
+          if (L <= 0.0 || radius <= 0.0)
+            return {dp / fallbackResistance, 1.0 / fallbackResistance};
+
+          const Real mu0 = input.mu_0;
+          const Real muInf = input.mu_Inf;
+          const Real lambda = input.lambda;
+          const Real n = input.n;
+          const Real yasuda = input.yasuda;
+          const Real delta = mu0 - muInf;
+
+          const Real sgn = (dp >= 0.0) ? 1.0 : -1.0;
+          const Real adp = std::abs(dp);
+
+          const Real R0 =
+            8.0 * mu0 * L / (std::numbers::pi_v<Real> * std::pow(radius, 4.0));
+
+          if (adp < SolverConfig::pressureDropTolerance)
+            return {dp / R0, 1.0 / R0};
+
+          const Real tauW = radius * adp / (2.0 * L);
+
+          auto mu = [&](Real g) -> Real {
+            return muInf +
+              delta * std::pow(1.0 + std::pow(lambda * g, yasuda), (n - 1.0) / yasuda);
+          };
+
+          auto dmu = [&](Real g) -> Real {
+            const Real base = 1.0 + std::pow(lambda * g, yasuda);
+
+            return delta * (n - 1.0) * std::pow(base, (n - 1.0 - yasuda) / yasuda) *
+              std::pow(lambda, yasuda) * std::pow(g, yasuda - 1.0);
+          };
+
+          auto tauMinusTauW = [&](Real g) -> std::pair<Real, Real> {
+            const Real m = mu(g);
+            const Real dm = dmu(g);
+            return {g * m - tauW, m + g * dm};
+          };
+
+          Math::RootFinding::NewtonRaphson<Real> rootFinder(
+            SolverConfig::shearAbsoluteTolerance, SolverConfig::shearRelativeTolerance,
+            SolverConfig::shearStepTolerance, SolverConfig::shearMaxIterations);
+
+          Real gHi = std::max<Real>(tauW / muInf, SolverConfig::minShearRate);
+
+          for (int k = 0;
+               k < SolverConfig::maxBracketIterations && tauMinusTauW(gHi).first < 0.0;
+               ++k)
+            gHi *= 2.0;
+
+          if (tauMinusTauW(gHi).first < 0.0)
+          {
+            std::cerr << "Warning: failed to bracket wall shear rate. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const auto gammaRoot = rootFinder.solve(
+            tauMinusTauW, 0.5 * gHi, SolverConfig::shearStepTolerance, gHi);
+
+          if (!gammaRoot)
+          {
+            std::cerr << "Warning: failed to solve wall shear rate. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const Real gammaW = *gammaRoot;
+
+          auto integrand = [&](Real g) -> Real {
+            if (g <= 0.0)
+              return 0.0;
+
+            const Real m = mu(g);
+            const Real dm = dmu(g);
+            const Real dtau = m + g * dm;
+
+            return std::pow(g, 3.0) * m * m * dtau;
+          };
+
+          Math::RungeKutta::RK4 integrator;
+
+          const int steps = SolverConfig::integralSteps;
+          const Real h = gammaW / static_cast<Real>(steps);
+
+          Real I = 0.0;
+
+          auto rhs = [&](Real g, Real y) -> Real {
+            (void)y;
+            return integrand(g);
+          };
+
+          for (int i = 0; i < steps; ++i)
+          {
+            const Real g = static_cast<Real>(i) * h;
+            integrator.step(I, g, h, I, rhs);
+          }
+
+          if (I <= 0.0 || !std::isfinite(I))
+          {
+            std::cerr << "Warning: invalid WRMS integral. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          const Real qAbs =
+            std::numbers::pi_v<Real> * std::pow(radius, 3.0) * I / std::pow(tauW, 3.0);
+
+          const Real dqAbs =
+            (std::numbers::pi_v<Real> * std::pow(radius, 3.0) * gammaW - 3.0 * qAbs) /
+            adp;
+
+          if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
+          {
+            std::cerr << "Warning: invalid WRMS flow derivative. "
+                      << "Using Poiseuille fallback.\n";
+            return {dp / R0, 1.0 / R0};
+          }
+
+          return {sgn * qAbs, dqAbs};
         }
-
-        const auto gammaRoot = rootFinder.solve(
-          tauMinusTauW, 0.5 * gHi, SolverConfig::shearStepTolerance, gHi);
-
-        if (!gammaRoot)
-        {
-          std::cerr << "Warning: failed to solve wall shear rate. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        const Real gammaW = *gammaRoot;
-
-        auto integrand = [&](Real g) -> Real {
-          if (g <= 0.0)
-            return 0.0;
-
-          const Real m = mu(g);
-          const Real dm = dmu(g);
-          const Real dtau = m + g * dm;
-
-          return std::pow(g, 3.0) * m * m * dtau;
-        };
-
-        Math::RungeKutta::RK4 integrator;
-
-        const int steps = SolverConfig::integralSteps;
-        const Real h = gammaW / static_cast<Real>(steps);
-
-        Real I = 0.0;
-
-        auto rhs = [&](Real g, Real y) -> Real {
-          (void)y;
-          return integrand(g);
-        };
-
-        for (int i = 0; i < steps; ++i)
-        {
-          const Real g = static_cast<Real>(i) * h;
-          integrator.step(I, g, h, I, rhs);
-        }
-
-        if (I <= 0.0 || !std::isfinite(I))
-        {
-          std::cerr << "Warning: invalid WRMS integral. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        const Real qAbs =
-          std::numbers::pi_v<Real> * std::pow(radius, 3.0) * I / std::pow(tauW, 3.0);
-
-        const Real dqAbs =
-          (std::numbers::pi_v<Real> * std::pow(radius, 3.0) * gammaW - 3.0 * qAbs) / adp;
-
-        if (!std::isfinite(qAbs) || !std::isfinite(dqAbs) || dqAbs <= 0.0)
-        {
-          std::cerr << "Warning: invalid WRMS flow derivative. "
-                    << "Using Poiseuille fallback.\n";
-          return {dp / R0, 1.0 / R0};
-        }
-
-        return {sgn * qAbs, dqAbs};
-      }
-  };
-} // namespace Rheology
+    };
+  } // namespace Rheology
 
   /**
    * @brief Evaluates the Windkessel outflow and its pressure derivatives.
@@ -573,7 +578,8 @@ namespace Rodin::Heart::CCMLC2014::Physics
        * @brief Constructs an evaluator from model input parameters.
        * @param input Model input parameters.
        */
-      explicit WindkesselOutflowEvaluator(const Input &input) : m_input(input)
+      explicit WindkesselOutflowEvaluator(const Input& input)
+        : m_input(input)
       {}
 
       /**
@@ -581,26 +587,24 @@ namespace Rodin::Heart::CCMLC2014::Physics
        * @tparam EvalData Evaluation-data type.
        * @param data Evaluation data updated in place.
        */
-      template <class EvalData> void evaluate(EvalData &data) const
+      template <class EvalData>
+      void evaluate(EvalData& data) const
       {
         using Scalar = decltype(data.y);
 
         const Scalar aorticFlowRate = m_input.Kar * (data.pvMid - data.parMid);
         data.windkesselOutflow =
-            (aorticFlowRate > Scalar(0)) ? aorticFlowRate : Scalar(0);
+          (aorticFlowRate > Scalar(0)) ? aorticFlowRate : Scalar(0);
 
-        const Scalar valveDeriv =
-            (aorticFlowRate > Scalar(0)) ? m_input.Kar : Scalar(0);
+        const Scalar valveDeriv = (aorticFlowRate > Scalar(0)) ? m_input.Kar : Scalar(0);
         data.dWindkesselOutflow_dPv = valveDeriv;
         data.dWindkesselOutflow_dPar = -valveDeriv;
 
-        const auto [qp, dqp] =
-            RheologyModel::flowLaw(data.parMid - data.pdMid, m_input.proximalLength,
-                                   m_input.proximalRadius, m_input.Rp, m_input);
+        const auto [qp, dqp] = RheologyModel::flowLaw(data.parMid - data.pdMid,
+          m_input.proximalLength, m_input.proximalRadius, m_input.Rp, m_input);
 
-        const auto [qd, dqd] =
-            RheologyModel::flowLaw(data.pSvMid - data.pdMid, m_input.distalLength,
-                                   m_input.distalRadius, m_input.Rd, m_input);
+        const auto [qd, dqd] = RheologyModel::flowLaw(data.pSvMid - data.pdMid,
+          m_input.distalLength, m_input.distalRadius, m_input.Rd, m_input);
 
         data.windkesselflowP = qp - data.windkesselOutflow;
         data.windkesselflowD = -qp - qd;
@@ -612,7 +616,7 @@ namespace Rodin::Heart::CCMLC2014::Physics
       }
 
     private:
-      const Input &m_input;
+      const Input& m_input;
   };
 } // namespace Rodin::Heart::CCMLC2014::Physics
 

--- a/src/Rodin/IO/HDF5.h
+++ b/src/Rodin/IO/HDF5.h
@@ -622,7 +622,8 @@ namespace Rodin::IO
         case PT::Triangle:      return 4;
         case PT::Quadrilateral: return 5;
         case PT::Tetrahedron:   return 6;
-        case PT::Pyramid:       return 7;
+        case PT::Pyramid:
+          return 7;
         case PT::Wedge:         return 8;
         case PT::Hexahedron:    return 9;
       }
@@ -2592,7 +2593,8 @@ namespace Rodin::IO
         byGeometry[static_cast<size_t>(Geometry::Polytope::Type::Tetrahedron)] =
           static_cast<HDF5::U64>(connectivity.getCount(Geometry::Polytope::Type::Tetrahedron));
         byGeometry[static_cast<size_t>(Geometry::Polytope::Type::Pyramid)] =
-          static_cast<HDF5::U64>(connectivity.getCount(Geometry::Polytope::Type::Pyramid));
+          static_cast<HDF5::U64>(
+            connectivity.getCount(Geometry::Polytope::Type::Pyramid));
         byGeometry[static_cast<size_t>(Geometry::Polytope::Type::Wedge)] =
           static_cast<HDF5::U64>(connectivity.getCount(Geometry::Polytope::Type::Wedge));
         byGeometry[static_cast<size_t>(Geometry::Polytope::Type::Hexahedron)] =

--- a/src/Rodin/IO/MEDIT.cpp
+++ b/src/Rodin/IO/MEDIT.cpp
@@ -234,9 +234,7 @@ namespace Rodin::IO
             {
               Alert::MemberFunctionException(*this, __func__)
                 << "Failed to parse Pyramid on line "
-                << std::to_string(m_currentLineNumber)
-                << "."
-                << Alert::Raise;
+                << std::to_string(m_currentLineNumber) << "." << Alert::Raise;
             }
             data->vertices -= 1;
             Index index;

--- a/src/Rodin/IO/MEDIT.h
+++ b/src/Rodin/IO/MEDIT.h
@@ -1224,8 +1224,7 @@ namespace Rodin::IO
           const Real psi3 = (q - x) * y / q;
           const Real psi4 = z;
 
-          return psi0 * u[0] + psi1 * u[1] + psi2 * u[2]
-               + psi3 * u[3] + psi4 * u[4];
+          return psi0 * u[0] + psi1 * u[1] + psi2 * u[2] + psi3 * u[3] + psi4 * u[4];
         };
 
         // Element loop

--- a/src/Rodin/IO/MFEM.h
+++ b/src/Rodin/IO/MFEM.h
@@ -375,11 +375,11 @@ namespace Rodin::IO::MFEM
       }
       case Geometry::Polytope::Type::Pyramid:
       {
-        callback(std::array<int, 4>{ 0, 1, 2, 3 });
-        callback(std::array<int, 3>{ 0, 1, 4 });
-        callback(std::array<int, 3>{ 1, 2, 4 });
-        callback(std::array<int, 3>{ 2, 3, 4 });
-        callback(std::array<int, 3>{ 3, 0, 4 });
+        callback(std::array<int, 4>{0, 1, 2, 3});
+        callback(std::array<int, 3>{0, 1, 4});
+        callback(std::array<int, 3>{1, 2, 4});
+        callback(std::array<int, 3>{2, 3, 4});
+        callback(std::array<int, 3>{3, 0, 4});
         break;
       }
       case Geometry::Polytope::Type::Hexahedron:

--- a/src/Rodin/IO/XDMF.h
+++ b/src/Rodin/IO/XDMF.h
@@ -166,7 +166,8 @@ namespace Rodin::IO
           case PT::Triangle:      return Topology::TRIANGLE;
           case PT::Quadrilateral: return Topology::QUADRILATERAL;
           case PT::Tetrahedron:   return Topology::TETRAHEDRON;
-          case PT::Pyramid:       return Topology::PYRAMID;
+          case PT::Pyramid:
+            return Topology::PYRAMID;
           case PT::Wedge:         return Topology::WEDGE;
           case PT::Hexahedron:    return Topology::HEXAHEDRON;
         }
@@ -191,7 +192,8 @@ namespace Rodin::IO
           case Topology::TRIANGLE:        return PT::Triangle;
           case Topology::QUADRILATERAL:   return PT::Quadrilateral;
           case Topology::TETRAHEDRON:     return PT::Tetrahedron;
-          case Topology::PYRAMID:         return PT::Pyramid;
+          case Topology::PYRAMID:
+            return PT::Pyramid;
           case Topology::WEDGE:           return PT::Wedge;
           case Topology::HEXAHEDRON:      return PT::Hexahedron;
 
@@ -786,8 +788,7 @@ namespace Rodin::IO
     if (gr.sourceMesh && gr.sourceMesh != &gf.getFiniteElementSpace().getMesh())
     {
       Alert::MemberFunctionException(*this, __func__)
-        << "Attribute mesh does not match the grid mesh."
-        << Alert::Raise;
+        << "Attribute mesh does not match the grid mesh." << Alert::Raise;
     }
 
     for (const auto& attr : gr.attributes)
@@ -795,9 +796,8 @@ namespace Rodin::IO
       if (attr.name == name)
       {
         Alert::MemberFunctionException(*this, __func__)
-          << "Duplicate XDMF attribute name \"" << name
-          << "\" in grid \"" << gr.name << "\"."
-          << Alert::Raise;
+          << "Duplicate XDMF attribute name \"" << name << "\" in grid \"" << gr.name
+          << "\"." << Alert::Raise;
       }
     }
 

--- a/src/Rodin/MPI/Assembly/MPI.h
+++ b/src/Rodin/MPI/Assembly/MPI.h
@@ -170,8 +170,7 @@ namespace Rodin::Assembly
 
         res.clear();
 
-        auto assembleFace = [&](const Geometry::Polytope& face)
-        {
+        auto assembleFace = [&](const Geometry::Polytope& face) {
           const Index i = face.getIndex();
 
           if (!essBdr.empty())
@@ -229,19 +228,14 @@ namespace Rodin::Assembly
    * own DOF connectivity. Generalises to non-trivial @f$ A @f$ by evaluating
    * @c Av.getBasis(j) with a live @c IntegrationPoint built from @p p.
    */
-  template <class Scalar, class Sol1, class FES1,
-            class Derived2, class FES2,
-            Variational::ShapeFunctionSpaceType Sp>
-  class MPI<
-    IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-    Variational::DirichletBC<
-      Variational::TrialFunction<Sol1, FES1>,
-      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>> final
-    : public AssemblyBase<
-        IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
-        Variational::DirichletBC<
-          Variational::TrialFunction<Sol1, FES1>,
-          Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+  template <class Scalar, class Sol1, class FES1, class Derived2, class FES2,
+    Variational::ShapeFunctionSpaceType Sp>
+  class MPI<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+    Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+      Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
+    final : public AssemblyBase<IndexMap<std::pair<IndexArray, Math::Vector<Scalar>>>,
+              Variational::DirichletBC<Variational::TrialFunction<Sol1, FES1>,
+                Variational::ShapeFunctionBase<Derived2, FES2, Sp>>>
   {
     public:
       /// @brief Output map containing slave DOF indices and master coefficients.
@@ -251,8 +245,7 @@ namespace Rodin::Assembly
       /// @brief Shape-function expression used as the boundary value.
       using ValueType = Variational::ShapeFunctionBase<Derived2, FES2, Sp>;
       /// @brief Concrete Dirichlet boundary-condition type.
-      using DirichletBCType =
-        Variational::DirichletBC<TrialFunctionType, ValueType>;
+      using DirichletBCType = Variational::DirichletBC<TrialFunctionType, ValueType>;
       /// @brief Parent class type.
       using Parent = AssemblyBase<OutputType, DirichletBCType>;
       /// @brief Input payload type consumed by execute().
@@ -261,9 +254,13 @@ namespace Rodin::Assembly
       /// @brief Default constructor.
       MPI() = default;
       /// @brief Copy constructor.
-      MPI(const MPI& other) : Parent(other) {}
+      MPI(const MPI& other)
+        : Parent(other)
+      {}
       /// @brief Move constructor.
-      MPI(MPI&& other) : Parent(std::move(other)) {}
+      MPI(MPI&& other)
+        : Parent(std::move(other))
+      {}
 
       /**
        * @brief Assembles distributed identification constraints.
@@ -282,14 +279,14 @@ namespace Rodin::Assembly
 
         res.clear();
 
-        auto assembleFace = [&](const Geometry::Polytope& face)
-        {
+        auto assembleFace = [&](const Geometry::Polytope& face) {
           const Index fi = face.getIndex();
 
           if (!essBdr.empty())
           {
             const auto a = face.getAttribute();
-            if (!a || !essBdr.contains(*a)) return;
+            if (!a || !essBdr.contains(*a))
+              return;
           }
 
           const auto& feU = fesU.getFiniteElement(faceDim, fi);
@@ -303,18 +300,17 @@ namespace Rodin::Assembly
           {
             const Index slave = slaveDOFs[s];
             auto pos = res.find(slave);
-            if (pos != res.end()) continue;
+            if (pos != res.end())
+              continue;
 
-            std::vector<Index>  mIdx;
+            std::vector<Index> mIdx;
             std::vector<Scalar> mCoef;
             mIdx.reserve(static_cast<size_t>(nMasters));
             mCoef.reserve(static_cast<size_t>(nMasters));
 
             for (Index j = 0; j < nMasters; j++)
             {
-              auto basisCallable = [&Av, j]
-                                   (const Geometry::Point& p)
-              {
+              auto basisCallable = [&Av, j](const Geometry::Point& p) {
                 const Variational::IntegrationPoint ip(p);
                 Av.setIntegrationPoint(ip);
                 return Av.getBasis(static_cast<size_t>(j));
@@ -329,7 +325,8 @@ namespace Rodin::Assembly
               }
             }
 
-            if (mIdx.empty()) continue;
+            if (mIdx.empty())
+              continue;
 
             const Index n = static_cast<Index>(mIdx.size());
             IndexArray masters(n);
@@ -337,10 +334,10 @@ namespace Rodin::Assembly
             for (Index k = 0; k < n; k++)
             {
               masters.coeffRef(k) = mIdx[static_cast<size_t>(k)];
-              coeffs.coeffRef(k)  = mCoef[static_cast<size_t>(k)];
+              coeffs.coeffRef(k) = mCoef[static_cast<size_t>(k)];
             }
-            res.emplace_hint(pos, slave,
-                std::pair{ std::move(masters), std::move(coeffs) });
+            res.emplace_hint(
+              pos, slave, std::pair{std::move(masters), std::move(coeffs)});
           }
         };
 

--- a/src/Rodin/MPI/Geometry/Mesh.cpp
+++ b/src/Rodin/MPI/Geometry/Mesh.cpp
@@ -466,15 +466,11 @@ namespace Rodin::Geometry
   {
     const auto& shard = this->getShard();
     assert(localIdx < shard.getPolytopeCount(dimension));
-    return m_quadratures.get(
-        { dimension, localIdx },
-        shard.getPolytopeCount(dimension),
-        qf,
-        [&]() -> std::unique_ptr<PolytopeQuadrature>
-        {
-          return std::make_unique<PolytopeQuadrature>(
-              *this->getPolytope(dimension, localIdx), qf);
-        });
+    return m_quadratures.get({dimension, localIdx}, shard.getPolytopeCount(dimension), qf,
+      [&]() -> std::unique_ptr<PolytopeQuadrature> {
+        return std::make_unique<PolytopeQuadrature>(
+          *this->getPolytope(dimension, localIdx), qf);
+      });
   }
 
   Polytope::Type MPIMesh::getGeometry(size_t dimension, Index localIdx) const
@@ -2095,11 +2091,9 @@ namespace Rodin::Geometry
                 const Shard::State state =
                   (owner == rank ? Shard::State::Owned : Shard::State::Ghost);
 
-                const Index lv = sb.vertex(
-                  gvid,
-                  sp3(static_cast<Real>(i) + Real(0.5),
-                      static_cast<Real>(j) + Real(0.5),
-                      static_cast<Real>(k) + Real(0.5)),
+                const Index lv = sb.vertex(gvid,
+                  sp3(static_cast<Real>(i) + Real(0.5), static_cast<Real>(j) + Real(0.5),
+                    static_cast<Real>(k) + Real(0.5)),
                   state);
                 gv2lv.emplace(gvid, lv);
 
@@ -2199,34 +2193,28 @@ namespace Rodin::Geometry
               {
                 const Index centerOffset = static_cast<Index>(nx * ny * nz);
 
-                const Index v0 = gv2lv.at(vid3(i,     j,     k,     nx, ny));
-                const Index v1 = gv2lv.at(vid3(i + 1, j,     k,     nx, ny));
-                const Index v2 = gv2lv.at(vid3(i + 1, j + 1, k,     nx, ny));
-                const Index v3 = gv2lv.at(vid3(i,     j + 1, k,     nx, ny));
-                const Index v4 = gv2lv.at(vid3(i,     j,     k + 1, nx, ny));
-                const Index v5 = gv2lv.at(vid3(i + 1, j,     k + 1, nx, ny));
+                const Index v0 = gv2lv.at(vid3(i, j, k, nx, ny));
+                const Index v1 = gv2lv.at(vid3(i + 1, j, k, nx, ny));
+                const Index v2 = gv2lv.at(vid3(i + 1, j + 1, k, nx, ny));
+                const Index v3 = gv2lv.at(vid3(i, j + 1, k, nx, ny));
+                const Index v4 = gv2lv.at(vid3(i, j, k + 1, nx, ny));
+                const Index v5 = gv2lv.at(vid3(i + 1, j, k + 1, nx, ny));
                 const Index v6 = gv2lv.at(vid3(i + 1, j + 1, k + 1, nx, ny));
-                const Index v7 = gv2lv.at(vid3(i,     j + 1, k + 1, nx, ny));
-                const Index c  = gv2lv.at(centerOffset + macroId3(i, j, k, cx, cy));
+                const Index v7 = gv2lv.at(vid3(i, j + 1, k + 1, nx, ny));
+                const Index c = gv2lv.at(centerOffset + macroId3(i, j, k, cx, cy));
 
-                const Index lc0 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 0), Polytope::Type::Pyramid,
-                  makeIndexArray(v0, v1, v2, v3, c), state);
-                const Index lc1 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 1), Polytope::Type::Pyramid,
-                  makeIndexArray(v4, v5, v6, v7, c), state);
-                const Index lc2 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 2), Polytope::Type::Pyramid,
-                  makeIndexArray(v0, v4, v5, v1, c), state);
-                const Index lc3 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 3), Polytope::Type::Pyramid,
-                  makeIndexArray(v1, v5, v6, v2, c), state);
-                const Index lc4 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 4), Polytope::Type::Pyramid,
-                  makeIndexArray(v2, v6, v7, v3, c), state);
-                const Index lc5 = sb.polytope(
-                  3, static_cast<Index>(6 * mid + 5), Polytope::Type::Pyramid,
-                  makeIndexArray(v3, v7, v4, v0, c), state);
+                const Index lc0 = sb.polytope(3, static_cast<Index>(6 * mid + 0),
+                  Polytope::Type::Pyramid, makeIndexArray(v0, v1, v2, v3, c), state);
+                const Index lc1 = sb.polytope(3, static_cast<Index>(6 * mid + 1),
+                  Polytope::Type::Pyramid, makeIndexArray(v4, v5, v6, v7, c), state);
+                const Index lc2 = sb.polytope(3, static_cast<Index>(6 * mid + 2),
+                  Polytope::Type::Pyramid, makeIndexArray(v0, v4, v5, v1, c), state);
+                const Index lc3 = sb.polytope(3, static_cast<Index>(6 * mid + 3),
+                  Polytope::Type::Pyramid, makeIndexArray(v1, v5, v6, v2, c), state);
+                const Index lc4 = sb.polytope(3, static_cast<Index>(6 * mid + 4),
+                  Polytope::Type::Pyramid, makeIndexArray(v2, v6, v7, v3, c), state);
+                const Index lc5 = sb.polytope(3, static_cast<Index>(6 * mid + 5),
+                  Polytope::Type::Pyramid, makeIndexArray(v3, v7, v4, v0, c), state);
 
                 if (state == Shard::State::Owned)
                 {

--- a/src/Rodin/MPI/Geometry/SubMesh.cpp
+++ b/src/Rodin/MPI/Geometry/SubMesh.cpp
@@ -22,10 +22,10 @@ namespace Rodin::Geometry
   {
     struct MaxSize
     {
-      size_t operator()(size_t lhs, size_t rhs) const
-      {
-        return std::max(lhs, rhs);
-      }
+        size_t operator()(size_t lhs, size_t rhs) const
+        {
+          return std::max(lhs, rhs);
+        }
     };
   }
 
@@ -33,8 +33,8 @@ namespace Rodin::Geometry
   // Builder
   // ---------------------------------------------------------------------------
 
-  SubMesh<Context::MPI>::Builder&
-  SubMesh<Context::MPI>::Builder::initialize(const Mesh<Context::MPI>& parent)
+  SubMesh<Context::MPI>::Builder& SubMesh<Context::MPI>::Builder::initialize(
+    const Mesh<Context::MPI>& parent)
   {
     const auto& shard = parent.getShard();
     const size_t dim = parent.getDimension();
@@ -52,8 +52,8 @@ namespace Rodin::Geometry
     return *this;
   }
 
-  SubMesh<Context::MPI>::Builder&
-  SubMesh<Context::MPI>::Builder::include(size_t d, Index parentLocalIdx)
+  SubMesh<Context::MPI>::Builder& SubMesh<Context::MPI>::Builder::include(
+    size_t d, Index parentLocalIdx)
   {
     assert(m_parent.has_value());
     const auto& parentMesh = m_parent.value().get();
@@ -215,24 +215,24 @@ namespace Rodin::Geometry
     // -------------------------------------------------------------------------
     {
       const auto& comm = parentMesh.getContext().getCommunicator();
-      const int   rank = comm.rank();
+      const int rank = comm.rank();
       const size_t maxDim = parentMesh.getDimension();
 
       for (size_t d = 0; d <= maxDim; ++d)
       {
-        const auto& pm    = shard.getPolytopeMap(d);
-        const size_t n    = pm.left.size();
+        const auto& pm = shard.getPolytopeMap(d);
+        const size_t n = pm.left.size();
 
         auto& subState = shard.getState(d);
         auto& subOwner = shard.getOwner(d);
-        auto& subHalo  = shard.getHalo(d);
+        auto& subHalo = shard.getHalo(d);
 
         // Build the neighbor set from the PARENT shard so that the send/recv
         // pattern is symmetric across all ranks without global communication.
         // Rationale: if e is Shared(owner=A) on B in the parent, A has B in its
         // parent halo — both A and B therefore appear in each other's set.
         const auto& pOwner = parentShard.getOwner(d);
-        const auto& pHalo  = parentShard.getHalo(d);
+        const auto& pHalo = parentShard.getHalo(d);
 
         UnorderedSet<int> neighborSet;
         for (const auto& [li, r] : pOwner)
@@ -382,7 +382,7 @@ namespace Rodin::Geometry
               continue; // should not happen
 
             const Index localIdx = static_cast<Index>(pit->second);
-            const int   newOwner = queriers.front(); // already sorted, front = min
+            const int newOwner = queriers.front(); // already sorted, front = min
 
             if (newOwner == rank)
             {
@@ -411,7 +411,7 @@ namespace Rodin::Geometry
     result.Parent::operator=(meshBuilder.finalize());
     result.m_s2ps = std::move(m_s2ps);
     result.m_dimension = boost::mpi::all_reduce(
-        parentMesh.getContext().getCommunicator(), m_dimension, MaxSize{});
+      parentMesh.getContext().getCommunicator(), m_dimension, MaxSize{});
     return result;
   }
 
@@ -419,8 +419,7 @@ namespace Rodin::Geometry
   // SubMesh<Context::MPI>
   // ---------------------------------------------------------------------------
 
-  SubMesh<Context::MPI>::SubMesh(
-      std::reference_wrapper<const Mesh<Context::MPI>> parent)
+  SubMesh<Context::MPI>::SubMesh(std::reference_wrapper<const Mesh<Context::MPI>> parent)
     : Parent(parent.get().getContext()),
       m_parent(parent)
   {
@@ -500,6 +499,7 @@ namespace Rodin::Geometry
       i = find->second;
     }
 
-    return Point(*getPolytope(d, i), p.getReferenceCoordinates(), p.getPhysicalCoordinates());
+    return Point(
+      *getPolytope(d, i), p.getReferenceCoordinates(), p.getPhysicalCoordinates());
   }
 }

--- a/src/Rodin/MPI/Geometry/SubMesh.h
+++ b/src/Rodin/MPI/Geometry/SubMesh.h
@@ -135,8 +135,7 @@ namespace Rodin::Geometry
        * @brief Constructs a submesh with a parent distributed mesh.
        * @param[in] parent Reference to the parent MPI mesh.
        */
-      explicit
-      SubMesh(std::reference_wrapper<const Mesh<Context::MPI>> parent);
+      explicit SubMesh(std::reference_wrapper<const Mesh<Context::MPI>> parent);
 
       /**
        * @brief Copy constructor.
@@ -258,10 +257,11 @@ namespace Rodin::Geometry
       }
 
     private:
-      std::reference_wrapper<const Mesh<Context::MPI>> m_parent;  ///< Parent mesh reference
-      std::vector<PolytopeMap> m_s2ps;                            ///< Submesh-to-parent index maps
-      Deque<Ancestor> m_ancestors;                                 ///< Ancestor mesh chain
-      size_t m_dimension = 0;                                      ///< Collective submesh dimension
+      std::reference_wrapper<const Mesh<Context::MPI>>
+        m_parent;  ///< Parent mesh reference
+      std::vector<PolytopeMap> m_s2ps; ///< Submesh-to-parent index maps
+      Deque<Ancestor> m_ancestors; ///< Ancestor mesh chain
+      size_t m_dimension = 0; ///< Collective submesh dimension
   };
 }
 

--- a/src/Rodin/MPI/Variational/H1/H1.h
+++ b/src/Rodin/MPI/Variational/H1/H1.h
@@ -482,8 +482,7 @@ namespace Rodin::Variational
             // Pyramid DOF ordering follows horizontal square layers:
             // layer k has (K-k+1)^2 nodes. Interior DOFs are strictly away
             // from the base and all four triangular side faces.
-            auto offset = [](size_t layer)
-            {
+            auto offset = [](size_t layer) {
               size_t out = 0;
               for (size_t kk = 0; kk < layer; ++kk)
               {
@@ -862,9 +861,11 @@ namespace Rodin::Variational
             const auto& dimensionHaloNeighbors = shard.getHalo(d);
             for (const auto& [i, peers] : dimensionHaloNeighbors)
               for (const Index r : peers)
-                if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
+                if (static_cast<int>(r) != rank)
+                  nbrs.insert(static_cast<int>(r));
             for (const auto& [i, r] : owner)
-              if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
+              if (static_cast<int>(r) != rank)
+                nbrs.insert(static_cast<int>(r));
             dimensionNeighbors.assign(nbrs.begin(), nbrs.end());
           }
 

--- a/src/Rodin/MPI/Variational/P0/P0.h
+++ b/src/Rodin/MPI/Variational/P0/P0.h
@@ -294,7 +294,8 @@ namespace Rodin::Variational
           UnorderedSet<int> nbrs;
           for (const auto& [i, peers] : halo)
             for (const Index r : peers)
-              if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
+              if (static_cast<int>(r) != rank)
+                nbrs.insert(static_cast<int>(r));
           for (const auto& entry : owner)
             if (static_cast<int>(entry.second) != rank)
               nbrs.insert(static_cast<int>(entry.second));

--- a/src/Rodin/MPI/Variational/P1/P1.h
+++ b/src/Rodin/MPI/Variational/P1/P1.h
@@ -7,7 +7,6 @@
 #ifndef RODIN_MPI_VARIATIONAL_P1_P1_H
 #define RODIN_MPI_VARIATIONAL_P1_P1_H
 
-
 /**
  * @file
  * @brief Distributed P1 finite element space specialization on MPI meshes.
@@ -185,7 +184,8 @@ namespace Rodin::Variational
            */
           template <class Callable>
           CallablePullback(const Geometry::Polytope& polytope, Callable&& v)
-            : m_polytope(polytope), m_v(std::forward<Callable>(v))
+            : m_polytope(polytope),
+              m_v(std::forward<Callable>(v))
           {}
 
           /// @brief Copy constructor.
@@ -341,9 +341,11 @@ namespace Rodin::Variational
           UnorderedSet<int> nbrs;
           for (const auto& [i, peers] : halo)
             for (const Index r : peers)
-              if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
+              if (static_cast<int>(r) != rank)
+                nbrs.insert(static_cast<int>(r));
           for (const auto& [lv, own] : owner)
-            if (static_cast<int>(own) != rank) nbrs.insert(static_cast<int>(own));
+            if (static_cast<int>(own) != rank)
+              nbrs.insert(static_cast<int>(own));
           neighbors.assign(nbrs.begin(), nbrs.end());
         }
 
@@ -492,9 +494,11 @@ namespace Rodin::Variational
           UnorderedSet<int> nbrs;
           for (const auto& [i, peers] : halo)
             for (const Index r : peers)
-              if (static_cast<int>(r) != rank) nbrs.insert(static_cast<int>(r));
+              if (static_cast<int>(r) != rank)
+                nbrs.insert(static_cast<int>(r));
           for (const auto& [lv, own] : owner)
-            if (static_cast<int>(own) != rank) nbrs.insert(static_cast<int>(own));
+            if (static_cast<int>(own) != rank)
+              nbrs.insert(static_cast<int>(own));
           neighbors.assign(nbrs.begin(), nbrs.end());
         }
 
@@ -536,7 +540,7 @@ namespace Rodin::Variational
               {
                 const int rpeer = static_cast<int>(peer);
                 assert(rpeer != rank);
-                push[rpeer].push_back({ gid, s_send });
+                push[rpeer].push_back({gid, s_send});
               }
             }
           }

--- a/src/Rodin/Math/SpatialMatrix.h
+++ b/src/Rodin/Math/SpatialMatrix.h
@@ -110,8 +110,7 @@ namespace Rodin::Math
 
       /// @brief Constructs a spatial matrix from an Eigen matrix expression.
       template <class EigenDerived>
-      constexpr
-      SpatialMatrix(const Eigen::MatrixBase<EigenDerived>& other)
+      constexpr SpatialMatrix(const Eigen::MatrixBase<EigenDerived>& other)
         : m_rows(0),
           m_cols(0)
       {
@@ -1541,8 +1540,7 @@ namespace Rodin::Math
       }
 
     private:
-      constexpr
-      void zeroStorage() noexcept
+      constexpr void zeroStorage() noexcept
       {
         m_data.setZero();
       }
@@ -2349,11 +2347,10 @@ namespace Rodin::Math
       typename FormLanguage::Mult<typename EigenDerived::Scalar, Scalar>::Type;
     assert(static_cast<std::uint8_t>(s.cols()) == m.rows());
     assert(static_cast<std::uint8_t>(s.rows()) <= SpatialMatrix<OutScalar>::MaxSize);
-    SpatialMatrix<OutScalar> result(
-      static_cast<std::uint8_t>(s.rows()), m.cols());
-    result = s * m.getData().topLeftCorner(
-      static_cast<Eigen::Index>(m.rows()),
-      static_cast<Eigen::Index>(m.cols()));
+    SpatialMatrix<OutScalar> result(static_cast<std::uint8_t>(s.rows()), m.cols());
+    result = s *
+      m.getData().topLeftCorner(
+        static_cast<Eigen::Index>(m.rows()), static_cast<Eigen::Index>(m.cols()));
     return result;
   }
 
@@ -2368,11 +2365,10 @@ namespace Rodin::Math
       typename FormLanguage::Mult<Scalar, typename EigenDerived::Scalar>::Type;
     assert(m.cols() == static_cast<std::uint8_t>(s.rows()));
     assert(static_cast<std::uint8_t>(s.cols()) <= SpatialMatrix<OutScalar>::MaxSize);
-    SpatialMatrix<OutScalar> result(
-      m.rows(), static_cast<std::uint8_t>(s.cols()));
+    SpatialMatrix<OutScalar> result(m.rows(), static_cast<std::uint8_t>(s.cols()));
     result = m.getData().topLeftCorner(
-      static_cast<Eigen::Index>(m.rows()),
-      static_cast<Eigen::Index>(m.cols())) * s;
+               static_cast<Eigen::Index>(m.rows()), static_cast<Eigen::Index>(m.cols())) *
+      s;
     return result;
   }
 

--- a/src/Rodin/Math/SpatialVector.h
+++ b/src/Rodin/Math/SpatialVector.h
@@ -806,8 +806,7 @@ namespace Rodin::Math
       }
 
     private:
-      constexpr
-      void zeroStorage() noexcept
+      constexpr void zeroStorage() noexcept
       {
         m_data[0] = ScalarType(0);
         m_data[1] = ScalarType(0);

--- a/src/Rodin/PETSc/Assembly/MPI.h
+++ b/src/Rodin/PETSc/Assembly/MPI.h
@@ -432,40 +432,39 @@ namespace Rodin::Assembly
           if (dbc.getOperand().getUUID() != u.getUUID())
             continue;
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
-                constraints.setFixed(
-                    static_cast<Index>(local),
-                    static_cast<PetscScalar>(value));
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
               {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                for (const auto& [local, value] : dofs)
+                  constraints.setFixed(
+                    static_cast<Index>(local), static_cast<PetscScalar>(value));
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
+              {
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(masters[k]),
-                      static_cast<PetscScalar>(coeffs[k]) });
-                }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back({static_cast<Index>(masters[k]),
+                      static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(static_cast<Index>(slave), entries, value);
+                  constraints.setIdentification(
+                    static_cast<Index>(slave), entries, value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -476,10 +475,9 @@ namespace Rodin::Assembly
         }
 
         auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             const PetscInt I = static_cast<PetscInt>(r.index);
@@ -510,8 +508,7 @@ namespace Rodin::Assembly
           }
         };
 
-        auto vector_entry = [&](Index row, PetscScalar val)
-        {
+        auto vector_entry = [&](Index row, PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
@@ -746,13 +743,8 @@ namespace Rodin::Assembly
             if (rbegin <= gs && gs < rend)
               rowsToZero.push_back(static_cast<PetscInt>(gs));
 
-          ierr = MatZeroRows(
-              A,
-              static_cast<PetscInt>(rowsToZero.size()),
-              rowsToZero.empty() ? nullptr : rowsToZero.data(),
-              0.0,
-              nullptr,
-              nullptr);
+          ierr = MatZeroRows(A, static_cast<PetscInt>(rowsToZero.size()),
+            rowsToZero.empty() ? nullptr : rowsToZero.data(), 0.0, nullptr, nullptr);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
 
@@ -1105,47 +1097,46 @@ namespace Rodin::Assembly
           const size_t uOff = trialOffsets[uBlock];
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
-                constraints.setFixed(
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
+              {
+                for (const auto& [local, value] : dofs)
+                  constraints.setFixed(
                     static_cast<Index>(uOff + static_cast<size_t>(local)),
                     static_cast<PetscScalar>(value));
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto vUUIDOpt = dbc.getValueUUID();
-              assert(vUUIDOpt);
-              const size_t vBlock = findTrialBlock(*vUUIDOpt);
-              const size_t vOff = trialOffsets[vBlock];
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
               {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                const auto vUUIDOpt = dbc.getValueUUID();
+                assert(vUUIDOpt);
+                const size_t vBlock = findTrialBlock(*vUUIDOpt);
+                const size_t vOff = trialOffsets[vBlock];
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
-                      static_cast<PetscScalar>(coeffs[k]) });
-                }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back(
+                      {static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
+                        static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(
-                    static_cast<Index>(uOff + static_cast<size_t>(slave)),
-                    entries,
+                  constraints.setIdentification(
+                    static_cast<Index>(uOff + static_cast<size_t>(slave)), entries,
                     value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -1155,11 +1146,9 @@ namespace Rodin::Assembly
             << Alert::Raise;
         }
 
-        auto ownsTrialGlobal = [&](Index g) -> bool
-        {
+        auto ownsTrialGlobal = [&](Index g) -> bool {
           bool owned = false;
-          us.iapply([&](size_t i, const auto& uref)
-          {
+          us.iapply([&](size_t i, const auto& uref) {
             size_t begin, end;
             uref.get().getFiniteElementSpace().getOwnershipRange(begin, end);
             const size_t off = trialOffsets[i];
@@ -1170,10 +1159,9 @@ namespace Rodin::Assembly
         };
 
         auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             const PetscInt I = static_cast<PetscInt>(r.index);
@@ -1187,8 +1175,7 @@ namespace Rodin::Assembly
             for (const auto& c : constraints.expand(col))
             {
               const PetscInt J = static_cast<PetscInt>(c.index);
-              const PetscScalar v =
-                r.coefficient * val * c.coefficient;
+              const PetscScalar v = r.coefficient * val * c.coefficient;
               // Insert unconditionally. PETSc decides whether zero-valued
               // insertions affect the pattern according to its current
               // matrix options.
@@ -1199,8 +1186,7 @@ namespace Rodin::Assembly
           }
         };
 
-        auto vector_entry = [&](Index row, PetscScalar val)
-        {
+        auto vector_entry = [&](Index row, PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
@@ -1475,13 +1461,8 @@ namespace Rodin::Assembly
             if (ownsTrialGlobal(gs))
               rowsToZero.push_back(static_cast<PetscInt>(gs));
 
-          ierr = MatZeroRows(
-              A,
-              static_cast<PetscInt>(rowsToZero.size()),
-              rowsToZero.empty() ? nullptr : rowsToZero.data(),
-              0.0,
-              nullptr,
-              nullptr);
+          ierr = MatZeroRows(A, static_cast<PetscInt>(rowsToZero.size()),
+            rowsToZero.empty() ? nullptr : rowsToZero.data(), 0.0, nullptr, nullptr);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
 
@@ -1548,12 +1529,9 @@ namespace Rodin::Assembly
           ierr = VecZeroEntries(bcVec);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
-          ierr = VecSetValues(
-              bcVec,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              bcVals.empty() ? nullptr : bcVals.data(),
-              INSERT_VALUES);
+          ierr = VecSetValues(bcVec, static_cast<PetscInt>(bcIdx.size()),
+            bcIdx.empty() ? nullptr : bcIdx.data(),
+            bcVals.empty() ? nullptr : bcVals.data(), INSERT_VALUES);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
           ierr = VecAssemblyBegin(bcVec);
@@ -1562,13 +1540,8 @@ namespace Rodin::Assembly
           ierr = VecAssemblyEnd(bcVec);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
-          ierr = MatZeroRowsColumns(
-              A,
-              static_cast<PetscInt>(bcIdx.size()),
-              bcIdx.empty() ? nullptr : bcIdx.data(),
-              1.0,
-              bcVec,
-              b);
+          ierr = MatZeroRowsColumns(A, static_cast<PetscInt>(bcIdx.size()),
+            bcIdx.empty() ? nullptr : bcIdx.data(), 1.0, bcVec, b);
           assert(ierr == PETSC_SUCCESS);
           (void)ierr;
           ierr = VecDestroy(&bcVec);

--- a/src/Rodin/PETSc/Assembly/OpenMP.h
+++ b/src/Rodin/PETSc/Assembly/OpenMP.h
@@ -654,7 +654,7 @@ namespace Rodin::Assembly
         (void)ierr;
 
         ConstraintMap<PetscScalar> constraints(
-            static_cast<size_t>(std::max(nrows, ncols)));
+          static_cast<size_t>(std::max(nrows, ncols)));
         using DBCBaseType = Variational::DirichletBCBase<PetscScalar>;
         using ValueDOFsType = typename DBCBaseType::ValueDOFs;
         using IdentDOFsType = typename DBCBaseType::IdentifiedDOFs;
@@ -665,42 +665,41 @@ namespace Rodin::Assembly
             continue;
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
               {
-                constraints.setFixed(
-                    static_cast<Index>(local),
-                    static_cast<PetscScalar>(value));
-              }
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
-              {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                for (const auto& [local, value] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(masters[k]),
-                      static_cast<PetscScalar>(coeffs[k]) });
+                  constraints.setFixed(
+                    static_cast<Index>(local), static_cast<PetscScalar>(value));
                 }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
+              {
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
+                {
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back({static_cast<Index>(masters[k]),
+                      static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(static_cast<Index>(slave), entries, value);
+                  constraints.setIdentification(
+                    static_cast<Index>(slave), entries, value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -716,10 +715,9 @@ namespace Rodin::Assembly
         auto add_matrix_entries = [&](std::vector<MatrixEntry>& local,
                                     std::vector<VectorEntry>& localRhs, Index row,
                                     Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             if (colValue != PetscScalar(0))
@@ -1116,13 +1114,8 @@ namespace Rodin::Assembly
 
           if (!rowsToZero.empty())
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(rowsToZero.size()),
-                rowsToZero.data(),
-                0.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(rowsToZero.size()),
+              rowsToZero.data(), 0.0, nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
             (void)ierr;
 
@@ -1500,47 +1493,46 @@ namespace Rodin::Assembly
           const size_t uOff = trialOffsets[uBlock];
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
-                constraints.setFixed(
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
+              {
+                for (const auto& [local, value] : dofs)
+                  constraints.setFixed(
                     static_cast<Index>(uOff + static_cast<size_t>(local)),
                     static_cast<PetscScalar>(value));
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto vUUIDOpt = dbc.getValueUUID();
-              assert(vUUIDOpt);
-              const size_t vBlock = findTrialBlock(*vUUIDOpt);
-              const size_t vOff = trialOffsets[vBlock];
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
               {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                const auto vUUIDOpt = dbc.getValueUUID();
+                assert(vUUIDOpt);
+                const size_t vBlock = findTrialBlock(*vUUIDOpt);
+                const size_t vOff = trialOffsets[vBlock];
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
-                      static_cast<PetscScalar>(coeffs[k]) });
-                }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back(
+                      {static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
+                        static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(
-                    static_cast<Index>(uOff + static_cast<size_t>(slave)),
-                    entries,
+                  constraints.setIdentification(
+                    static_cast<Index>(uOff + static_cast<size_t>(slave)), entries,
                     value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -1556,20 +1548,17 @@ namespace Rodin::Assembly
         auto add_matrix_entries = [&](std::vector<MatrixEntry>& local,
                                     std::vector<VectorEntry>& localRhs, Index row,
                                     Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             if (colValue != PetscScalar(0))
               localRhs.emplace_back(
                 static_cast<PetscInt>(r.index), -r.coefficient * val * colValue);
             for (const auto& c : constraints.expand(col))
-              local.emplace_back(
-                  static_cast<PetscInt>(r.index),
-                  static_cast<PetscInt>(c.index),
-                  r.coefficient * val * c.coefficient);
+              local.emplace_back(static_cast<PetscInt>(r.index),
+                static_cast<PetscInt>(c.index), r.coefficient * val * c.coefficient);
           }
         };
 
@@ -1848,12 +1837,9 @@ namespace Rodin::Assembly
             {
               std::vector<MatrixEntry> local;
               std::vector<VectorEntry> localRhs;
-              add_matrix_entries(
-                  local,
-                  localRhs,
-                  static_cast<Index>(vOff) + static_cast<Index>(i),
-                  static_cast<Index>(uOff) + static_cast<Index>(cols[j]),
-                  vals[j]);
+              add_matrix_entries(local, localRhs,
+                static_cast<Index>(vOff) + static_cast<Index>(i),
+                static_cast<Index>(uOff) + static_cast<Index>(cols[j]), vals[j]);
               std::vector<std::vector<MatrixEntry>> matrixChunks(1);
               matrixChunks[0] = std::move(local);
               flush_matrix_entries(matrixChunks);
@@ -1989,12 +1975,8 @@ namespace Rodin::Assembly
 
           if (!zeroRowsIdx.empty())
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(zeroRowsIdx.size()),
-                zeroRowsIdx.data(),
-                0.0,
-                nullptr, nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(zeroRowsIdx.size()),
+              zeroRowsIdx.data(), 0.0, nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
             (void)ierr;
 

--- a/src/Rodin/PETSc/Assembly/Sequential.h
+++ b/src/Rodin/PETSc/Assembly/Sequential.h
@@ -411,40 +411,39 @@ namespace Rodin::Assembly
           if (dbc.getOperand().getUUID() != u.getUUID())
             continue;
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
-                constraints.setFixed(
-                    static_cast<Index>(local),
-                    static_cast<PetscScalar>(value));
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
               {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                for (const auto& [local, value] : dofs)
+                  constraints.setFixed(
+                    static_cast<Index>(local), static_cast<PetscScalar>(value));
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
+              {
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(masters[k]),
-                      static_cast<PetscScalar>(coeffs[k]) });
-                }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back({static_cast<Index>(masters[k]),
+                      static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(static_cast<Index>(slave), entries, value);
+                  constraints.setIdentification(
+                    static_cast<Index>(slave), entries, value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -455,10 +454,9 @@ namespace Rodin::Assembly
         }
 
         auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             const PetscInt I = static_cast<PetscInt>(r.index);
@@ -489,8 +487,7 @@ namespace Rodin::Assembly
           }
         };
 
-        auto vector_entry = [&](Index row, PetscScalar val)
-        {
+        auto vector_entry = [&](Index row, PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
@@ -691,13 +688,8 @@ namespace Rodin::Assembly
 
           if (!rowsToZero.empty())
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(rowsToZero.size()),
-                rowsToZero.data(),
-                0.0,
-                nullptr,
-                nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(rowsToZero.size()),
+              rowsToZero.data(), 0.0, nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
             (void)ierr;
 
@@ -1028,47 +1020,46 @@ namespace Rodin::Assembly
           const size_t uOff = trialOffsets[uBlock];
 
           dbc.assemble();
-          std::visit([&](auto&& dofs)
-          {
-            using T = std::decay_t<decltype(dofs)>;
-            if constexpr (std::is_same_v<T, ValueDOFsType>)
-            {
-              for (const auto& [local, value] : dofs)
-                constraints.setFixed(
+          std::visit(
+            [&](auto&& dofs) {
+              using T = std::decay_t<decltype(dofs)>;
+              if constexpr (std::is_same_v<T, ValueDOFsType>)
+              {
+                for (const auto& [local, value] : dofs)
+                  constraints.setFixed(
                     static_cast<Index>(uOff + static_cast<size_t>(local)),
                     static_cast<PetscScalar>(value));
-            }
-            else if constexpr (std::is_same_v<T, IdentDOFsType>)
-            {
-              const auto vUUIDOpt = dbc.getValueUUID();
-              assert(vUUIDOpt);
-              const size_t vBlock = findTrialBlock(*vUUIDOpt);
-              const size_t vOff = trialOffsets[vBlock];
-              const auto& affineValues = dbc.getIdentificationValues();
-              for (const auto& [slave, pair] : dofs)
+              }
+              else if constexpr (std::is_same_v<T, IdentDOFsType>)
               {
-                const auto& masters = pair.first;
-                const auto& coeffs = pair.second;
-                std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
-                entries.reserve(static_cast<size_t>(masters.size()));
-                for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                const auto vUUIDOpt = dbc.getValueUUID();
+                assert(vUUIDOpt);
+                const size_t vBlock = findTrialBlock(*vUUIDOpt);
+                const size_t vOff = trialOffsets[vBlock];
+                const auto& affineValues = dbc.getIdentificationValues();
+                for (const auto& [slave, pair] : dofs)
                 {
-                  entries.push_back({
-                      static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
-                      static_cast<PetscScalar>(coeffs[k]) });
-                }
-                const auto valueIt = affineValues.find(slave);
-                const PetscScalar value =
-                  valueIt == affineValues.end()
+                  const auto& masters = pair.first;
+                  const auto& coeffs = pair.second;
+                  std::vector<typename ConstraintMap<PetscScalar>::Entry> entries;
+                  entries.reserve(static_cast<size_t>(masters.size()));
+                  for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
+                  {
+                    entries.push_back(
+                      {static_cast<Index>(vOff + static_cast<size_t>(masters[k])),
+                        static_cast<PetscScalar>(coeffs[k])});
+                  }
+                  const auto valueIt = affineValues.find(slave);
+                  const PetscScalar value = valueIt == affineValues.end()
                     ? PetscScalar(0)
                     : static_cast<PetscScalar>(valueIt->second);
-                constraints.setIdentification(
-                    static_cast<Index>(uOff + static_cast<size_t>(slave)),
-                    entries,
+                  constraints.setIdentification(
+                    static_cast<Index>(uOff + static_cast<size_t>(slave)), entries,
                     value);
+                }
               }
-            }
-          }, dbc.getDOFs());
+            },
+            dbc.getDOFs());
         }
 
         if (mode != AssemblyMode::Full && !constraints.getIdentifiedRows().empty())
@@ -1079,10 +1070,9 @@ namespace Rodin::Assembly
         }
 
         auto matrix_entry = [&](Index row, Index col, PetscScalar val) {
-          const PetscScalar colValue =
-            constraints.isIdentified(col)
-              ? constraints.getIdentificationValue(col)
-              : PetscScalar(0);
+          const PetscScalar colValue = constraints.isIdentified(col)
+            ? constraints.getIdentificationValue(col)
+            : PetscScalar(0);
           for (const auto& r : constraints.expand(row))
           {
             const PetscInt I = static_cast<PetscInt>(r.index);
@@ -1096,8 +1086,7 @@ namespace Rodin::Assembly
             for (const auto& c : constraints.expand(col))
             {
               const PetscInt J = static_cast<PetscInt>(c.index);
-              const PetscScalar v =
-                r.coefficient * val * c.coefficient;
+              const PetscScalar v = r.coefficient * val * c.coefficient;
               // Insert unconditionally. PETSc decides whether zero-valued
               // insertions affect the pattern according to its current
               // matrix options.
@@ -1108,8 +1097,7 @@ namespace Rodin::Assembly
           }
         };
 
-        auto vector_entry = [&](Index row, PetscScalar val)
-        {
+        auto vector_entry = [&](Index row, PetscScalar val) {
           if (val == PetscScalar(0))
             return;
           for (const auto& r : constraints.expand(row))
@@ -1375,12 +1363,8 @@ namespace Rodin::Assembly
 
           if (!zeroRowsIdx.empty())
           {
-            ierr = MatZeroRows(
-                A,
-                static_cast<PetscInt>(zeroRowsIdx.size()),
-                zeroRowsIdx.data(),
-                0.0,
-                nullptr, nullptr);
+            ierr = MatZeroRows(A, static_cast<PetscInt>(zeroRowsIdx.size()),
+              zeroRowsIdx.data(), 0.0, nullptr, nullptr);
             assert(ierr == PETSC_SUCCESS);
             (void)ierr;
 

--- a/src/Rodin/PETSc/Variational/GridFunction.h
+++ b/src/Rodin/PETSc/Variational/GridFunction.h
@@ -1290,11 +1290,11 @@ namespace Rodin::Variational
 
       /// @brief Returns the polynomial order of the finite element space on
       ///        the given polytope.
-      constexpr
-      Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
+      constexpr Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
       {
         const auto& fes = this->getFiniteElementSpace();
-        return fes.getFiniteElement(polytope.getDimension(), polytope.getIndex()).getOrder();
+        return fes.getFiniteElement(polytope.getDimension(), polytope.getIndex())
+          .getOrder();
       }
 
       /**

--- a/src/Rodin/QF/Centroid.cpp
+++ b/src/Rodin/QF/Centroid.cpp
@@ -46,7 +46,7 @@ namespace Rodin::QF
       }
       case Geometry::Polytope::Type::Pyramid:
       {
-        static const Math::SpatialPoint s_point{{ 0.375, 0.375, 0.25 }};
+        static const Math::SpatialPoint s_point{{0.375, 0.375, 0.25}};
         return s_point;
       }
       case Geometry::Polytope::Type::Wedge:

--- a/src/Rodin/QF/GaussLobatto.h
+++ b/src/Rodin/QF/GaussLobatto.h
@@ -476,11 +476,11 @@ namespace Rodin::QF
        */
       void buildPyramid(size_t nx, size_t ny, size_t nz)
       {
-        std::vector<Real> u,wu,v,wv,z,wz;
+        std::vector<Real> u, wu, v, wv, z, wz;
         gll1dUnit(nx, u, wu);
         gll1dUnit(ny, v, wv);
         gll1dUnit(nz, z, wz);
-        const size_t N = nx*ny*nz;
+        const size_t N = nx * ny * nz;
         m_points.clear();
         m_points.reserve(N);
         m_weights.resize(N);

--- a/src/Rodin/Solid/Constitutive/ActiveContraction.h
+++ b/src/Rodin/Solid/Constitutive/ActiveContraction.h
@@ -34,7 +34,8 @@ namespace Rodin::Solid
    * condensed dynamic tangent is used.
    */
   template <class PassiveLaw, class ActiveLaw = ActiveFiberLaw>
-  class ActiveContraction final : public HyperElasticLaw<ActiveContraction<PassiveLaw, ActiveLaw>>
+  class ActiveContraction final
+    : public HyperElasticLaw<ActiveContraction<PassiveLaw, ActiveLaw>>
   {
     public:
       /// @brief Cached passive and active quantities at a quadrature point.
@@ -60,8 +61,7 @@ namespace Rodin::Solid
 
       /// @brief Constructs the coupled active contraction law.
       ActiveContraction(
-          const PassiveLaw& passiveLaw,
-          const ActiveLaw& activeLaw = ActiveLaw())
+        const PassiveLaw& passiveLaw, const ActiveLaw& activeLaw = ActiveLaw())
         : m_passiveLaw(passiveLaw),
           m_activeLaw(activeLaw),
           m_localTolerance(1e-12),
@@ -163,8 +163,7 @@ namespace Rodin::Solid
           cache.activeExtension = cp.has<Tags::ActiveExtension>()
             ? cp.get<Tags::ActiveExtension>()
             : m_activeLaw.getParameters().initial.extension;
-          cache.active =
-            m_activeLaw.evaluateStatic(cache.strain, cache.activeExtension);
+          cache.active = m_activeLaw.evaluateStatic(cache.strain, cache.activeExtension);
           cache.newState = m_activeLaw.initialState();
           cache.dynamic = false;
           cache.localIterations = 0;
@@ -174,35 +173,27 @@ namespace Rodin::Solid
       /// @brief Returns the sum of passive and active strain-energy densities.
       Real getStrainEnergyDensity(const Cache& cache, const ConstitutivePoint& cp) const
       {
-        const Real passiveEnergy =
-          m_passiveLaw.getStrainEnergyDensity(cache.passive, cp);
+        const Real passiveEnergy = m_passiveLaw.getStrainEnergyDensity(cache.passive, cp);
         const Real denom = 1.0 + 2.0 * cache.activeExtension;
-        const Real activeEnergy =
-          0.5 * m_activeLaw.getParameters().stiffness
-          * (cache.strain - cache.activeExtension)
-          * (cache.strain - cache.activeExtension)
-          / (denom * denom);
+        const Real activeEnergy = 0.5 * m_activeLaw.getParameters().stiffness *
+          (cache.strain - cache.activeExtension) *
+          (cache.strain - cache.activeExtension) / (denom * denom);
         return passiveEnergy + activeEnergy;
       }
 
       /// @brief Adds the active contribution to the first Piola-Kirchhoff stress.
-      void getFirstPiolaKirchhoffStress(
-          Math::SpatialMatrix<Real>& P,
-          const Cache& cache,
-          const ConstitutivePoint& cp) const
+      void getFirstPiolaKirchhoffStress(Math::SpatialMatrix<Real>& P, const Cache& cache,
+        const ConstitutivePoint& cp) const
       {
         m_passiveLaw.getFirstPiolaKirchhoffStress(P, cache.passive, cp);
-        P = P + cache.active.stress
-              * cp.getKinematicState().getDeformationGradient()
-              * cache.fiber.tensor();
+        P = P +
+          cache.active.stress * cp.getKinematicState().getDeformationGradient() *
+            cache.fiber.tensor();
       }
 
       /// @brief Adds the active contribution to the material tangent action.
-      void getMaterialTangent(
-          Math::SpatialMatrix<Real>& dP,
-          const Cache& cache,
-          const ConstitutivePoint& cp,
-          const Math::SpatialMatrix<Real>& dF) const
+      void getMaterialTangent(Math::SpatialMatrix<Real>& dP, const Cache& cache,
+        const ConstitutivePoint& cp, const Math::SpatialMatrix<Real>& dF) const
       {
         m_passiveLaw.getMaterialTangent(dP, cache.passive, cp, dF);
 
@@ -220,21 +211,17 @@ namespace Rodin::Solid
         const Real dStrain = cache.fiber.dStrain(dF);
         const Real fiberTangent =
           cache.dynamic ? cache.active.tangent : cache.active.dStressDe;
-        dP = dP
-           + cache.active.stress * dF * cache.fiber.tensor()
-           + fiberTangent * dStrain
-             * cp.getKinematicState().getDeformationGradient()
-             * cache.fiber.tensor();
+        dP = dP + cache.active.stress * dF * cache.fiber.tensor() +
+          fiberTangent * dStrain * cp.getKinematicState().getDeformationGradient() *
+            cache.fiber.tensor();
       }
 
     private:
       static bool hasDynamicData(const ConstitutivePoint& cp)
       {
-        return cp.has<Tags::TimeStep>()
-            && cp.has<Tags::PreviousActiveExtension>()
-            && cp.has<Tags::PreviousActiveGamma>()
-            && cp.has<Tags::PreviousActiveBeta>()
-            && cp.has<Tags::ElectricalActivation>();
+        return cp.has<Tags::TimeStep>() && cp.has<Tags::PreviousActiveExtension>() &&
+          cp.has<Tags::PreviousActiveGamma>() && cp.has<Tags::PreviousActiveBeta>() &&
+          cp.has<Tags::ElectricalActivation>();
       }
 
       PassiveLaw m_passiveLaw;

--- a/src/Rodin/Solid/Constitutive/ActiveFiberLaw.h
+++ b/src/Rodin/Solid/Constitutive/ActiveFiberLaw.h
@@ -111,11 +111,8 @@ namespace Rodin::Solid
       State initialState() const
       {
         State state;
-        state.gamma =
-          std::sqrt(std::max<Real>(m_parameters.initial.stiffness, 0.0));
-        state.beta = state.gamma > 0.0
-          ? m_parameters.initial.stress / state.gamma
-          : 0.0;
+        state.gamma = std::sqrt(std::max<Real>(m_parameters.initial.stiffness, 0.0));
+        state.beta = state.gamma > 0.0 ? m_parameters.initial.stress / state.gamma : 0.0;
         return state;
       }
 
@@ -123,8 +120,7 @@ namespace Rodin::Solid
       Real stress(Real e, Real c) const
       {
         const Real denom = 1.0 + 2.0 * c;
-        return m_parameters.stiffness
-             * (e - c) / (denom * denom);
+        return m_parameters.stiffness * (e - c) / (denom * denom);
       }
 
       /// @brief Evaluates @f$\partial\sigma/\partial e@f$ at fixed extension.
@@ -138,9 +134,8 @@ namespace Rodin::Solid
       Real dStressDc(Real e, Real c) const
       {
         const Real denom = 1.0 + 2.0 * c;
-        return m_parameters.stiffness
-             * (2.0 * c - 4.0 * e - 1.0)
-             / (denom * denom * denom);
+        return m_parameters.stiffness * (2.0 * c - 4.0 * e - 1.0) /
+          (denom * denom * denom);
       }
 
       /// @brief Evaluates the static active response.
@@ -151,24 +146,17 @@ namespace Rodin::Solid
         response.dStressDe = dStressDe(c);
         response.dStressDc = dStressDc(e, c);
         response.kcc = m_parameters.stiffness * (1.0 + 2.0 * e);
-        response.kce =
-          -m_parameters.stiffness * (1.0 + 4.0 * e - 2.0 * c);
+        response.kce = -m_parameters.stiffness * (1.0 + 4.0 * e - 2.0 * c);
         response.residual =
-          (-m_parameters.stiffness
-           * (e - c) * (1.0 + 2.0 * e))
-          / response.kcc;
+          (-m_parameters.stiffness * (e - c) * (1.0 + 2.0 * e)) / response.kcc;
         response.tangent =
           response.dStressDe - response.dStressDc * response.kce / response.kcc;
         return response;
       }
 
       /// @brief Advances the internal active-fiber state.
-      State update(
-          Real dt,
-          const State& oldState,
-          Real previousActiveExtension,
-          Real activeExtension,
-          Real activation) const
+      State update(Real dt, const State& oldState, Real previousActiveExtension,
+        Real activeExtension, Real activation) const
       {
         const Real alpha = m_parameters.destructionRate;
         const Real k0 = m_parameters.crossBridgeStiffness;
@@ -179,28 +167,22 @@ namespace Rodin::Solid
         const Real n0 = starling(previousActiveExtension);
 
         const Real denominatorGamma =
-          1.0
-          + dt * std::abs(activation)
-          + alpha * std::abs(delta);
+          1.0 + dt * std::abs(activation) + alpha * std::abs(delta);
 
-        const Real gammaSquare =
-          std::max<Real>(1.e-16,
-              (oldState.gamma * oldState.gamma + dt * n0 * k0 * activationPlus)
-              / denominatorGamma);
+        const Real gammaSquare = std::max<Real>(1.e-16,
+          (oldState.gamma * oldState.gamma + dt * n0 * k0 * activationPlus) /
+            denominatorGamma);
 
         State state;
         state.gamma = std::sqrt(gammaSquare);
 
-        const Real denominatorBeta =
-          1.0
-          + 0.5 * dt * n0 * k0 * activationPlus / gammaSquare
-          + 0.5 * dt * std::abs(activation)
-          + 0.5 * alpha * std::abs(delta);
+        const Real denominatorBeta = 1.0 +
+          0.5 * dt * n0 * k0 * activationPlus / gammaSquare +
+          0.5 * dt * std::abs(activation) + 0.5 * alpha * std::abs(delta);
 
-        state.beta =
-          (oldState.beta + state.gamma * delta
-           + dt * n0 * sigma0 * activationPlus / state.gamma)
-          / denominatorBeta;
+        state.beta = (oldState.beta + state.gamma * delta +
+                       dt * n0 * sigma0 * activationPlus / state.gamma) /
+          denominatorBeta;
 
         return state;
       }
@@ -226,37 +208,30 @@ namespace Rodin::Solid
         Real e, Real previousActiveExtension, Real activeExtension, Real activation,
         Real strainFactor = 1.0) const
       {
-        const Real midpointExtension =
-          0.5 * (activeExtension + previousActiveExtension);
+        const Real midpointExtension = 0.5 * (activeExtension + previousActiveExtension);
         const Real onePlus2MidpointExtension = 1.0 + 2.0 * midpointExtension;
-        const Real activeBranchStress =
-          newState.activeStress()
-          + m_parameters.damping
-          * (activeExtension - previousActiveExtension) / dt;
+        const Real activeBranchStress = newState.activeStress() +
+          m_parameters.damping * (activeExtension - previousActiveExtension) / dt;
 
         Response response;
         response.stress = stress(e, midpointExtension);
         response.dStressDe = dStressDe(midpointExtension);
         response.dStressDc = dStressDc(e, midpointExtension);
         response.kce =
-          -m_parameters.stiffness
-          * (1.0 + 4.0 * e - 2.0 * midpointExtension);
-        response.kcc =
-          3.0 * onePlus2MidpointExtension * onePlus2MidpointExtension
-            * activeBranchStress
-          + onePlus2MidpointExtension * onePlus2MidpointExtension
-            * onePlus2MidpointExtension
-            * (dActiveStressDc(
-                dt, oldState, activation, previousActiveExtension, activeExtension)
-              + m_parameters.damping / dt)
-          + 0.5 * m_parameters.stiffness * (1.0 + 2.0 * e);
+          -m_parameters.stiffness * (1.0 + 4.0 * e - 2.0 * midpointExtension);
+        response.kcc = 3.0 * onePlus2MidpointExtension * onePlus2MidpointExtension *
+            activeBranchStress +
+          onePlus2MidpointExtension * onePlus2MidpointExtension *
+            onePlus2MidpointExtension *
+            (dActiveStressDc(
+               dt, oldState, activation, previousActiveExtension, activeExtension) +
+              m_parameters.damping / dt) +
+          0.5 * m_parameters.stiffness * (1.0 + 2.0 * e);
         response.residual =
-          (activeBranchStress
-             * onePlus2MidpointExtension * onePlus2MidpointExtension
-             * onePlus2MidpointExtension
-           - m_parameters.stiffness
-             * (e - midpointExtension) * (1.0 + 2.0 * e))
-          / response.kcc;
+          (activeBranchStress * onePlus2MidpointExtension * onePlus2MidpointExtension *
+              onePlus2MidpointExtension -
+            m_parameters.stiffness * (e - midpointExtension) * (1.0 + 2.0 * e)) /
+          response.kcc;
         // Chain rule to the current fiber strain: sigma and the local residual
         // are functions of the evaluation strain e, whose derivative with
         // respect to e_1D^{n+1} is strainFactor.
@@ -266,12 +241,8 @@ namespace Rodin::Solid
       }
 
       /// @brief Evaluates the derivative of active stress with respect to extension.
-      Real dActiveStressDc(
-          Real dt,
-          const State& oldState,
-          Real activation,
-          Real previousActiveExtension,
-          Real activeExtension) const
+      Real dActiveStressDc(Real dt, const State& oldState, Real activation,
+        Real previousActiveExtension, Real activeExtension) const
       {
         const Real alpha = m_parameters.destructionRate;
         const Real k0 = m_parameters.crossBridgeStiffness;
@@ -283,14 +254,9 @@ namespace Rodin::Solid
         const Real activationPlus = std::max<Real>(activation, 0.0);
         const Real n0 = starling(previousActiveExtension);
 
-        const Real Dg =
-          1.0
-          + dt * std::abs(activation)
-          + alpha * absDelta;
+        const Real Dg = 1.0 + dt * std::abs(activation) + alpha * absDelta;
 
-        const Real Ng =
-          oldState.gamma * oldState.gamma
-          + dt * n0 * k0 * activationPlus;
+        const Real Ng = oldState.gamma * oldState.gamma + dt * n0 * k0 * activationPlus;
 
         const Real gammaSquare = std::max<Real>(1.e-16, Ng / Dg);
         const Real gamma = std::sqrt(gammaSquare);
@@ -299,25 +265,17 @@ namespace Rodin::Solid
         const Real dGamma = 0.5 * dGammaSquare / gamma;
 
         const Real Nb =
-          oldState.beta
-          + gamma * delta
-          + dt * n0 * sigma0 * activationPlus / gamma;
+          oldState.beta + gamma * delta + dt * n0 * sigma0 * activationPlus / gamma;
 
-        const Real Db =
-          1.0
-          + 0.5 * dt * n0 * k0 * activationPlus / gammaSquare
-          + 0.5 * dt * std::abs(activation)
-          + 0.5 * alpha * absDelta;
+        const Real Db = 1.0 + 0.5 * dt * n0 * k0 * activationPlus / gammaSquare +
+          0.5 * dt * std::abs(activation) + 0.5 * alpha * absDelta;
 
-        const Real dNb =
-          dGamma * delta
-          + gamma
-          - dt * n0 * sigma0 * activationPlus * dGamma / (gamma * gamma);
+        const Real dNb = dGamma * delta + gamma -
+          dt * n0 * sigma0 * activationPlus * dGamma / (gamma * gamma);
 
-        const Real dDb =
-          -0.5 * dt * n0 * k0 * activationPlus
-            * dGammaSquare / (gammaSquare * gammaSquare)
-          + 0.5 * alpha * sign;
+        const Real dDb = -0.5 * dt * n0 * k0 * activationPlus * dGammaSquare /
+            (gammaSquare * gammaSquare) +
+          0.5 * alpha * sign;
 
         const Real dBeta = (dNb * Db - Nb * dDb) / (Db * Db);
 

--- a/src/Rodin/Solid/Constitutive/HolzapfelOgden.h
+++ b/src/Rodin/Solid/Constitutive/HolzapfelOgden.h
@@ -94,14 +94,7 @@ namespace Rodin::Solid
       {}
 
       /// @brief Constructs the law from scalar material parameters.
-      HolzapfelOgden(
-          Real mu1,
-          Real mu2,
-          Real C0,
-          Real C1,
-          Real C2,
-          Real C3,
-          Real kappa)
+      HolzapfelOgden(Real mu1, Real mu2, Real C0, Real C1, Real C2, Real C3, Real kappa)
         : m_params{mu1, mu2, C0, C1, C2, C3, kappa}
       {}
 
@@ -120,28 +113,22 @@ namespace Rodin::Solid
       /// @brief Returns the stored strain-energy density.
       Real getStrainEnergyDensity(const Cache& cache, const ConstitutivePoint&) const
       {
-        return m_params.mu1 * (cache.I1bar - 3.0)
-             + m_params.mu2 * (cache.I2bar - 3.0)
-             + m_params.C0 * std::exp(m_params.C1 * square(cache.I1bar - 3.0))
-             + m_params.C2 * std::exp(m_params.C3 * square(cache.I4bar - 1.0))
-             + m_params.kappa * (cache.J - 1.0 - std::log(cache.J));
+        return m_params.mu1 * (cache.I1bar - 3.0) + m_params.mu2 * (cache.I2bar - 3.0) +
+          m_params.C0 * std::exp(m_params.C1 * square(cache.I1bar - 3.0)) +
+          m_params.C2 * std::exp(m_params.C3 * square(cache.I4bar - 1.0)) +
+          m_params.kappa * (cache.J - 1.0 - std::log(cache.J));
       }
 
       /// @brief Computes the first Piola-Kirchhoff stress.
-      void getFirstPiolaKirchhoffStress(
-          Math::SpatialMatrix<Real>& P,
-          const Cache& cache,
-          const ConstitutivePoint& cp) const
+      void getFirstPiolaKirchhoffStress(Math::SpatialMatrix<Real>& P, const Cache& cache,
+        const ConstitutivePoint& cp) const
       {
         computeFirstPiolaKirchhoffStress(P, cache, cp.getKinematicState());
       }
 
       /// @brief Computes the material tangent action by directional differencing.
-      void getMaterialTangent(
-          Math::SpatialMatrix<Real>& dP,
-          const Cache& cache,
-          const ConstitutivePoint& cp,
-          const Math::SpatialMatrix<Real>& dF) const
+      void getMaterialTangent(Math::SpatialMatrix<Real>& dP, const Cache& cache,
+        const ConstitutivePoint& cp, const Math::SpatialMatrix<Real>& dF) const
       {
         const auto& state = cp.getKinematicState();
         const auto& H = state.getDisplacementGradient();
@@ -166,10 +153,8 @@ namespace Rodin::Solid
         return x * x;
       }
 
-      void setCache(
-          Cache& cache,
-          const KinematicState& state,
-          const Math::SpatialVector<Real>& direction) const
+      void setCache(Cache& cache, const KinematicState& state,
+        const Math::SpatialVector<Real>& direction) const
       {
         const auto& C = state.getRightCauchyGreenTensor();
         cache.J = state.getJacobian();
@@ -185,47 +170,38 @@ namespace Rodin::Solid
         cache.I4bar = cache.I4 * cache.I3m13;
       }
 
-      void computeFirstPiolaKirchhoffStress(
-          Math::SpatialMatrix<Real>& P,
-          const Cache& cache,
-          const KinematicState& state) const
+      void computeFirstPiolaKirchhoffStress(Math::SpatialMatrix<Real>& P,
+        const Cache& cache, const KinematicState& state) const
       {
         const auto& F = state.getDeformationGradient();
         const auto& C = state.getRightCauchyGreenTensor();
         const auto& Cinv = C.inverse();
         const size_t d = state.getDimension();
 
-        Math::SpatialMatrix<Real> I(static_cast<std::uint8_t>(d), static_cast<std::uint8_t>(d));
+        Math::SpatialMatrix<Real> I(
+          static_cast<std::uint8_t>(d), static_cast<std::uint8_t>(d));
         I.setIdentity();
-        const Math::SpatialMatrix<Real> A =
-          FiberKinematics::dyad(cache.direction);
+        const Math::SpatialMatrix<Real> A = FiberKinematics::dyad(cache.direction);
 
-        const Real W1 =
-          2.0 * m_params.C0 * m_params.C1 * cache.I3m13
-            * (cache.I1bar - 3.0)
-            * std::exp(m_params.C1 * square(cache.I1bar - 3.0))
-          + m_params.mu1 * cache.I3m13;
+        const Real W1 = 2.0 * m_params.C0 * m_params.C1 * cache.I3m13 *
+            (cache.I1bar - 3.0) * std::exp(m_params.C1 * square(cache.I1bar - 3.0)) +
+          m_params.mu1 * cache.I3m13;
         const Real W2 = m_params.mu2 * cache.I3m23;
-        const Real W4 =
-          2.0 * m_params.C2 * m_params.C3 * cache.I3m13
-            * (cache.I4bar - 1.0)
-            * std::exp(m_params.C3 * square(cache.I4bar - 1.0));
+        const Real W4 = 2.0 * m_params.C2 * m_params.C3 * cache.I3m13 *
+          (cache.I4bar - 1.0) * std::exp(m_params.C3 * square(cache.I4bar - 1.0));
         const Real W3 =
-          -(1.0 / 3.0) * m_params.mu1 * cache.I1 * std::pow(cache.I3, -4.0 / 3.0)
-          -(2.0 / 3.0) * m_params.mu2 * cache.I2 * std::pow(cache.I3, -5.0 / 3.0)
-          -(2.0 / 3.0) * m_params.C0 * m_params.C1 * cache.I1
-            * std::pow(cache.I3, -4.0 / 3.0) * (cache.I1bar - 3.0)
-            * std::exp(m_params.C1 * square(cache.I1bar - 3.0))
-          -(1.0 / 3.0) * 2.0 * m_params.C2 * m_params.C3 * cache.I4
-            * std::pow(cache.I3, -4.0 / 3.0) * (cache.I4bar - 1.0)
-            * std::exp(m_params.C3 * square(cache.I4bar - 1.0))
-          + 0.5 * m_params.kappa * (std::pow(cache.I3, -0.5) - 1.0 / cache.I3);
+          -(1.0 / 3.0) * m_params.mu1 * cache.I1 * std::pow(cache.I3, -4.0 / 3.0) -
+          (2.0 / 3.0) * m_params.mu2 * cache.I2 * std::pow(cache.I3, -5.0 / 3.0) -
+          (2.0 / 3.0) * m_params.C0 * m_params.C1 * cache.I1 *
+            std::pow(cache.I3, -4.0 / 3.0) * (cache.I1bar - 3.0) *
+            std::exp(m_params.C1 * square(cache.I1bar - 3.0)) -
+          (1.0 / 3.0) * 2.0 * m_params.C2 * m_params.C3 * cache.I4 *
+            std::pow(cache.I3, -4.0 / 3.0) * (cache.I4bar - 1.0) *
+            std::exp(m_params.C3 * square(cache.I4bar - 1.0)) +
+          0.5 * m_params.kappa * (std::pow(cache.I3, -0.5) - 1.0 / cache.I3);
 
         const Math::SpatialMatrix<Real> dWdC =
-          W1 * I
-          + W2 * (cache.I1 * I + (-1.0) * C)
-          + W3 * cache.I3 * Cinv
-          + W4 * A;
+          W1 * I + W2 * (cache.I1 * I + (-1.0) * C) + W3 * cache.I3 * Cinv + W4 * A;
 
         P = 2.0 * F * dWdC;
       }

--- a/src/Rodin/Solid/Local/FiberKinematics.h
+++ b/src/Rodin/Solid/Local/FiberKinematics.h
@@ -36,8 +36,7 @@ namespace Rodin::Solid
 
       /// @brief Constructs fiber kinematics from a state and reference direction.
       FiberKinematics(
-          const KinematicState& state,
-          const Math::SpatialVector<Real>& direction)
+        const KinematicState& state, const Math::SpatialVector<Real>& direction)
         : m_direction(normalize(direction)),
           m_tensor(dyad(m_direction)),
           m_current(state.getDeformationGradient() * m_direction),
@@ -89,8 +88,7 @@ namespace Rodin::Solid
       /// @brief Reads and normalizes the fiber direction from a constitutive point.
       static Math::SpatialVector<Real> direction(const ConstitutivePoint& cp)
       {
-        const auto d =
-          static_cast<std::uint8_t>(cp.getKinematicState().getDimension());
+        const auto d = static_cast<std::uint8_t>(cp.getKinematicState().getDimension());
         Math::SpatialVector<Real> a(d);
         if (cp.has<Tags::FiberDirection>())
           a = cp.get<Tags::FiberDirection>();

--- a/src/Rodin/Variational/BilinearFormIntegrator.h
+++ b/src/Rodin/Variational/BilinearFormIntegrator.h
@@ -79,13 +79,12 @@ namespace Rodin::Variational
        * the trial function @f$ u @f$ and test function @f$ v @f$.
        */
       template <class TrialFunctionType, class TestFunctionType,
-                std::enable_if_t<
-                  IsTrialFunction<std::decay_t<TrialFunctionType>>::Value &&
-                  IsTestFunction<std::decay_t<TestFunctionType>>::Value,
-                  int> = 0>
-      BilinearFormIntegratorBase(
-          const TrialFunctionType& u, const TestFunctionType& v)
-        : m_u(u.copy()), m_v(v.copy())
+        std::enable_if_t<IsTrialFunction<std::decay_t<TrialFunctionType>>::Value &&
+            IsTestFunction<std::decay_t<TestFunctionType>>::Value,
+          int> = 0>
+      BilinearFormIntegratorBase(const TrialFunctionType& u, const TestFunctionType& v)
+        : m_u(u.copy()),
+          m_v(v.copy())
       {}
 
       /**

--- a/src/Rodin/Variational/DirichletBC.h
+++ b/src/Rodin/Variational/DirichletBC.h
@@ -297,8 +297,7 @@ namespace Rodin::Variational
        *
        * The constraint encoded is @f$ u_s = \sum_j C_{sj}\, v_j @f$.
        */
-      using IdentifiedDOFs =
-        IndexMap<std::pair<IndexArray, Math::Vector<ScalarType>>>;
+      using IdentifiedDOFs = IndexMap<std::pair<IndexArray, Math::Vector<ScalarType>>>;
 
       /**
        * @brief Optional defects for affine identification rows.
@@ -362,7 +361,10 @@ namespace Rodin::Variational
        * apply the correct global offset when assembling identified-DOF
        * constraints.
        */
-      virtual Optional<Identifiable::UUID> getValueUUID() const { return {}; }
+      virtual Optional<Identifiable::UUID> getValueUUID() const
+      {
+        return {};
+      }
 
       /**
        * @brief Returns optional defects for affine identification BCs.
@@ -468,7 +470,8 @@ namespace Rodin::Variational
         typename FormLanguage::Traits<FESMeshType>::ContextType;
 
       using DefaultAssemblyType =
-        typename Assembly::Default<FESMeshContextType>::template Type<ValueDOFs, DirichletBC>;
+        typename Assembly::Default<FESMeshContextType>::template Type<ValueDOFs,
+          DirichletBC>;
 
       using AssemblyType =
         DefaultAssemblyType;
@@ -568,8 +571,7 @@ namespace Rodin::Variational
         // Ensure variant holds the ValueDOFs alternative.
         if (!std::holds_alternative<ValueDOFs>(m_dofs))
           m_dofs = ValueDOFs{};
-        m_assembly.execute(
-            std::get<ValueDOFs>(m_dofs), { m_u.get(), *m_value, m_essBdr });
+        m_assembly.execute(std::get<ValueDOFs>(m_dofs), {m_u.get(), *m_value, m_essBdr});
       }
 
       bool isComponent() const override
@@ -773,11 +775,10 @@ namespace Rodin::Variational
    * @see ShapeFunctionBase::setIntegrationPoint
    * @see PeriodicBC
    */
-  template <class Solution, class FES1,
-            class Derived2, class FES2, ShapeFunctionSpaceType Sp>
-  class DirichletBC<TrialFunction<Solution, FES1>,
-                    ShapeFunctionBase<Derived2, FES2, Sp>> final
-    : public DirichletBCBase<typename FormLanguage::Traits<FES1>::ScalarType>
+  template <class Solution, class FES1, class Derived2, class FES2,
+    ShapeFunctionSpaceType Sp>
+  class DirichletBC<TrialFunction<Solution, FES1>, ShapeFunctionBase<Derived2, FES2, Sp>>
+    final : public DirichletBCBase<typename FormLanguage::Traits<FES1>::ScalarType>
   {
     public:
       /// @brief Finite element space type.
@@ -790,8 +791,7 @@ namespace Rodin::Variational
       using ValueType = ShapeFunctionBase<Derived2, FES2, Sp>;
 
       /// Scalar type
-      using ScalarType =
-        typename FormLanguage::Traits<FESType>::ScalarType;
+      using ScalarType = typename FormLanguage::Traits<FESType>::ScalarType;
 
       /// Parent class
       using Parent = DirichletBCBase<ScalarType>;
@@ -804,20 +804,17 @@ namespace Rodin::Variational
       /// Variant DOFs type
       using DOFs = typename Parent::DOFs;
 
-      using FESMeshType =
-        typename FormLanguage::Traits<FESType>::MeshType;
+      using FESMeshType = typename FormLanguage::Traits<FESType>::MeshType;
 
-      using FESRangeType =
-        typename FormLanguage::Traits<FESType>::RangeType;
+      using FESRangeType = typename FormLanguage::Traits<FESType>::RangeType;
 
-      using FESMeshContextType =
-        typename FormLanguage::Traits<FESMeshType>::ContextType;
+      using FESMeshContextType = typename FormLanguage::Traits<FESMeshType>::ContextType;
 
       using DefaultAssemblyType =
-        typename Assembly::Default<FESMeshContextType>::template Type<IdentifiedDOFs, DirichletBC>;
+        typename Assembly::Default<FESMeshContextType>::template Type<IdentifiedDOFs,
+          DirichletBC>;
 
-      using AssemblyType =
-        DefaultAssemblyType;
+      using AssemblyType = DefaultAssemblyType;
 
       class DefectBase
       {
@@ -863,7 +860,8 @@ namespace Rodin::Variational
        * @param[in] v Right-hand-side shape function expression @f$ A(v) @f$
        */
       DirichletBC(const OperandType& u, const ValueType& v)
-        : m_u(u), m_v(v.copy())
+        : m_u(u),
+          m_v(v.copy())
       {}
 
       /**
@@ -883,10 +881,8 @@ namespace Rodin::Variational
        * @param[in] defect Known additive defect @f$ d @f$
        */
       template <class DefectDerived>
-      DirichletBC(
-          const OperandType& u,
-          const ValueType& v,
-          const FunctionBase<DefectDerived>& defect)
+      DirichletBC(const OperandType& u, const ValueType& v,
+        const FunctionBase<DefectDerived>& defect)
         : m_u(u),
           m_v(v.copy()),
           m_defect(std::make_unique<Defect<DefectDerived>>(defect))
@@ -923,8 +919,7 @@ namespace Rodin::Variational
        * @f$ u=A(v) @f$ is enforced. Both slave and master DOFs are read from
        * the *same* face polytopes — there is no cross-face matching.
        */
-      constexpr
-      DirichletBC& on(Geometry::Attribute bdrAtr)
+      constexpr DirichletBC& on(Geometry::Attribute bdrAtr)
       {
         return on(FlatSet<Geometry::Attribute>{bdrAtr});
       }
@@ -932,18 +927,16 @@ namespace Rodin::Variational
       /**
        * @brief Sets @f$ \Gamma_D @f$ to the union of multiple attributes.
        */
-      template <class A1, class A2, class ... As>
-      constexpr
-      DirichletBC& on(A1 a1, A2 a2, As... as)
+      template <class A1, class A2, class... As>
+      constexpr DirichletBC& on(A1 a1, A2 a2, As... as)
       {
-        return on(FlatSet<Geometry::Attribute>{ a1, a2, as... });
+        return on(FlatSet<Geometry::Attribute>{a1, a2, as...});
       }
 
       /**
        * @brief Sets @f$ \Gamma_D @f$ to a precomputed attribute set.
        */
-      constexpr
-      DirichletBC& on(const FlatSet<Geometry::Attribute>& bdrAttrs)
+      constexpr DirichletBC& on(const FlatSet<Geometry::Attribute>& bdrAttrs)
       {
         assert(bdrAttrs.size() > 0);
         m_essBdr = bdrAttrs;
@@ -953,8 +946,7 @@ namespace Rodin::Variational
       /**
        * @returns The boundary attribute set defining @f$ \Gamma_D @f$.
        */
-      constexpr
-      const FlatSet<Geometry::Attribute>& getAttributes() const
+      constexpr const FlatSet<Geometry::Attribute>& getAttributes() const
       {
         return m_essBdr;
       }
@@ -994,8 +986,7 @@ namespace Rodin::Variational
       {
         if (!std::holds_alternative<IdentifiedDOFs>(m_dofs))
           m_dofs = IdentifiedDOFs{};
-        m_assembly.execute(
-            std::get<IdentifiedDOFs>(m_dofs), { m_u.get(), *m_v, m_essBdr });
+        m_assembly.execute(std::get<IdentifiedDOFs>(m_dofs), {m_u.get(), *m_v, m_essBdr});
 
         m_values.clear();
         if (m_defect)
@@ -1019,18 +1010,17 @@ namespace Rodin::Variational
 
             const auto& fe = fes.getFiniteElement(faceDim, i);
             const auto mapping = fes.getPullback(
-                { faceDim, i },
-                [defect = m_defect.get()](const Geometry::Point& p)
-                {
-                  return defect->getValue(p);
-                });
+              {faceDim, i}, [defect = m_defect.get()](const Geometry::Point& p) {
+                return defect->getValue(p);
+              });
 
             for (Index local = 0; local < fe.getCount(); local++)
             {
-              const Index global = fes.getGlobalIndex({ faceDim, i }, local);
+              const Index global = fes.getGlobalIndex({faceDim, i}, local);
               auto find = m_values.find(global);
               if (find == m_values.end())
-                m_values.insert(find, std::pair{ global, fe.getLinearForm(local)(mapping) });
+                m_values.insert(
+                  find, std::pair{global, fe.getLinearForm(local)(mapping)});
             }
           }
         }
@@ -1107,21 +1097,17 @@ namespace Rodin::Variational
    * @ingroup RodinCTAD
    * @brief CTAD for the identification DirichletBC.
    */
-  template <class Solution, class FES1,
-            class Derived2, class FES2, ShapeFunctionSpaceType Sp>
-  DirichletBC(const TrialFunction<Solution, FES1>&,
-              const ShapeFunctionBase<Derived2, FES2, Sp>&)
-    -> DirichletBC<TrialFunction<Solution, FES1>,
-                   ShapeFunctionBase<Derived2, FES2, Sp>>;
+  template <class Solution, class FES1, class Derived2, class FES2,
+    ShapeFunctionSpaceType Sp>
+  DirichletBC(
+    const TrialFunction<Solution, FES1>&, const ShapeFunctionBase<Derived2, FES2, Sp>&)
+    -> DirichletBC<TrialFunction<Solution, FES1>, ShapeFunctionBase<Derived2, FES2, Sp>>;
 
-  template <class Solution, class FES1,
-            class Derived2, class FES2, ShapeFunctionSpaceType Sp,
-            class DefectDerived>
+  template <class Solution, class FES1, class Derived2, class FES2,
+    ShapeFunctionSpaceType Sp, class DefectDerived>
   DirichletBC(const TrialFunction<Solution, FES1>&,
-              const ShapeFunctionBase<Derived2, FES2, Sp>&,
-              const FunctionBase<DefectDerived>&)
-    -> DirichletBC<TrialFunction<Solution, FES1>,
-                   ShapeFunctionBase<Derived2, FES2, Sp>>;
+    const ShapeFunctionBase<Derived2, FES2, Sp>&, const FunctionBase<DefectDerived>&)
+    -> DirichletBC<TrialFunction<Solution, FES1>, ShapeFunctionBase<Derived2, FES2, Sp>>;
 }
 
 /// @endcond

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -1169,12 +1169,9 @@ namespace Rodin::Variational
           size_t d, Index i, const IntegrationPoint& ip) const
       {
         auto& cache = getEvaluationCache();
-        if (!cache.hasBasisValues
-            || cache.owner != this
-            || cache.d != d
-            || cache.i != i
-            || cache.qf != ip.getQuadratureFormula()
-            || cache.qp != ip.getIndex())
+        if (!cache.hasBasisValues || cache.owner != this || cache.d != d ||
+          cache.i != i || cache.qf != ip.getQuadratureFormula() ||
+          cache.qp != ip.getIndex())
         {
           const auto* fes = &this->getFiniteElementSpace();
           const auto& fe = fes->getFiniteElement(d, i);
@@ -1190,7 +1187,7 @@ namespace Rodin::Variational
           cache.basisValues.resize(count);
           for (Index local = 0; local < count; ++local)
           {
-            const auto mapping = fes->getPushforward({ d, i }, fe.getBasis(local));
+            const auto mapping = fes->getPushforward({d, i}, fe.getBasis(local));
             cache.basisValues[local] = mapping(p);
           }
           cache.hasBasisValues = true;
@@ -1520,11 +1517,11 @@ namespace Rodin::Variational
        * @param[in] polytope Entity whose finite element order is requested
        * @returns Polynomial order when available
        */
-      constexpr
-      Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
+      constexpr Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
       {
         const auto& fes = this->getFiniteElementSpace();
-        return fes.getFiniteElement(polytope.getDimension(), polytope.getIndex()).getOrder();
+        return fes.getFiniteElement(polytope.getDimension(), polytope.getIndex())
+          .getOrder();
       }
 
     private:

--- a/src/Rodin/Variational/H1/Div.h
+++ b/src/Rodin/Variational/H1/Div.h
@@ -402,7 +402,7 @@ namespace Rodin::Variational
         key.geom  = geom;
         key.dim   = d;
         key.cell  = cell;
-        key.qf    = qf;
+        key.qf = qf;
         key.qp    = qp;
         key.valid = true;
 
@@ -435,10 +435,8 @@ namespace Rodin::Variational
         for (size_t alpha = 0; alpha < nscalar; ++alpha)
         {
           for (size_t j = 0; j < d; ++j)
-            ref(j) =
-              qf
-                ? tab->getGradient(qp, alpha)[j]
-                : feS.getBasis(alpha).template getDerivative<1>(j)(rc);
+            ref(j) = qf ? tab->getGradient(qp, alpha)[j]
+                        : feS.getBasis(alpha).template getDerivative<1>(j)(rc);
 
           phys = JinvT * ref;
 

--- a/src/Rodin/Variational/H1/Grad.h
+++ b/src/Rodin/Variational/H1/Grad.h
@@ -310,7 +310,7 @@ namespace Rodin::Variational
         key.geom  = geom;
         key.dim   = d;
         key.cell  = cell;
-        key.qf    = qf;
+        key.qf = qf;
         key.qp    = qp;
         key.valid = true;
 
@@ -345,10 +345,8 @@ namespace Rodin::Variational
         for (size_t a = 0; a < ndof; ++a)
         {
           for (size_t ii = 0; ii < d; ++ii)
-            ref(ii) =
-              qf
-                ? tab->getGradient(qp, a)[ii]
-                : fe.getBasis(a).template getDerivative<1>(ii)(rc);
+            ref(ii) = qf ? tab->getGradient(qp, a)[ii]
+                         : fe.getBasis(a).template getDerivative<1>(ii)(rc);
 
           m_cache.gradPhys[a] = JinvT * ref;
         }

--- a/src/Rodin/Variational/H1/H1.hpp
+++ b/src/Rodin/Variational/H1/H1.hpp
@@ -575,11 +575,9 @@ namespace Rodin::Variational
 
           if (local == 0)
           {
-            Utility::ForIndex<K + 1>([&](auto jj)
-            {
+            Utility::ForIndex<K + 1>([&](auto jj) {
               constexpr size_t j = jj.value;
-              Utility::ForIndex<K + 1>([&](auto ii)
-              {
+              Utility::ForIndex<K + 1>([&](auto ii) {
                 constexpr size_t i = ii.value;
                 constexpr size_t qIdx = j * (K + 1) + i;
                 constexpr size_t pIdx = PyramidIndex<K>::getIndex(i, j, 0);
@@ -589,8 +587,7 @@ namespace Rodin::Variational
           }
           else
           {
-            Utility::ForIndex<TriangleCount>([&](auto aa)
-            {
+            Utility::ForIndex<TriangleCount>([&](auto aa) {
               constexpr size_t triIdx = aa.value;
               const size_t pIdx = PyramidIndex<K>::getSideIndex(local, triIdx);
               codomain[pIdx] = domain[triIdx];
@@ -1401,74 +1398,63 @@ namespace Rodin::Variational
         const auto& mesh = m_mesh.get();
         const auto& conn = mesh.getConnectivity();
 
-        const auto& inc = conn.getIncidence({ d, d - 1 }, idx);
+        const auto& inc = conn.getIncidence({d, d - 1}, idx);
         assert(inc.size() == 5);
 
-        using PyrCochain  = Cochain<Geometry::Polytope::Type::Pyramid>;
-        using TriCochain  = Cochain<Geometry::Polytope::Type::Triangle>;
+        using PyrCochain = Cochain<Geometry::Polytope::Type::Pyramid>;
+        using TriCochain = Cochain<Geometry::Polytope::Type::Triangle>;
         using QuadCochain = Cochain<Geometry::Polytope::Type::Quadrilateral>;
 
-        constexpr size_t TriCount  = TriCochain::Count;
+        constexpr size_t TriCount = TriCochain::Count;
         constexpr size_t QuadCount = QuadCochain::Count;
-        constexpr size_t N1        = K + 1;
+        constexpr size_t N1 = K + 1;
 
         std::array<uint8_t, PyrCochain::Count> used{};
         used.fill(0);
 
         const auto& cellVertsIA = conn.getPolytope(d, idx);
         assert(cellVertsIA.size() == 5);
-        std::array<Index,5> v = {
-          cellVertsIA(0),
-          cellVertsIA(1),
-          cellVertsIA(2),
-          cellVertsIA(3),
-          cellVertsIA(4)
-        };
+        std::array<Index, 5> v = {
+          cellVertsIA(0), cellVertsIA(1), cellVertsIA(2), cellVertsIA(3), cellVertsIA(4)};
 
-        auto sort4 = [](std::array<Index,4> a)
-        {
+        auto sort4 = [](std::array<Index, 4> a) {
           std::sort(a.begin(), a.end());
           return a;
         };
 
-        auto canonicalTriFaceVerts = [&](size_t lf) -> std::array<Index,3>
-        {
+        auto canonicalTriFaceVerts = [&](size_t lf) -> std::array<Index, 3> {
           switch (lf)
           {
-            case 1: return { v[0], v[1], v[4] };
-            case 2: return { v[1], v[2], v[4] };
-            case 3: return { v[2], v[3], v[4] };
-            case 4: return { v[3], v[0], v[4] };
+            case 1:
+              return {v[0], v[1], v[4]};
+            case 2:
+              return {v[1], v[2], v[4]};
+            case 3:
+              return {v[2], v[3], v[4]};
+            case 4:
+              return {v[3], v[0], v[4]};
             default:
               assert(false && "Invalid local triangular face index for pyramid.");
-              return { 0, 0, 0 };
+              return {0, 0, 0};
           }
         };
 
-        auto canonicalQuadFaceVerts = [&]() -> std::array<Index,4>
-        {
-          return { v[0], v[1], v[2], v[3] };
+        auto canonicalQuadFaceVerts = [&]() -> std::array<Index, 4> {
+          return {v[0], v[1], v[2], v[3]};
         };
 
-        static constexpr int perms3[6][3] =
-        {
-          {0,1,2}, {1,2,0}, {2,0,1},
-          {0,2,1}, {2,1,0}, {1,0,2}
-        };
+        static constexpr int perms3[6][3] = {
+          {0, 1, 2}, {1, 2, 0}, {2, 0, 1}, {0, 2, 1}, {2, 1, 0}, {1, 0, 2}};
 
-        static constexpr int perms4[24][4] =
-        {
-          {0,1,2,3}, {0,1,3,2}, {0,2,1,3}, {0,2,3,1},
-          {0,3,1,2}, {0,3,2,1}, {1,0,2,3}, {1,0,3,2},
-          {1,2,0,3}, {1,2,3,0}, {1,3,0,2}, {1,3,2,0},
-          {2,0,1,3}, {2,0,3,1}, {2,1,0,3}, {2,1,3,0},
-          {2,3,0,1}, {2,3,1,0}, {3,0,1,2}, {3,0,2,1},
-          {3,1,0,2}, {3,1,2,0}, {3,2,0,1}, {3,2,1,0}
-        };
+        static constexpr int perms4[24][4] = {{0, 1, 2, 3}, {0, 1, 3, 2}, {0, 2, 1, 3},
+          {0, 2, 3, 1}, {0, 3, 1, 2}, {0, 3, 2, 1}, {1, 0, 2, 3}, {1, 0, 3, 2},
+          {1, 2, 0, 3}, {1, 2, 3, 0}, {1, 3, 0, 2}, {1, 3, 2, 0}, {2, 0, 1, 3},
+          {2, 0, 3, 1}, {2, 1, 0, 3}, {2, 1, 3, 0}, {2, 3, 0, 1}, {2, 3, 1, 0},
+          {3, 0, 1, 2}, {3, 0, 2, 1}, {3, 1, 0, 2}, {3, 1, 2, 0}, {3, 2, 0, 1},
+          {3, 2, 1, 0}};
 
-        auto getTriFaceEntityAndPerm =
-          [&](size_t lf, std::array<int,3>& canonToTri) -> Index
-        {
+        auto getTriFaceEntityAndPerm = [&](size_t lf,
+                                         std::array<int, 3>& canonToTri) -> Index {
           const auto wanted = canonicalTriFaceVerts(lf);
 
           for (Index f : inc)
@@ -1479,11 +1465,7 @@ namespace Rodin::Variational
             const auto& fVertsIA = conn.getPolytope(d - 1, f);
             assert(fVertsIA.size() == 3);
 
-            std::array<Index,3> tv = {
-              fVertsIA(0),
-              fVertsIA(1),
-              fVertsIA(2)
-            };
+            std::array<Index, 3> tv = {fVertsIA(0), fVertsIA(1), fVertsIA(2)};
 
             for (int pi = 0; pi < 6; ++pi)
             {
@@ -1491,9 +1473,7 @@ namespace Rodin::Variational
               const int b = perms3[pi][1];
               const int c = perms3[pi][2];
 
-              if (tv[a] == wanted[0] &&
-                  tv[b] == wanted[1] &&
-                  tv[c] == wanted[2])
+              if (tv[a] == wanted[0] && tv[b] == wanted[1] && tv[c] == wanted[2])
               {
                 canonToTri[0] = a;
                 canonToTri[1] = b;
@@ -1503,19 +1483,17 @@ namespace Rodin::Variational
             }
           }
 
-          assert(false && "Could not match pyramid triangular face to incident triangle entity.");
+          assert(false &&
+            "Could not match pyramid triangular face to incident triangle entity.");
           return -1;
         };
 
-        auto buildCanonicalTriFace =
-          [&](Index fIdx,
-              const std::array<int,3>& canonToTri,
-              IndexArray& faceCanon)
-        {
+        auto buildCanonicalTriFace = [&](Index fIdx, const std::array<int, 3>& canonToTri,
+                                       IndexArray& faceCanon) {
           const auto& faceLocal = m_closure[d - 1][fIdx];
           faceCanon.resize(TriCount);
 
-          std::array<int,3> triToCanon{};
+          std::array<int, 3> triToCanon{};
           for (int p = 0; p < 3; ++p)
             triToCanon[canonToTri[p]] = p;
 
@@ -1527,7 +1505,7 @@ namespace Rodin::Variational
               const size_t a = K - i2 - j2;
               const size_t b = i2;
               const size_t c = j2;
-              const size_t abc[3] = { a, b, c };
+              const size_t abc[3] = {a, b, c};
 
               const size_t bT = abc[triToCanon[1]];
               const size_t cT = abc[triToCanon[2]];
@@ -1540,9 +1518,7 @@ namespace Rodin::Variational
           }
         };
 
-        auto getQuadFaceEntityAndPerm =
-          [&](std::array<int,4>& canonToQuad) -> Index
-        {
+        auto getQuadFaceEntityAndPerm = [&](std::array<int, 4>& canonToQuad) -> Index {
           const auto wanted = canonicalQuadFaceVerts();
           const auto wantedS = sort4(wanted);
 
@@ -1554,12 +1530,8 @@ namespace Rodin::Variational
             const auto& fVertsIA = conn.getPolytope(d - 1, f);
             assert(fVertsIA.size() == 4);
 
-            std::array<Index,4> qv = {
-              fVertsIA(0),
-              fVertsIA(1),
-              fVertsIA(2),
-              fVertsIA(3)
-            };
+            std::array<Index, 4> qv = {
+              fVertsIA(0), fVertsIA(1), fVertsIA(2), fVertsIA(3)};
 
             if (sort4(qv) != wantedS)
               continue;
@@ -1571,10 +1543,8 @@ namespace Rodin::Variational
               const int c = perms4[pi][2];
               const int d4 = perms4[pi][3];
 
-              if (qv[a] == wanted[0] &&
-                  qv[b] == wanted[1] &&
-                  qv[c] == wanted[2] &&
-                  qv[d4] == wanted[3])
+              if (qv[a] == wanted[0] && qv[b] == wanted[1] && qv[c] == wanted[2] &&
+                qv[d4] == wanted[3])
               {
                 canonToQuad[0] = a;
                 canonToQuad[1] = b;
@@ -1585,53 +1555,64 @@ namespace Rodin::Variational
             }
           }
 
-          assert(false && "Could not match pyramid quadrilateral base to incident quadrilateral entity.");
+          assert(false &&
+            "Could not match pyramid quadrilateral base to incident quadrilateral "
+            "entity.");
           return -1;
         };
 
-        auto vertCornerCoords = [](int vidx) -> std::pair<size_t,size_t>
-        {
+        auto vertCornerCoords = [](int vidx) -> std::pair<size_t, size_t> {
           switch (vidx)
           {
-            case 0: return { 0, 0 };
-            case 1: return { static_cast<size_t>(K), 0 };
-            case 2: return { static_cast<size_t>(K), static_cast<size_t>(K) };
-            case 3: return { 0, static_cast<size_t>(K) };
+            case 0:
+              return {0, 0};
+            case 1:
+              return {static_cast<size_t>(K), 0};
+            case 2:
+              return {static_cast<size_t>(K), static_cast<size_t>(K)};
+            case 3:
+              return {0, static_cast<size_t>(K)};
             default:
               assert(false && "Invalid quad vertex index for corner coords.");
-              return { 0, 0 };
+              return {0, 0};
           }
         };
 
-        auto applyTransform = [](int tid, size_t i, size_t j) -> std::pair<size_t,size_t>
-        {
+        auto applyTransform = [](int tid, size_t i,
+                                size_t j) -> std::pair<size_t, size_t> {
           switch (tid)
           {
-            case 0: return { i, j };
-            case 1: return { j, static_cast<size_t>(K) - i };
-            case 2: return { static_cast<size_t>(K) - i, static_cast<size_t>(K) - j };
-            case 3: return { static_cast<size_t>(K) - j, i };
-            case 4: return { i, static_cast<size_t>(K) - j };
-            case 5: return { static_cast<size_t>(K) - i, j };
-            case 6: return { j, i };
-            case 7: return { static_cast<size_t>(K) - j, static_cast<size_t>(K) - i };
+            case 0:
+              return {i, j};
+            case 1:
+              return {j, static_cast<size_t>(K) - i};
+            case 2:
+              return {static_cast<size_t>(K) - i, static_cast<size_t>(K) - j};
+            case 3:
+              return {static_cast<size_t>(K) - j, i};
+            case 4:
+              return {i, static_cast<size_t>(K) - j};
+            case 5:
+              return {static_cast<size_t>(K) - i, j};
+            case 6:
+              return {j, i};
+            case 7:
+              return {static_cast<size_t>(K) - j, static_cast<size_t>(K) - i};
             default:
               assert(false && "Invalid transform id.");
-              return { i, j };
+              return {i, j};
           }
         };
 
-        auto buildCanonicalQuadFace =
-          [&](Index fIdx,
-              const std::array<int,4>& canonToQuad,
-              IndexArray& faceCanon)
-        {
+        auto buildCanonicalQuadFace = [&](Index fIdx,
+                                        const std::array<int, 4>& canonToQuad,
+                                        IndexArray& faceCanon) {
           const IndexArray& faceLocal = m_closure[d - 1][fIdx];
           assert(faceLocal.size() == QuadCount);
 
           faceCanon.resize(QuadCount);
 
-          std::pair<size_t,size_t> oldCorners[4];
+          std::pair<size_t, size_t> oldCorners[4];
           for (int kCorner = 0; kCorner < 4; ++kCorner)
             oldCorners[kCorner] = vertCornerCoords(canonToQuad[kCorner]);
 
@@ -1643,10 +1624,8 @@ namespace Rodin::Variational
             auto p2 = applyTransform(tid, static_cast<size_t>(K), static_cast<size_t>(K));
             auto p3 = applyTransform(tid, 0, static_cast<size_t>(K));
 
-            if (p0 == oldCorners[0] &&
-                p1 == oldCorners[1] &&
-                p2 == oldCorners[2] &&
-                p3 == oldCorners[3])
+            if (p0 == oldCorners[0] && p1 == oldCorners[1] && p2 == oldCorners[2] &&
+              p3 == oldCorners[3])
             {
               chosenT = tid;
               break;
@@ -1668,18 +1647,16 @@ namespace Rodin::Variational
         };
 
         {
-          std::array<int,4> canonToQuad{};
+          std::array<int, 4> canonToQuad{};
           const Index f = getQuadFaceEntityAndPerm(canonToQuad);
           this->getClosure(d - 1, f);
 
           IndexArray faceCanon;
           buildCanonicalQuadFace(f, canonToQuad, faceCanon);
 
-          Utility::ForIndex<N1>([&](auto jj)
-          {
+          Utility::ForIndex<N1>([&](auto jj) {
             constexpr size_t j = jj.value;
-            Utility::ForIndex<N1>([&](auto ii)
-            {
+            Utility::ForIndex<N1>([&](auto ii) {
               constexpr size_t i = ii.value;
               constexpr size_t qIdx = j * N1 + i;
               constexpr size_t pIdx = PyramidIndex<K>::getIndex(i, j, 0);
@@ -1691,7 +1668,7 @@ namespace Rodin::Variational
 
         for (size_t lf = 1; lf <= 4; ++lf)
         {
-          std::array<int,3> canonToTri{};
+          std::array<int, 3> canonToTri{};
           const Index f = getTriFaceEntityAndPerm(lf, canonToTri);
           this->getClosure(d - 1, f);
 
@@ -2534,8 +2511,7 @@ namespace Rodin::Variational
           }
           case Geometry::Polytope::Type::Pyramid:
           {
-            m_closure[d][i].resize(
-              Cochain<Geometry::Polytope::Type::Pyramid>::Count);
+            m_closure[d][i].resize(Cochain<Geometry::Polytope::Type::Pyramid>::Count);
             break;
           }
           case Geometry::Polytope::Type::Wedge:

--- a/src/Rodin/Variational/H1/H1Element.h
+++ b/src/Rodin/Variational/H1/H1Element.h
@@ -482,8 +482,7 @@ namespace Rodin::Variational
             static const std::vector<Math::SpatialPoint> s_nodes = [] {
               constexpr size_t count = (K + 1) * (K + 2) * (2 * K + 3) / 6;
 
-              auto offset = [](size_t layer)
-              {
+              auto offset = [](size_t layer) {
                 size_t out = 0;
                 for (size_t k = 0; k < layer; ++k)
                 {
@@ -493,25 +492,26 @@ namespace Rodin::Variational
                 return out;
               };
 
-              auto idx = [&](size_t i, size_t j, size_t k)
-              {
+              auto idx = [&](size_t i, size_t j, size_t k) {
                 const size_t n = K - k + 1;
                 return offset(k) + j * n + i;
               };
 
-              auto triLattice = [](size_t alpha)
-              {
-                struct IJ { size_t i, j; };
+              auto triLattice = [](size_t alpha) {
+                struct IJ
+                {
+                    size_t i, j;
+                };
                 size_t pos = 0;
                 for (size_t j = 0; j <= K; ++j)
                 {
                   for (size_t i = 0; i <= K - j; ++i, ++pos)
                   {
                     if (pos == alpha)
-                      return IJ{ i, j };
+                      return IJ{i, j};
                   }
                 }
-                return IJ{ 0, 0 };
+                return IJ{0, 0};
               };
 
               std::vector<Math::SpatialPoint> nodes(count);
@@ -519,9 +519,8 @@ namespace Rodin::Variational
               const auto& xi = GLL01<K>::getNodes();
               const auto& tri = FeketeTriangle<K>::getNodes();
 
-              auto set = [&](size_t node, Real x, Real y, Real z)
-              {
-                nodes[node] = Math::SpatialPoint{{ x, y, z }};
+              auto set = [&](size_t node, Real x, Real y, Real z) {
+                nodes[node] = Math::SpatialPoint{{x, y, z}};
                 assigned[node] = 1;
               };
 
@@ -558,10 +557,8 @@ namespace Rodin::Variational
                     const size_t node = idx(i, j, k);
                     if (!assigned[node])
                     {
-                      set(node,
-                          q * static_cast<Real>(i) / static_cast<Real>(n),
-                          q * static_cast<Real>(j) / static_cast<Real>(n),
-                          z);
+                      set(node, q * static_cast<Real>(i) / static_cast<Real>(n),
+                        q * static_cast<Real>(j) / static_cast<Real>(n), z);
                     }
                   }
                 }

--- a/src/Rodin/Variational/H1/H1Element.hpp
+++ b/src/Rodin/Variational/H1/H1Element.hpp
@@ -44,85 +44,85 @@ namespace Rodin::Variational
   template <size_t K>
   struct PyramidIndex
   {
-    static constexpr size_t Count = (K + 1) * (K + 2) * (2 * K + 3) / 6;
+      static constexpr size_t Count = (K + 1) * (K + 2) * (2 * K + 3) / 6;
 
-    struct IJ
-    {
-      size_t i;
-      size_t j;
-    };
+      struct IJ
+      {
+          size_t i;
+          size_t j;
+      };
 
-    static constexpr size_t getLayerOffset(size_t layer)
-    {
-      size_t out = 0;
-      for (size_t k = 0; k < layer; ++k)
+      static constexpr size_t getLayerOffset(size_t layer)
+      {
+        size_t out = 0;
+        for (size_t k = 0; k < layer; ++k)
+        {
+          const size_t n = K - k + 1;
+          out += n * n;
+        }
+        return out;
+      }
+
+      static constexpr size_t getIndex(size_t i, size_t j, size_t k)
       {
         const size_t n = K - k + 1;
-        out += n * n;
+        return getLayerOffset(k) + j * n + i;
       }
-      return out;
-    }
 
-    static constexpr size_t getIndex(size_t i, size_t j, size_t k)
-    {
-      const size_t n = K - k + 1;
-      return getLayerOffset(k) + j * n + i;
-    }
-
-    static constexpr void decode(size_t idx, size_t& i, size_t& j, size_t& k)
-    {
-      size_t rem = idx;
-      for (k = 0; k <= K; ++k)
+      static constexpr void decode(size_t idx, size_t& i, size_t& j, size_t& k)
       {
-        const size_t n = K - k + 1;
-        const size_t layer = n * n;
-        if (rem < layer)
+        size_t rem = idx;
+        for (k = 0; k <= K; ++k)
         {
-          j = rem / n;
-          i = rem % n;
-          return;
+          const size_t n = K - k + 1;
+          const size_t layer = n * n;
+          if (rem < layer)
+          {
+            j = rem / n;
+            i = rem % n;
+            return;
+          }
+          rem -= layer;
         }
-        rem -= layer;
+
+        i = j = k = 0;
       }
 
-      i = j = k = 0;
-    }
-
-    static constexpr IJ getTriangleLattice(size_t alpha)
-    {
-      size_t pos = 0;
-      for (size_t j = 0; j <= K; ++j)
+      static constexpr IJ getTriangleLattice(size_t alpha)
       {
-        for (size_t i = 0; i <= K - j; ++i, ++pos)
+        size_t pos = 0;
+        for (size_t j = 0; j <= K; ++j)
         {
-          if (pos == alpha)
-            return IJ{ i, j };
+          for (size_t i = 0; i <= K - j; ++i, ++pos)
+          {
+            if (pos == alpha)
+              return IJ{i, j};
+          }
+        }
+        return IJ{0, 0};
+      }
+
+      static constexpr size_t getSideIndex(size_t local, size_t alpha)
+      {
+        const auto ij = getTriangleLattice(alpha);
+        const size_t i = ij.i;
+        const size_t k = ij.j;
+        const size_t n = K - k;
+
+        switch (local)
+        {
+          case 1:
+            return getIndex(i, 0, k);
+          case 2:
+            return getIndex(n, i, k);
+          case 3:
+            return getIndex(n - i, n, k);
+          case 4:
+            return getIndex(0, n - i, k);
+          default:
+            return 0;
         }
       }
-      return IJ{ 0, 0 };
-    }
-
-    static constexpr size_t getSideIndex(size_t local, size_t alpha)
-    {
-      const auto ij = getTriangleLattice(alpha);
-      const size_t i = ij.i;
-      const size_t k = ij.j;
-      const size_t n = K - k;
-
-      switch (local)
-      {
-        case 1:
-          return getIndex(i, 0, k);
-        case 2:
-          return getIndex(n, i, k);
-        case 3:
-          return getIndex(n - i, n, k);
-        case 4:
-          return getIndex(0, n - i, k);
-        default:
-          return 0;
-      }
-    }
   };
 
   template <size_t K>
@@ -193,9 +193,8 @@ namespace Rodin::Variational
         const Real a = r.x() / q;
         const Real b = r.y() / q;
 
-        return BernsteinPyramid<K>::getBasis(n, i, a)
-             * BernsteinPyramid<K>::getBasis(n, j, b)
-             * BernsteinPyramid<K>::getBasis(K, k, z);
+        return BernsteinPyramid<K>::getBasis(n, i, a) *
+          BernsteinPyramid<K>::getBasis(n, j, b) * BernsteinPyramid<K>::getBasis(K, k, z);
       }
 
       static Real getDerivative(size_t mode, size_t deriv, const Math::SpatialPoint& r)
@@ -212,9 +211,9 @@ namespace Rodin::Variational
         const Real a = r.x() / q;
         const Real b = r.y() / q;
 
-        const Real Ba  = BernsteinPyramid<K>::getBasis(n, i, a);
-        const Real Bb  = BernsteinPyramid<K>::getBasis(n, j, b);
-        const Real Bz  = BernsteinPyramid<K>::getBasis(K, k, z);
+        const Real Ba = BernsteinPyramid<K>::getBasis(n, i, a);
+        const Real Bb = BernsteinPyramid<K>::getBasis(n, j, b);
+        const Real Bz = BernsteinPyramid<K>::getBasis(K, k, z);
         const Real dBa = BernsteinPyramid<K>::getDerivative(n, i, a);
         const Real dBb = BernsteinPyramid<K>::getDerivative(n, j, b);
         const Real dBz = BernsteinPyramid<K>::getDerivative(K, k, z);
@@ -224,8 +223,7 @@ namespace Rodin::Variational
         if (deriv == 1)
           return Ba * dBb * Bz / q;
         if (deriv == 2)
-          return (dBa * (a / q) * Bb + Ba * dBb * (b / q)) * Bz
-               + Ba * Bb * dBz;
+          return (dBa * (a / q) * Bb + Ba * dBb * (b / q)) * Bz + Ba * Bb * dBz;
         return 0;
       }
   };
@@ -261,7 +259,8 @@ namespace Rodin::Variational
           Eigen::BDCSVD<Math::Matrix<Real>, Eigen::ComputeThinU | Eigen::ComputeThinV>
             svd(V);
 #else
-          Eigen::BDCSVD<Math::Matrix<Real>> svd(V, Eigen::ComputeThinU | Eigen::ComputeThinV);
+          Eigen::BDCSVD<Math::Matrix<Real>> svd(
+            V, Eigen::ComputeThinU | Eigen::ComputeThinV);
 #endif
           const Math::Matrix<Real> I = Math::Matrix<Real>::Identity(V.rows(), V.cols());
           return svd.solve(I).eval();
@@ -820,8 +819,8 @@ namespace Rodin::Variational
           Scalar result = Scalar(0);
           for (size_t mode = 0; mode < count; ++mode)
           {
-            result += inverse(mode, m_local)
-                    * PyramidModal<K>::getDerivative(mode, m_i, r);
+            result +=
+              inverse(mode, m_local) * PyramidModal<K>::getDerivative(mode, m_i, r);
           }
 
           return result;
@@ -937,7 +936,7 @@ namespace Rodin::Variational
           const Real dlz = LagrangeBasisSegment<K>::getDerivative(k, z);
 
           Real val = 0;
-          if (m_i == 0)      // \partial/\partialx
+          if (m_i == 0) // \partial/\partialx
             val = dlx * ly * lz;
           else if (m_i == 1) // \partial/\partialy
             val = lx * dly * lz;

--- a/src/Rodin/Variational/H1/Jacobian.h
+++ b/src/Rodin/Variational/H1/Jacobian.h
@@ -419,7 +419,7 @@ namespace Rodin::Variational
         key.geom  = geom;
         key.dim   = d;
         key.cell  = cell;
-        key.qf    = qf;
+        key.qf = qf;
         key.qp    = qp;
         key.valid = true;
 
@@ -447,10 +447,8 @@ namespace Rodin::Variational
         for (size_t alpha = 0; alpha < nscalar; ++alpha)
         {
           for (size_t j = 0; j < d; ++j)
-            ref(j) =
-              qf
-                ? tab->getGradient(qp, alpha)[j]
-                : feS.getBasis(alpha).template getDerivative<1>(j)(rc);
+            ref(j) = qf ? tab->getGradient(qp, alpha)[j]
+                        : feS.getBasis(alpha).template getDerivative<1>(j)(rc);
 
           m_cache.gradPhys[alpha] = JinvT * ref;
         }

--- a/src/Rodin/Variational/H1/ShapeFunction.h
+++ b/src/Rodin/Variational/H1/ShapeFunction.h
@@ -124,7 +124,7 @@ namespace Rodin::Variational
 
         typename Cache::Key key;
         key.geom  = geom;
-        key.qf    = qf;
+        key.qf = qf;
         key.qp    = qp;
         key.valid = true;
 
@@ -297,7 +297,7 @@ namespace Rodin::Variational
 
         typename Cache::Key key;
         key.geom  = geom;
-        key.qf    = qf;
+        key.qf = qf;
         key.qp    = qp;
         key.vdim  = vdim;
         key.valid = true;

--- a/src/Rodin/Variational/IntegrationPoint.h
+++ b/src/Rodin/Variational/IntegrationPoint.h
@@ -36,7 +36,9 @@ namespace Rodin::Variational
   {
     public:
       IntegrationPoint(const Geometry::Point& p)
-        : m_p(p), m_qf(nullptr), m_qp(0)
+        : m_p(p),
+          m_qf(nullptr),
+          m_qp(0)
       {}
 
       /**
@@ -48,10 +50,10 @@ namespace Rodin::Variational
        * @param[in] qp Quadrature sample index in @p qf
        */
       IntegrationPoint(
-          const Geometry::Point& p,
-          const QF::QuadratureFormulaBase* qf,
-          size_t qp)
-        : m_p(p), m_qf(qf), m_qp(qp)
+        const Geometry::Point& p, const QF::QuadratureFormulaBase* qf, size_t qp)
+        : m_p(p),
+          m_qf(qf),
+          m_qp(qp)
       {}
 
       /**

--- a/src/Rodin/Variational/LinearFormIntegrator.h
+++ b/src/Rodin/Variational/LinearFormIntegrator.h
@@ -81,9 +81,7 @@ namespace Rodin::Variational
        * the test function @f$ v @f$.
        */
       template <class TestFunctionType,
-                std::enable_if_t<
-                  IsTestFunction<std::decay_t<TestFunctionType>>::Value,
-                  int> = 0>
+        std::enable_if_t<IsTestFunction<std::decay_t<TestFunctionType>>::Value, int> = 0>
       LinearFormIntegratorBase(const TestFunctionType& v)
         : m_v(v.copy())
       {}

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -136,8 +136,7 @@ namespace Rodin::Variational
   namespace Internal
   {
     template <class Product>
-    constexpr
-    auto materializeProduct(const Product& product)
+    constexpr auto materializeProduct(const Product& product)
     {
       /// @brief Range (evaluation value) type.
       using RangeType =

--- a/src/Rodin/Variational/P0g/P0gElement.h
+++ b/src/Rodin/Variational/P0g/P0gElement.h
@@ -173,7 +173,7 @@ namespace Rodin::Variational
         }
         case G::Pyramid:
         {
-          static const Math::SpatialVector<Real> s_node{ { 0.375, 0.375, 0.25 } };
+          static const Math::SpatialVector<Real> s_node{{0.375, 0.375, 0.25}};
           return s_node;
         }
         case G::Wedge:

--- a/src/Rodin/Variational/P1/Div.h
+++ b/src/Rodin/Variational/P1/Div.h
@@ -435,9 +435,7 @@ namespace Rodin::Variational
           const size_t nv = feScalar.getCount();
 
           const auto& rc =
-            qf
-              ? qf->getPoint(ip.getIndex())
-              : pt.getReferenceCoordinates();
+            qf ? qf->getPoint(ip.getIndex()) : pt.getReferenceCoordinates();
 
           const auto& Jinv = pt.getJacobianInverse();
 

--- a/src/Rodin/Variational/P1/Grad.h
+++ b/src/Rodin/Variational/P1/Grad.h
@@ -396,9 +396,7 @@ namespace Rodin::Variational
           const size_t nv = fe.getCount();
 
           const auto& rc =
-            qf
-              ? qf->getPoint(ip.getIndex())
-              : pt.getReferenceCoordinates();
+            qf ? qf->getPoint(ip.getIndex()) : pt.getReferenceCoordinates();
 
           // J^{-T} at this integration point (constant for affine maps)
           const auto JinvT = pt.getJacobianInverse().transpose();

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -480,9 +480,7 @@ namespace Rodin::Variational
 
           // Reference coordinates at this sample.
           const auto& rc =
-            qf
-              ? qf->getPoint(ip.getIndex())
-              : pt.getReferenceCoordinates();
+            qf ? qf->getPoint(ip.getIndex()) : pt.getReferenceCoordinates();
 
           // J^{-1} at this integration point
           const auto Jinv = pt.getJacobianInverse();

--- a/src/Rodin/Variational/P1/P1Element.hpp
+++ b/src/Rodin/Variational/P1/P1Element.hpp
@@ -190,11 +190,12 @@ namespace Rodin::Variational
           {
             return z;
           }
-          default: [[unlikely]]
-          {
-            assert(false);
-            return Math::nan<Scalar>();
-          }
+          default:
+            [[unlikely]]
+            {
+              assert(false);
+              return Math::nan<Scalar>();
+            }
         }
       }
       case Geometry::Polytope::Type::Wedge:
@@ -668,11 +669,12 @@ namespace Rodin::Variational
                 return Math::nan<Scalar>();
               }
             }
-            default: [[unlikely]]
-            {
-              assert(false);
-              return Math::nan<Scalar>();
-            }
+            default:
+              [[unlikely]]
+              {
+                assert(false);
+                return Math::nan<Scalar>();
+              }
           }
         }
         case Geometry::Polytope::Type::Wedge:

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -3455,7 +3455,8 @@ namespace Rodin::Variational
         return *m_integrand;
       }
 
-      QuadratureRule& setPolytope(const Geometry::Polytope& trp, const Geometry::Polytope& tep) override
+      QuadratureRule& setPolytope(
+        const Geometry::Polytope& trp, const Geometry::Polytope& tep) override
       {
         m_trp = trp;
         m_tep = tep;

--- a/src/Rodin/Variational/P1/ShapeFunction.h
+++ b/src/Rodin/Variational/P1/ShapeFunction.h
@@ -208,7 +208,7 @@ namespace Rodin::Variational
 
         // ---- value cache: update once per (qf, qp)
         typename Cache::ValueKey vkey;
-        vkey.qf    = qf;
+        vkey.qf = qf;
         vkey.qp    = qp;
         vkey.valid = true;
 
@@ -217,8 +217,7 @@ namespace Rodin::Variational
         {
           m_cache.vkey = vkey;
 
-          const auto& rq =
-            qf ? qf->getPoint(qp) : p.getReferenceCoordinates();
+          const auto& rq = qf ? qf->getPoint(qp) : p.getReferenceCoordinates();
 
           // Cheap scalar P1 element (no allocations)
           const P1Element<ScalarType> feScalar(geom);

--- a/tests/installation/test_poisson.cpp
+++ b/tests/installation/test_poisson.cpp
@@ -37,7 +37,7 @@ int main()
     
     // Right-hand side function f = 1
     RealFunction f = 1.0;
-    
+
     // Assemble the Poisson problem:
     // -Δu = f in \Omega
     // u = 0 on \partial\Omega

--- a/tests/manufactured/Rodin/Assembly/AssemblyTest.cpp
+++ b/tests/manufactured/Rodin/Assembly/AssemblyTest.cpp
@@ -254,7 +254,7 @@ namespace Rodin::Tests::Manufactured::Assembly
     protected:
       void SetUp() override
       {
-        m_mesh = Mesh<Context::Local>::UniformGrid(GetParam(), { 4, 4, 4 });
+        m_mesh = Mesh<Context::Local>::UniformGrid(GetParam(), {4, 4, 4});
         m_mesh.scale(1.0 / 3.0);
         m_mesh.getConnectivity().compute(2, 3);
         m_mesh.getConnectivity().compute(3, 0);
@@ -576,13 +576,7 @@ namespace Rodin::Tests::Manufactured::Assembly
   }
 
   /// @brief Instantiates Assembly 3 D Test over the All Geometries 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries3D,
-    Assembly_3D_Test,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries3D, Assembly_3D_Test,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/H1/LinearElasticity3D.cpp
+++ b/tests/manufactured/Rodin/H1/LinearElasticity3D.cpp
@@ -34,7 +34,7 @@ namespace Rodin::Tests::Manufactured::H1LinearElasticity3D
   protected:
     void SetUp() override
     {
-      m_mesh = Mesh().UniformGrid(GetParam(), { M, M, M });
+      m_mesh = Mesh().UniformGrid(GetParam(), {M, M, M});
       m_mesh.scale(1.0 / (M - 1));
       m_mesh.getConnectivity().compute(2, 3);
       m_mesh.getConnectivity().compute(3, 2);
@@ -170,7 +170,7 @@ namespace Rodin::Tests::Manufactured::H1LinearElasticity3D
   protected:
     void SetUp() override
     {
-      m_mesh = Mesh().UniformGrid(GetParam(), { M, M, M });
+      m_mesh = Mesh().UniformGrid(GetParam(), {M, M, M});
       m_mesh.scale(1.0 / (M - 1));
       m_mesh.getConnectivity().compute(2, 3);
       m_mesh.getConnectivity().compute(3, 2);
@@ -271,35 +271,17 @@ namespace Rodin::Tests::Manufactured::H1LinearElasticity3D
   }
 
   /// @brief Instantiates Manufactured Linear Elasticity 3 D H1 Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_LinearElasticity3D_H1_Test_8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_LinearElasticity3D_H1_Test_8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Constant Linear Elasticity 3 D H1 Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Constant_LinearElasticity3D_H1_Test_8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Constant_LinearElasticity3D_H1_Test_8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Constant Linear Elasticity 3 D H1 Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Constant_LinearElasticity3D_H1_Test_16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Constant_LinearElasticity3D_H1_Test_16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/H1/NavierStokes3D.cpp
+++ b/tests/manufactured/Rodin/H1/NavierStokes3D.cpp
@@ -267,14 +267,7 @@ namespace Rodin::Tests::Manufactured::NavierStokes3D
   }
 
   /// @brief Instantiates Manufactured Navier Stokes 3 D Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_NavierStokes3D_Test_8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_NavierStokes3D_Test_8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/H1/Poisson.cpp
+++ b/tests/manufactured/Rodin/H1/Poisson.cpp
@@ -37,12 +37,9 @@ namespace Rodin::Tests::Manufactured::H1Poisson
     constexpr Attribute BottomAttribute = 3;
     constexpr Attribute TopAttribute = 4;
 
-    void labelBoundaryAttributes(
-      Geometry::Mesh<Context::Local>& mesh,
-      Attribute left = LeftAttribute,
-      Attribute right = RightAttribute,
-      Attribute bottom = BottomAttribute,
-      Attribute top = TopAttribute)
+    void labelBoundaryAttributes(Geometry::Mesh<Context::Local>& mesh,
+      Attribute left = LeftAttribute, Attribute right = RightAttribute,
+      Attribute bottom = BottomAttribute, Attribute top = TopAttribute)
     {
       for (auto it = mesh.getBoundary(); !it.end(); ++it)
       {
@@ -200,7 +197,8 @@ namespace Rodin::Tests::Manufactured::H1Poisson
   }
 
   /// @brief Verifies poisson nonhomogeneous dirichlet H1 2 labeled boundary for manufactured poisson H1 test 16 x 16 by checking tolerance-based numerical results, solver behavior, manufactured-solution convergence.
-  TEST_P(Manufactured_Poisson_H1_Test_16x16, Poisson_NonhomogeneousDirichlet_H1_2_LabeledBoundary)
+  TEST_P(Manufactured_Poisson_H1_Test_16x16,
+    Poisson_NonhomogeneousDirichlet_H1_2_LabeledBoundary)
   {
     auto pi = Rodin::Math::Constants::pi();
 
@@ -212,19 +210,15 @@ namespace Rodin::Tests::Manufactured::H1Poisson
     H1 vh(order, mesh);
 
     TrialFunction u(vh);
-    TestFunction  v(vh);
+    TestFunction v(vh);
 
     const auto solution = cos(pi * F::x) * cos(pi * F::y);
     const auto f = 2 * pi * pi * solution;
 
     Problem poisson(u, v);
-    poisson = Integral(Grad(u), Grad(v))
-            - Integral(f, v)
-            + DirichletBC(u, solution).on(
-                LeftAttribute,
-                RightAttribute,
-                BottomAttribute,
-                TopAttribute);
+    poisson = Integral(Grad(u), Grad(v)) - Integral(f, v) +
+      DirichletBC(u, solution)
+        .on(LeftAttribute, RightAttribute, BottomAttribute, TopAttribute);
     CG(poisson).solve();
 
     GridFunction diff(vh);

--- a/tests/manufactured/Rodin/H1/Poisson3D.cpp
+++ b/tests/manufactured/Rodin/H1/Poisson3D.cpp
@@ -230,26 +230,12 @@ namespace Rodin::Tests::Manufactured::H1Poisson3D
   }
 
   /// @brief Instantiates Manufactured Poisson 3 D H1 Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Poisson3D_H1_Test_8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Poisson3D_H1_Test_8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Manufactured Poisson 3 D H1 Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Poisson3D_H1_Test_16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Poisson3D_H1_Test_16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/H1/Stokes3D.cpp
+++ b/tests/manufactured/Rodin/H1/Stokes3D.cpp
@@ -154,14 +154,7 @@ namespace Rodin::Tests::Manufactured::Stokes3D
   }
 
   /// @brief Instantiates Manufactured Stokes 3 D Test 12 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Stokes3D_Test_12,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-      )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Stokes3D_Test_12,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/H1/Stokes3D_Slow.cpp
+++ b/tests/manufactured/Rodin/H1/Stokes3D_Slow.cpp
@@ -114,14 +114,7 @@ namespace Rodin::Tests::Manufactured::Stokes3D
     EXPECT_NEAR(error_p, 0, 2e-3);
   }
 
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Stokes3D_Test_12,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-      )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Stokes3D_Test_12,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/MPI/H1/LinearElasticityTest.cpp
+++ b/tests/manufactured/Rodin/MPI/H1/LinearElasticityTest.cpp
@@ -470,7 +470,9 @@ namespace
         case Polytope::Type::Quadrilateral: g = "Quadrilateral"; break;
         case Polytope::Type::Tetrahedron:   g = "Tetrahedron";   break;
         case Polytope::Type::Hexahedron:    g = "Hexahedron";    break;
-        case Polytope::Type::Pyramid:       g = "Pyramid";       break;
+        case Polytope::Type::Pyramid:
+          g = "Pyramid";
+          break;
         case Polytope::Type::Wedge:         g = "Wedge";         break;
         default:                            g = "Unknown";        break;
       }
@@ -561,19 +563,12 @@ namespace Rodin::Tests::Manufactured::MPI::H1LinearElasticity
   }
 
   /// @brief Instantiates H1 Linear Elasticity 3 D over the All Geometries And Degrees parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometriesAndDegrees,
-    H1LinearElasticity3D,
+  INSTANTIATE_TEST_SUITE_P(AllGeometriesAndDegrees, H1LinearElasticity3D,
     testing::Combine(
-      testing::Values(
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Wedge),
-      testing::Values<size_t>(2, 3, 4)
-    ),
-    ParamName{}
-  );
+      testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+        Polytope::Type::Pyramid, Polytope::Type::Wedge),
+      testing::Values<size_t>(2, 3, 4)),
+    ParamName{});
 } // namespace Rodin::Tests::Manufactured::MPI::H1LinearElasticity
 
 // ---------------------------------------------------------------------------

--- a/tests/manufactured/Rodin/MPI/H1/PoissonTest.cpp
+++ b/tests/manufactured/Rodin/MPI/H1/PoissonTest.cpp
@@ -439,7 +439,9 @@ namespace
         case Polytope::Type::Quadrilateral: g = "Quadrilateral"; break;
         case Polytope::Type::Tetrahedron:   g = "Tetrahedron";   break;
         case Polytope::Type::Hexahedron:    g = "Hexahedron";    break;
-        case Polytope::Type::Pyramid:       g = "Pyramid";       break;
+        case Polytope::Type::Pyramid:
+          g = "Pyramid";
+          break;
         case Polytope::Type::Wedge:         g = "Wedge";         break;
         default:                            g = "Unknown";        break;
       }
@@ -520,19 +522,12 @@ namespace Rodin::Tests::Manufactured::MPI::H1Poisson
   }
 
   /// @brief Instantiates H1 Poisson 3 D Workflow 1 over the All Geometries And Degrees parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometriesAndDegrees,
-    H1Poisson3D_Workflow1,
+  INSTANTIATE_TEST_SUITE_P(AllGeometriesAndDegrees, H1Poisson3D_Workflow1,
     testing::Combine(
-      testing::Values(
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Wedge),
-      testing::Values<size_t>(1, 2, 3, 4, 6)
-    ),
-    ParamName{}
-  );
+      testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+        Polytope::Type::Pyramid, Polytope::Type::Wedge),
+      testing::Values<size_t>(1, 2, 3, 4, 6)),
+    ParamName{});
 
   // =========================================================================
   // Workflow 2 — Construct → Shard → Distribute → Reconcile → Assemble → Solve
@@ -598,19 +593,12 @@ namespace Rodin::Tests::Manufactured::MPI::H1Poisson
   }
 
   /// @brief Instantiates H1 Poisson 3 D Workflow 2 over the All Geometries And Degrees parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometriesAndDegrees,
-    H1Poisson3D_Workflow2,
+  INSTANTIATE_TEST_SUITE_P(AllGeometriesAndDegrees, H1Poisson3D_Workflow2,
     testing::Combine(
-      testing::Values(
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Wedge),
-      testing::Values<size_t>(1, 2, 3, 4, 6)
-    ),
-    ParamName{}
-  );
+      testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+        Polytope::Type::Pyramid, Polytope::Type::Wedge),
+      testing::Values<size_t>(1, 2, 3, 4, 6)),
+    ParamName{});
 
   // =========================================================================
   // Workflow 3 — UniformGrid → Reconcile → Assemble → Solve
@@ -678,19 +666,12 @@ namespace Rodin::Tests::Manufactured::MPI::H1Poisson
   }
 
   /// @brief Instantiates H1 Poisson 3 D Workflow 3 over the All Geometries And Degrees parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometriesAndDegrees,
-    H1Poisson3D_Workflow3,
+  INSTANTIATE_TEST_SUITE_P(AllGeometriesAndDegrees, H1Poisson3D_Workflow3,
     testing::Combine(
-      testing::Values(
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Wedge),
-      testing::Values<size_t>(1, 2, 3, 4, 6)
-    ),
-    ParamName{}
-  );
+      testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+        Polytope::Type::Pyramid, Polytope::Type::Wedge),
+      testing::Values<size_t>(1, 2, 3, 4, 6)),
+    ParamName{});
 } // namespace Rodin::Tests::Manufactured::MPI::H1Poisson
 
 // ---------------------------------------------------------------------------

--- a/tests/manufactured/Rodin/Models/Advection/Lagrangian3D.cpp
+++ b/tests/manufactured/Rodin/Models/Advection/Lagrangian3D.cpp
@@ -209,13 +209,7 @@ namespace Rodin::Tests::Manufactured::AdvectionLagrangian3D
   }
 
   /// @brief Instantiates Manufactured Advection 3 D Test 10 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    ManufacturedAdvection3DTest_10,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, ManufacturedAdvection3DTest_10,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/Models/Eikonal/Eikonal2D3D.cpp
+++ b/tests/manufactured/Rodin/Models/Eikonal/Eikonal2D3D.cpp
@@ -142,13 +142,7 @@ namespace Rodin::Tests::Manufactured::Eikonal
   );
 
   /// @brief Instantiates Eikonal 3 D Test over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Eikonal3DTest,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Eikonal3DTest,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/Models/Eikonal/FMM.cpp
+++ b/tests/manufactured/Rodin/Models/Eikonal/FMM.cpp
@@ -329,8 +329,8 @@ namespace Rodin::Tests::Manufactured::Eikonal
 
     // Create 3D mesh
     Mesh mesh;
-    mesh = mesh.UniformGrid(GetParam(), { n, n, n });
-    mesh.scale(h);  // Scale to [0, 2]^3
+    mesh = mesh.UniformGrid(GetParam(), {n, n, n});
+    mesh.scale(h); // Scale to [0, 2]^3
     mesh.displace(VectorFunction{ -1.0, -1.0, -1.0 });  // Center at origin: [-1, 1]^3
     mesh.getConnectivity().compute(3, 0);
     mesh.getConnectivity().compute(2, 3);
@@ -380,21 +380,14 @@ namespace Rodin::Tests::Manufactured::Eikonal
     if (count > 0)
     {
       Real avg_error = total_error / count;
-      EXPECT_LT(avg_error, h)
-        << "Average error should be within tolerance";
+      EXPECT_LT(avg_error, h) << "Average error should be within tolerance";
     }
   }
 
   /// @brief Instantiates FMM Manufactured 3 D Test over the All Geometries 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries3D,
-    FMMManufactured3DTest,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries3D, FMMManufactured3DTest,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   // Test 6: Anisotropic speed function test
   /// @brief Verifies anisotropic speed 2 D for FMM manufactured test by checking false predicates, solver behavior, manufactured-solution convergence.

--- a/tests/manufactured/Rodin/P0/P0L2.cpp
+++ b/tests/manufactured/Rodin/P0/P0L2.cpp
@@ -32,7 +32,8 @@ namespace Rodin::Tests::Manufactured::P0L2
     void SetUp() override
     {
       const auto geom = GetParam();
-      if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron || geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
+      if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron ||
+        geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
       {
         m_mesh = Mesh().UniformGrid(geom, { NX, NY, NZ });
         m_mesh.scale(1.0 / (NX - 1));
@@ -137,14 +138,7 @@ namespace Rodin::Tests::Manufactured::P0L2
   );
 
   /// @brief Instantiates Manufactured P0 L 2 Test 20 x 20 x 20 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_P0_L2_Test_20x20x20,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-      )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_P0_L2_Test_20x20x20,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P0_P1/P0P1Mixed.cpp
+++ b/tests/manufactured/Rodin/P0_P1/P0P1Mixed.cpp
@@ -35,7 +35,8 @@ namespace Rodin::Tests::Manufactured::P0P1Mixed
     void SetUp() override
     {
       const auto geom = GetParam();
-      if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron || geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
+      if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron ||
+        geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
       {
         m_mesh = Mesh().UniformGrid(geom, { NX, NY, NZ });
         m_mesh.scale(1.0 / (NX - 1));
@@ -239,13 +240,7 @@ namespace Rodin::Tests::Manufactured::P0P1Mixed
   );
 
   /// @brief Instantiates Manufactured P0 P1 Mixed Test 6 x 6 x 6 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_P0P1_Mixed_Test_6x6x6,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_P0P1_Mixed_Test_6x6x6,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P1/DirichletBCIdentification.cpp
+++ b/tests/manufactured/Rodin/P1/DirichletBCIdentification.cpp
@@ -62,7 +62,7 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
       Mesh<Context::Local> getMesh()
       {
         Mesh<Context::Local> mesh;
-        mesh = mesh.UniformGrid(GetParam(), { M, M });
+        mesh = mesh.UniformGrid(GetParam(), {M, M});
         mesh.scale(1.0 / (M - 1));
         mesh.getConnectivity().compute(1, 2);
         return mesh;
@@ -70,11 +70,9 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
   };
 
   /// @brief Helper used by the tests to Test 16 x 16.
-  using Test_16x16 =
-    Manufactured_DirichletBCIdentification_Test<16>;
+  using Test_16x16 = Manufactured_DirichletBCIdentification_Test<16>;
   /// @brief Helper used by the tests to Test 32 x 32.
-  using Test_32x32 =
-    Manufactured_DirichletBCIdentification_Test<32>;
+  using Test_32x32 = Manufactured_DirichletBCIdentification_Test<32>;
 
   /**
    * @brief `DirichletBC(u, -u).on(\Gamma)` is algebraically equivalent to
@@ -98,11 +96,10 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
     Mesh meshRef = this->getMesh();
     P1 vhRef(meshRef);
     TrialFunction uRef(vhRef);
-    TestFunction  vRef(vhRef);
+    TestFunction vRef(vhRef);
     Problem refProblem(uRef, vRef);
-    refProblem = Integral(Grad(uRef), Grad(vRef))
-               - Integral(f, vRef)
-               + DirichletBC(uRef, Zero());
+    refProblem =
+      Integral(Grad(uRef), Grad(vRef)) - Integral(f, vRef) + DirichletBC(uRef, Zero());
     SparseLU(refProblem).solve();
     const auto& uRefData = uRef.getSolution().getData();
 
@@ -110,11 +107,10 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
     Mesh meshId = this->getMesh();
     P1 vhId(meshId);
     TrialFunction uId(vhId);
-    TestFunction  vId(vhId);
+    TestFunction vId(vhId);
     Problem idProblem(uId, vId);
-    idProblem = Integral(Grad(uId), Grad(vId))
-              - Integral(f, vId)
-              + DirichletBC(uId, -uId);
+    idProblem =
+      Integral(Grad(uId), Grad(vId)) - Integral(f, vId) + DirichletBC(uId, -uId);
     SparseLU(idProblem).solve();
     const auto& uIdData = uId.getSolution().getData();
 
@@ -148,24 +144,22 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
     Mesh meshRef = this->getMesh();
     P1 vhRef(meshRef);
     TrialFunction uRef(vhRef);
-    TestFunction  vRef(vhRef);
+    TestFunction vRef(vhRef);
     Problem refProblem(uRef, vRef);
-    refProblem = Integral(Grad(uRef), Grad(vRef))
-               - Integral(f, vRef)
-               + DirichletBC(uRef, Zero());
+    refProblem =
+      Integral(Grad(uRef), Grad(vRef)) - Integral(f, vRef) + DirichletBC(uRef, Zero());
     SparseLU(refProblem).solve();
     const auto& uRefData = uRef.getSolution().getData();
 
-    for (const Real c : { Real(-1), Real(-2), Real(0.5), Real(3) })
+    for (const Real c : {Real(-1), Real(-2), Real(0.5), Real(3)})
     {
       Mesh meshId = this->getMesh();
       P1 vhId(meshId);
       TrialFunction uId(vhId);
-      TestFunction  vId(vhId);
+      TestFunction vId(vhId);
       Problem idProblem(uId, vId);
-      idProblem = Integral(Grad(uId), Grad(vId))
-                - Integral(f, vId)
-                + DirichletBC(uId, RealFunction(c) * uId);
+      idProblem = Integral(Grad(uId), Grad(vId)) - Integral(f, vId) +
+        DirichletBC(uId, RealFunction(c) * uId);
       SparseLU(idProblem).solve();
       const auto& uIdData = uId.getSolution().getData();
 
@@ -189,18 +183,16 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
   TEST_P(Test_16x16, NegativeSelfIdentificationFEError)
   {
     const Real pi = Rodin::Math::Constants::pi();
-    const auto f        = 2 * pi * pi * sin(pi * F::x) * sin(pi * F::y);
+    const auto f = 2 * pi * pi * sin(pi * F::x) * sin(pi * F::y);
     const auto solution = sin(pi * F::x) * sin(pi * F::y);
 
     // Identification path
     Mesh mesh = this->getMesh();
     P1 vh(mesh);
     TrialFunction u(vh);
-    TestFunction  v(vh);
+    TestFunction v(vh);
     Problem poisson(u, v);
-    poisson = Integral(Grad(u), Grad(v))
-            - Integral(f, v)
-            + DirichletBC(u, -u);
+    poisson = Integral(Grad(u), Grad(v)) - Integral(f, v) + DirichletBC(u, -u);
     SparseLU(poisson).solve();
 
     GridFunction diff(vh);
@@ -227,20 +219,19 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
     Mesh meshRef = this->getMesh();
     P1 vhRef(meshRef);
     TrialFunction uRef(vhRef);
-    TestFunction  vRef(vhRef);
+    TestFunction vRef(vhRef);
     Problem refProblem(uRef, vRef);
-    refProblem = Integral(Grad(uRef), Grad(vRef))
-               + DirichletBC(uRef, Zero());
+    refProblem = Integral(Grad(uRef), Grad(vRef)) + DirichletBC(uRef, Zero());
     SparseLU(refProblem).solve();
     const auto& uRefData = uRef.getSolution().getData();
 
     Mesh meshId = this->getMesh();
     P1 vhId(meshId);
     TrialFunction uId(vhId);
-    TestFunction  vId(vhId);
+    TestFunction vId(vhId);
     Problem idProblem(uId, vId);
-    idProblem = Integral(Grad(uId), Grad(vId))
-              + DirichletBC(uId, RealFunction(2.0) * uId);
+    idProblem =
+      Integral(Grad(uId), Grad(vId)) + DirichletBC(uId, RealFunction(2.0) * uId);
     SparseLU(idProblem).solve();
     const auto& uIdData = uId.getSolution().getData();
 
@@ -284,58 +275,47 @@ namespace Rodin::Tests::Manufactured::DirichletBCIdentification
     P1 scalarRef(meshRef);
     P1 vectorRef(meshRef, meshRef.getSpaceDimension());
     TrialFunction uRef(scalarRef);
-    TestFunction  vRef(scalarRef);
+    TestFunction vRef(scalarRef);
     TrialFunction etaRef(vectorRef);
-    TestFunction  zetaRef(vectorRef);
+    TestFunction zetaRef(vectorRef);
 
     Problem refProblem(uRef, vRef, etaRef, zetaRef);
-    refProblem =
-      Integral(uRef, vRef)
-      + Integral(etaRef, zetaRef)
-      + DirichletBC(uRef, uBoundary)
-      + DirichletBC(etaRef, VectorFunction{ etaX, etaY });
+    refProblem = Integral(uRef, vRef) + Integral(etaRef, zetaRef) +
+      DirichletBC(uRef, uBoundary) + DirichletBC(etaRef, VectorFunction{etaX, etaY});
     SparseLU(refProblem).solve();
 
     Mesh meshId = this->getMesh();
     P1 scalarId(meshId);
     P1 vectorId(meshId, meshId.getSpaceDimension());
     TrialFunction uId(scalarId);
-    TestFunction  vId(scalarId);
+    TestFunction vId(scalarId);
     TrialFunction etaId(vectorId);
-    TestFunction  zetaId(vectorId);
+    TestFunction zetaId(vectorId);
 
     Problem idProblem(uId, vId, etaId, zetaId);
-    idProblem =
-      Integral(uId, vId)
-      + Integral(etaId, zetaId)
-      + DirichletBC(
-          uId,
-          RealFunction(2.0) * etaId.x() + RealFunction(-0.5) * etaId.y())
-      + DirichletBC(etaId, VectorFunction{ etaX, etaY });
+    idProblem = Integral(uId, vId) + Integral(etaId, zetaId) +
+      DirichletBC(uId, RealFunction(2.0) * etaId.x() + RealFunction(-0.5) * etaId.y()) +
+      DirichletBC(etaId, VectorFunction{etaX, etaY});
     SparseLU(idProblem).solve();
 
     const auto& uRefData = uRef.getSolution().getData();
-    const auto& uIdData  = uId.getSolution().getData();
+    const auto& uIdData = uId.getSolution().getData();
     ASSERT_EQ(uRefData.size(), uIdData.size());
     for (Eigen::Index i = 0; i < uRefData.size(); i++)
       EXPECT_NEAR(uRefData(i), uIdData(i), 1e-10) << "u dof " << i;
 
     const auto& etaRefData = etaRef.getSolution().getData();
-    const auto& etaIdData  = etaId.getSolution().getData();
+    const auto& etaIdData = etaId.getSolution().getData();
     ASSERT_EQ(etaRefData.size(), etaIdData.size());
     for (Eigen::Index i = 0; i < etaRefData.size(); i++)
       EXPECT_NEAR(etaRefData(i), etaIdData(i), 1e-10) << "eta dof " << i;
   }
 
   /// @brief Instantiates Test 16 x 16 over the Mesh Params 16 x 16 parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    MeshParams16x16,
-    Test_16x16,
+  INSTANTIATE_TEST_SUITE_P(MeshParams16x16, Test_16x16,
     ::testing::Values(Polytope::Type::Triangle, Polytope::Type::Quadrilateral));
 
   /// @brief Instantiates Test 32 x 32 over the Mesh Params 32 x 32 parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    MeshParams32x32,
-    Test_32x32,
+  INSTANTIATE_TEST_SUITE_P(MeshParams32x32, Test_32x32,
     ::testing::Values(Polytope::Type::Triangle, Polytope::Type::Quadrilateral));
 }

--- a/tests/manufactured/Rodin/P1/Helmholtz3D.cpp
+++ b/tests/manufactured/Rodin/P1/Helmholtz3D.cpp
@@ -69,7 +69,7 @@ namespace Rodin::Tests::Manufactured::Helmholtz3D
   };
 
   /// @brief Helper used by the tests to Helmholtz 3 D Test 8.
-  using Helmholtz3DTest8  = Helmholtz3DFixture<8>;
+  using Helmholtz3DTest8 = Helmholtz3DFixture<8>;
   /// @brief Helper used by the tests to Helmholtz 3 D Test 16.
   using Helmholtz3DTest16 = Helmholtz3DFixture<16>;
   /// @brief Helper used by the tests to Helmholtz 3 D Test 32.
@@ -301,35 +301,17 @@ namespace Rodin::Tests::Manufactured::Helmholtz3D
   }
 
   /// @brief Instantiates Helmholtz 3 D Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Helmholtz3DTest8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Helmholtz3DTest8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Helmholtz 3 D Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Helmholtz3DTest16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Helmholtz3DTest16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Helmholtz 3 D Test 32 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Helmholtz3DTest32,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Helmholtz3DTest32,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P1/HyperElasticity.cpp
+++ b/tests/manufactured/Rodin/P1/HyperElasticity.cpp
@@ -41,10 +41,10 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
 
     struct SolveResult
     {
-      Real l2ErrorSquared;
-      bool converged;
-      Real initialResidual;
-      Real finalResidual;
+        Real l2ErrorSquared;
+        bool converged;
+        Real initialResidual;
+        Real finalResidual;
     };
 
     auto makeUnitSquareMesh()
@@ -165,16 +165,13 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       const Real pi = Math::Constants::pi();
       // Affine displacement is represented exactly in P1, making this a strict
       // manufactured test for the nonlinear solver/integrator plumbing.
-      auto uExact = VectorFunction{
-        xDisplacementScale * F::x + xDisplacementOffset,
-        yDisplacementScale * F::y + yDisplacementOffset
-      };
-      auto zero = VectorFunction{ Zero(), Zero() };
+      auto uExact = VectorFunction{xDisplacementScale * F::x + xDisplacementOffset,
+        yDisplacementScale * F::y + yDisplacementOffset};
+      auto zero = VectorFunction{Zero(), Zero()};
       auto perturbation = perturbationScale * sin(pi * F::x) * sin(pi * F::y);
-      uCurrent = VectorFunction{
-        xDisplacementScale * F::x + xDisplacementOffset + perturbation,
-        yDisplacementScale * F::y + yDisplacementOffset - perturbation
-      };
+      uCurrent =
+        VectorFunction{xDisplacementScale * F::x + xDisplacementOffset + perturbation,
+          yDisplacementScale * F::y + yDisplacementOffset - perturbation};
 
       TrialFunction du(Vh);
       TestFunction v(Vh);
@@ -185,23 +182,19 @@ namespace Rodin::Tests::Manufactured::HyperElasticity
       Problem newtonProblem(du, v);
       if (residualSign == ResidualSign::Correct)
       {
-        newtonProblem = ivw(du, v)
-                      + DirichletBC(du, zero);
+        newtonProblem = ivw(du, v) + DirichletBC(du, zero);
       }
       else
       {
-        newtonProblem = ivw.Tangent(du, v)
-                      - ivw.Residual(v)
-                      + DirichletBC(du, zero);
+        newtonProblem = ivw.Tangent(du, v) - ivw.Residual(v) + DirichletBC(du, zero);
       }
 
       SparseLU linearSolver(newtonProblem);
       NewtonSolver newton(linearSolver);
       if (residualSign == ResidualSign::Correct)
       {
-        newton.setMaxIterations(12)
-          .setAbsoluteTolerance(1e-12)
-          .setRelativeTolerance(1e-10);
+        newton.setMaxIterations(12).setAbsoluteTolerance(1e-12).setRelativeTolerance(
+          1e-10);
       }
       else
       {

--- a/tests/manufactured/Rodin/P1/LinearElasticity3D.cpp
+++ b/tests/manufactured/Rodin/P1/LinearElasticity3D.cpp
@@ -91,7 +91,7 @@ namespace Rodin::Tests::Manufactured::LinearElasticity3D
   };
 
   /// @brief Helper used by the tests to Elasticity 3 D Test 8.
-  using Elasticity3DTest8  = Elasticity3DFixture<8>;
+  using Elasticity3DTest8 = Elasticity3DFixture<8>;
   /// @brief Helper used by the tests to Elasticity 3 D Test 16.
   using Elasticity3DTest16 = Elasticity3DFixture<16>;
   /// @brief Helper used by the tests to Elasticity 3 D Test 32.
@@ -333,35 +333,17 @@ namespace Rodin::Tests::Manufactured::LinearElasticity3D
   }
 
   /// @brief Instantiates Elasticity 3 D Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Elasticity3DTest8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Elasticity3DTest8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Elasticity 3 D Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Elasticity3DTest16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Elasticity3DTest16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Elasticity 3 D Test 32 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Elasticity3DTest32,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Elasticity3DTest32,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P1/Poisson3D.cpp
+++ b/tests/manufactured/Rodin/P1/Poisson3D.cpp
@@ -27,7 +27,6 @@ using namespace Rodin::Variational;
 using namespace Rodin::Solver;
 using namespace Rodin::Test::Random;
 
-
 /**
  * @brief Manufactured solutions for the 3D Poisson problem on supported 3D meshes.
  *
@@ -53,8 +52,7 @@ using namespace Rodin::Test::Random;
 namespace Rodin::Tests::Manufactured::Poisson3D
 {
   template <size_t M>
-  class Manufactured_Poisson3D_Test
-    : public ::testing::TestWithParam<Polytope::Type>
+  class Manufactured_Poisson3D_Test : public ::testing::TestWithParam<Polytope::Type>
   {
   protected:
     void SetUp() override
@@ -681,35 +679,17 @@ namespace Rodin::Tests::Manufactured::Poisson3D
   }
 
   /// @brief Instantiates Manufactured Poisson 3 D Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Poisson3D_Test_8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Poisson3D_Test_8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Manufactured Poisson 3 D Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Poisson3D_Test_16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Poisson3D_Test_16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Manufactured Poisson 3 D Test 32 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    Manufactured_Poisson3D_Test_32,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, Manufactured_Poisson3D_Test_32,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P1/ReactionDiffusion.cpp
+++ b/tests/manufactured/Rodin/P1/ReactionDiffusion.cpp
@@ -55,12 +55,9 @@ namespace Rodin::Tests::Manufactured::ReactionDiffusion
     constexpr Attribute BottomAttribute = 3;
     constexpr Attribute TopAttribute = 4;
 
-    void labelBoundaryAttributes(
-      Geometry::Mesh<Context::Local>& mesh,
-      Attribute left = LeftAttribute,
-      Attribute right = RightAttribute,
-      Attribute bottom = BottomAttribute,
-      Attribute top = TopAttribute)
+    void labelBoundaryAttributes(Geometry::Mesh<Context::Local>& mesh,
+      Attribute left = LeftAttribute, Attribute right = RightAttribute,
+      Attribute bottom = BottomAttribute, Attribute top = TopAttribute)
     {
       for (auto it = mesh.getBoundary(); !it.end(); ++it)
       {
@@ -330,22 +327,14 @@ namespace Rodin::Tests::Manufactured::ReactionDiffusion
     TestFunction phi(vh), psi(vh);
 
     const FlatSet<Attribute> boundary{
-      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute
-    };
+      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute};
 
     Problem rd(u, w, phi, psi);
-    rd = Integral(Grad(u), Grad(phi))
-       + Integral(u, phi)
-       - Integral(forcing, phi)
-       + Integral(Grad(w), Grad(psi))
-       + Integral(w, psi)
-       - Integral(forcing, psi)
-       + DirichletBC(u, w).on(boundary)
-       + DirichletBC(w, solution).on(
-           LeftAttribute,
-           RightAttribute,
-           BottomAttribute,
-           TopAttribute);
+    rd = Integral(Grad(u), Grad(phi)) + Integral(u, phi) - Integral(forcing, phi) +
+      Integral(Grad(w), Grad(psi)) + Integral(w, psi) - Integral(forcing, psi) +
+      DirichletBC(u, w).on(boundary) +
+      DirichletBC(w, solution)
+        .on(LeftAttribute, RightAttribute, BottomAttribute, TopAttribute);
 
     GMRES(rd).solve();
 

--- a/tests/manufactured/Rodin/P1/ReactionDiffusion3D.cpp
+++ b/tests/manufactured/Rodin/P1/ReactionDiffusion3D.cpp
@@ -64,7 +64,7 @@ namespace Rodin::Tests::Manufactured::ReactionDiffusion3D
   };
 
   /// @brief Helper used by the tests to Reaction Diffusion 3 D Test 8.
-  using ReactionDiffusion3DTest8  = ReactionDiffusion3DFixture<8>;
+  using ReactionDiffusion3DTest8 = ReactionDiffusion3DFixture<8>;
   /// @brief Helper used by the tests to Reaction Diffusion 3 D Test 16.
   using ReactionDiffusion3DTest16 = ReactionDiffusion3DFixture<16>;
 
@@ -286,24 +286,12 @@ namespace Rodin::Tests::Manufactured::ReactionDiffusion3D
   }
 
   /// @brief Instantiates Reaction Diffusion 3 D Test 8 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    ReactionDiffusion3DTest8,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, ReactionDiffusion3DTest8,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Reaction Diffusion 3 D Test 16 over the Polytope Coverage 3 D parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D,
-    ReactionDiffusion3DTest16,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D, ReactionDiffusion3DTest16,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/manufactured/Rodin/P1_H1/P1H1Mixed.cpp
+++ b/tests/manufactured/Rodin/P1_H1/P1H1Mixed.cpp
@@ -39,7 +39,8 @@ namespace Rodin::Tests::Manufactured::P1H1
       void SetUp() override
       {
         const auto geom = GetParam();
-        if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron || geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
+        if (geom == Polytope::Type::Tetrahedron || geom == Polytope::Type::Hexahedron ||
+          geom == Polytope::Type::Pyramid || geom == Polytope::Type::Wedge)
         {
           m_mesh = Mesh().UniformGrid(geom, { NX, NY, NZ });
           m_mesh.scale(1.0 / (NX - 1));
@@ -248,16 +249,9 @@ namespace Rodin::Tests::Manufactured::P1H1
   );
 
   /// @brief Instantiates Manufactured P1 H1 Mixed Test 20 K 1 over the Polytope Coverage 3 D K 1 parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D_K1,
-    Manufactured_P1H1_Mixed_Test_20_K1,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-      )
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D_K1, Manufactured_P1H1_Mixed_Test_20_K1,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   /// @brief Instantiates Manufactured P1 H1 Mixed Test 10 x 10 K 2 over the Polytope Coverage 2 D K 2 parameter coverage.
   INSTANTIATE_TEST_SUITE_P(
@@ -269,13 +263,7 @@ namespace Rodin::Tests::Manufactured::P1H1
   );
 
   /// @brief Instantiates Manufactured P1 H1 Mixed Test 6 x 6 x 6 K 2 over the Polytope Coverage 3 D K 2 parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    PolytopeCoverage3D_K2,
-    Manufactured_P1H1_Mixed_Test_6x6x6_K2,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge)
-  );
+  INSTANTIATE_TEST_SUITE_P(PolytopeCoverage3D_K2, Manufactured_P1H1_Mixed_Test_6x6x6_K2,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/unit/Rodin/Assembly/OpenMPTest.cpp
+++ b/tests/unit/Rodin/Assembly/OpenMPTest.cpp
@@ -67,26 +67,22 @@ namespace Rodin::Tests::Unit
   /// @brief Helper used by the tests to Check Open MP Self Identification Matches Zero Value Constraint.
   void checkOpenMPSelfIdentificationMatchesZeroValueConstraint()
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 refFES(mesh);
     TrialFunction uRef(refFES);
-    TestFunction  vRef(refFES);
+    TestFunction vRef(refFES);
 
-    auto refBody =
-      Integral(Grad(uRef), Grad(vRef))
-      - Integral(RealFunction(1.0), vRef)
-      + DirichletBC(uRef, Zero());
+    auto refBody = Integral(Grad(uRef), Grad(vRef)) - Integral(RealFunction(1.0), vRef) +
+      DirichletBC(uRef, Zero());
 
     P1 idFES(mesh);
     TrialFunction uId(idFES);
-    TestFunction  vId(idFES);
+    TestFunction vId(idFES);
 
-    auto idBody =
-      Integral(Grad(uId), Grad(vId))
-      - Integral(RealFunction(1.0), vId)
-      + DirichletBC(uId, -uId);
+    auto idBody = Integral(Grad(uId), Grad(vId)) - Integral(RealFunction(1.0), vId) +
+      DirichletBC(uId, -uId);
 
     Problem refProblem(uRef, vRef);
     refProblem = refBody;
@@ -96,12 +92,10 @@ namespace Rodin::Tests::Unit
     idProblem = idBody;
     idProblem.assemble();
 
-    const auto matrixDiff =
-      refProblem.getLinearSystem().getOperator()
-      - idProblem.getLinearSystem().getOperator();
+    const auto matrixDiff = refProblem.getLinearSystem().getOperator() -
+      idProblem.getLinearSystem().getOperator();
     const auto vectorDiff =
-      refProblem.getLinearSystem().getVector()
-      - idProblem.getLinearSystem().getVector();
+      refProblem.getLinearSystem().getVector() - idProblem.getLinearSystem().getVector();
 
     EXPECT_NEAR(matrixDiff.norm(), 0.0, 1e-12);
     EXPECT_NEAR(vectorDiff.norm(), 0.0, 1e-12);
@@ -168,19 +162,10 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates Assembly Open MP Linear Form over the All Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries,
-    Assembly_OpenMP_LinearForm,
-    ::testing::Values(
-      Polytope::Type::Segment,
-      Polytope::Type::Triangle,
-      Polytope::Type::Quadrilateral,
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries, Assembly_OpenMP_LinearForm,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   // =========================================================================
   // BilinearForm — OpenMP matches Sequential across geometries
@@ -349,19 +334,10 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates Assembly Open MP Bilinear Form over the All Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries,
-    Assembly_OpenMP_BilinearForm,
-    ::testing::Values(
-      Polytope::Type::Segment,
-      Polytope::Type::Triangle,
-      Polytope::Type::Quadrilateral,
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries, Assembly_OpenMP_BilinearForm,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge));
 
   // =========================================================================
   // Problem (multi-variable) — OpenMP matches Sequential
@@ -422,14 +398,14 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies affine identification defect matches sequential for assembly open MP problem by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(Assembly_OpenMP_Problem, AffineIdentificationDefectMatchesSequential)
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     TrialFunction u(fes);
-    TestFunction  v(fes);
+    TestFunction v(fes);
     TrialFunction eta(fes);
-    TestFunction  zeta(fes);
+    TestFunction zeta(fes);
 
     constexpr Real gamma = 2.0;
     constexpr Real defect = 3.0;
@@ -443,11 +419,7 @@ namespace Rodin::Tests::Unit
       triplets.emplace_back(i, i, 1.0);
     uu.getOperator().setFromTriplets(triplets.begin(), triplets.end());
 
-    auto bc =
-      DirichletBC(
-          u,
-          RealFunction(gamma) * eta,
-          RealFunction(defect));
+    auto bc = DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect));
     LinearForm zero(v);
     zero.getVector().resize(n);
     zero.getVector().setZero();
@@ -457,33 +429,24 @@ namespace Rodin::Tests::Unit
     using LinearSystemType =
       Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>>;
     using ProblemType =
-      Problem<LinearSystemType,
-              decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
 
-    auto trialFunctions = Tuple{ std::ref(u), std::ref(eta) };
-    auto testFunctions  = Tuple{ std::ref(v), std::ref(zeta) };
+    auto trialFunctions = Tuple{std::ref(u), std::ref(eta)};
+    auto testFunctions = Tuple{std::ref(v), std::ref(zeta)};
 
-    std::array<size_t, 2> offsets{ 0, static_cast<size_t>(n) };
+    std::array<size_t, 2> offsets{0, static_cast<size_t>(n)};
 
     boost::bimap<FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, eta.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, zeta.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, eta.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, zeta.getUUID()});
 
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(body)>,
-      decltype(u), decltype(v), decltype(eta), decltype(zeta)> input(
-          body,
-          trialFunctions,
-          testFunctions,
-          offsets,
-          offsets,
-          trialUUIDMap,
-          testUUIDMap,
-          static_cast<size_t>(nTotal),
-          static_cast<size_t>(nTotal));
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(body)>, decltype(u), decltype(v),
+      decltype(eta), decltype(zeta)>
+      input(body, trialFunctions, testFunctions, offsets, offsets, trialUUIDMap,
+        testUUIDMap, static_cast<size_t>(nTotal), static_cast<size_t>(nTotal));
 
     LinearSystemType seqLS;
     LinearSystemType ompLS;
@@ -526,21 +489,18 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies identification vector master matches sequential for assembly open MP problem by checking tolerance-based numerical results, exact expected values, true predicates.
   TEST(Assembly_OpenMP_Problem, IdentificationVectorMasterMatchesSequential)
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 slaveFES(mesh);
     P1 masterFES(mesh, mesh.getSpaceDimension());
 
     TrialFunction u(slaveFES);
-    TestFunction  v(slaveFES);
+    TestFunction v(slaveFES);
     TrialFunction eta(masterFES);
-    TestFunction  zeta(masterFES);
+    TestFunction zeta(masterFES);
 
-    auto bc =
-      DirichletBC(
-          u,
-          RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
+    auto bc = DirichletBC(u, RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
     bc.assemble();
 
     using IdentifiedDOFs = DirichletBCBase<Real>::IdentifiedDOFs;
@@ -551,24 +511,21 @@ namespace Rodin::Tests::Unit
     bool sawMultiMaster = false;
     for (const auto& [slave, row] : ident)
     {
-      (void) slave;
+      (void)slave;
       if (row.first.size() >= 2)
         sawMultiMaster = true;
     }
     ASSERT_TRUE(sawMultiMaster);
 
-    const Index nSlave  = static_cast<Index>(slaveFES.getSize());
+    const Index nSlave = static_cast<Index>(slaveFES.getSize());
     const Index nMaster = static_cast<Index>(masterFES.getSize());
-    const Index nTotal  = nSlave + nMaster;
+    const Index nTotal = nSlave + nMaster;
 
     BilinearForm uu(u, v);
     uu.getOperator().resize(nSlave, nSlave);
-    std::vector<Eigen::Triplet<Real>> triplets{
-      Eigen::Triplet<Real>(0, 0, 2.0),
-      Eigen::Triplet<Real>(0, 1, 3.0),
-      Eigen::Triplet<Real>(1, 0, 5.0),
-      Eigen::Triplet<Real>(1, 1, 7.0)
-    };
+    std::vector<Eigen::Triplet<Real>> triplets{Eigen::Triplet<Real>(0, 0, 2.0),
+      Eigen::Triplet<Real>(0, 1, 3.0), Eigen::Triplet<Real>(1, 0, 5.0),
+      Eigen::Triplet<Real>(1, 1, 7.0)};
     uu.getOperator().setFromTriplets(triplets.begin(), triplets.end());
 
     LinearForm loadU(v);
@@ -582,38 +539,25 @@ namespace Rodin::Tests::Unit
     using LinearSystemType =
       Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>>;
     using ProblemType =
-      Problem<LinearSystemType,
-              decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
 
-    auto trialFunctions = Tuple{ std::ref(u), std::ref(eta) };
-    auto testFunctions  = Tuple{ std::ref(v), std::ref(zeta) };
+    auto trialFunctions = Tuple{std::ref(u), std::ref(eta)};
+    auto testFunctions = Tuple{std::ref(v), std::ref(zeta)};
 
-    std::array<size_t, 2> trialOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
-    std::array<size_t, 2> testOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
+    std::array<size_t, 2> trialOffsets{0, static_cast<size_t>(nSlave)};
+    std::array<size_t, 2> testOffsets{0, static_cast<size_t>(nSlave)};
 
     boost::bimap<FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, eta.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, zeta.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, eta.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, zeta.getUUID()});
 
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(body)>,
-      decltype(u), decltype(v), decltype(eta), decltype(zeta)> input(
-          body,
-          trialFunctions,
-          testFunctions,
-          trialOffsets,
-          testOffsets,
-          trialUUIDMap,
-          testUUIDMap,
-          static_cast<size_t>(nTotal),
-          static_cast<size_t>(nTotal));
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(body)>, decltype(u), decltype(v),
+      decltype(eta), decltype(zeta)>
+      input(body, trialFunctions, testFunctions, trialOffsets, testOffsets, trialUUIDMap,
+        testUUIDMap, static_cast<size_t>(nTotal), static_cast<size_t>(nTotal));
 
     LinearSystemType seqLS;
     LinearSystemType ompLS;
@@ -650,17 +594,8 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates Assembly Open MP Problem over the All Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries,
-    Assembly_OpenMP_Problem,
-    ::testing::Values(
-      Polytope::Type::Segment,
-      Polytope::Type::Triangle,
-      Polytope::Type::Quadrilateral,
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries, Assembly_OpenMP_Problem,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/unit/Rodin/Assembly/SequentialTest.cpp
+++ b/tests/unit/Rodin/Assembly/SequentialTest.cpp
@@ -529,25 +529,22 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies preassembled forms project rows columns and vector for assembly problem identification by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(Assembly_Problem_Identification, PreassembledFormsProjectRowsColumnsAndVector)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     TrialFunction u(fes);
-    TestFunction  v(fes);
+    TestFunction v(fes);
     TrialFunction eta(fes);
-    TestFunction  zeta(fes);
+    TestFunction zeta(fes);
 
     constexpr Real gamma = 2.0;
     const Index n = static_cast<Index>(fes.getSize());
 
     BilinearForm uu(u, v);
     uu.getOperator().resize(n, n);
-    std::vector<Eigen::Triplet<Real>> triplets{
-      Eigen::Triplet<Real>(0, 0, 2.0),
-      Eigen::Triplet<Real>(0, 1, 3.0),
-      Eigen::Triplet<Real>(1, 0, 5.0)
-    };
+    std::vector<Eigen::Triplet<Real>> triplets{Eigen::Triplet<Real>(0, 0, 2.0),
+      Eigen::Triplet<Real>(0, 1, 3.0), Eigen::Triplet<Real>(1, 0, 5.0)};
     uu.getOperator().setFromTriplets(triplets.begin(), triplets.end());
 
     LinearForm loadU(v);
@@ -579,14 +576,14 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies affine identification writes defect rows for assembly problem identification by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(Assembly_Problem_Identification, AffineIdentificationWritesDefectRows)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     TrialFunction u(fes);
-    TestFunction  v(fes);
+    TestFunction v(fes);
     TrialFunction eta(fes);
-    TestFunction  zeta(fes);
+    TestFunction zeta(fes);
 
     constexpr Real gamma = 2.0;
     constexpr Real defect = 3.0;
@@ -604,12 +601,7 @@ namespace Rodin::Tests::Unit
     zero.getVector().setZero();
 
     Problem problem(u, v, eta, zeta);
-    problem = uu
-            + DirichletBC(
-                u,
-                RealFunction(gamma) * eta,
-                RealFunction(defect))
-            - zero;
+    problem = uu + DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect)) - zero;
     problem.assemble();
 
     const auto& A = problem.getLinearSystem().getOperator();
@@ -621,35 +613,31 @@ namespace Rodin::Tests::Unit
     for (Index i = 0; i < n; i++)
     {
       EXPECT_NEAR(b.coeff(i), defect, 1e-14) << "row " << i;
-      EXPECT_NEAR(A.coeff(i, i), 1.0, 1e-14)
-        << "entry (" << i << ", " << i << ")";
+      EXPECT_NEAR(A.coeff(i, i), 1.0, 1e-14) << "entry (" << i << ", " << i << ")";
       EXPECT_NEAR(A.coeff(i, n + i), -gamma, 1e-14)
         << "entry (" << i << ", " << (n + i) << ")";
-      EXPECT_NEAR(b.coeff(n + i), -gamma * defect, 1e-14)
-        << "projected row " << (n + i);
+      EXPECT_NEAR(b.coeff(n + i), -gamma * defect, 1e-14) << "projected row " << (n + i);
       EXPECT_NEAR(A.coeff(n + i, n + i), gamma * gamma, 1e-14)
         << "projected entry (" << (n + i) << ", " << (n + i) << ")";
     }
   }
 
   /// @brief Verifies sequential vector master projects multiple finite spaces for assembly problem identification by checking tolerance-based numerical results, exact expected values, true predicates.
-  TEST(Assembly_Problem_Identification, SequentialVectorMasterProjectsMultipleFiniteSpaces)
+  TEST(
+    Assembly_Problem_Identification, SequentialVectorMasterProjectsMultipleFiniteSpaces)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 slaveFES(mesh);
     P1 masterFES(mesh, mesh.getSpaceDimension());
 
     TrialFunction u(slaveFES);
-    TestFunction  v(slaveFES);
+    TestFunction v(slaveFES);
     TrialFunction eta(masterFES);
-    TestFunction  zeta(masterFES);
+    TestFunction zeta(masterFES);
 
-    auto bc =
-      DirichletBC(
-          u,
-          RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
+    auto bc = DirichletBC(u, RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
     bc.assemble();
 
     using IdentifiedDOFs = DirichletBCBase<Real>::IdentifiedDOFs;
@@ -660,32 +648,25 @@ namespace Rodin::Tests::Unit
     bool sawMultiMaster = false;
     for (const auto& [slave, row] : ident)
     {
-      (void) slave;
+      (void)slave;
       if (row.first.size() >= 2)
         sawMultiMaster = true;
     }
     ASSERT_TRUE(sawMultiMaster);
 
-    const Index nSlave  = static_cast<Index>(slaveFES.getSize());
+    const Index nSlave = static_cast<Index>(slaveFES.getSize());
     const Index nMaster = static_cast<Index>(masterFES.getSize());
-    const Index nTotal  = nSlave + nMaster;
+    const Index nTotal = nSlave + nMaster;
 
     struct MatrixEntry
     {
-      Index row;
-      Index col;
-      Real value;
+        Index row;
+        Index col;
+        Real value;
     };
     const std::vector<MatrixEntry> matrixEntries{
-      { 0, 0, 2.0 },
-      { 0, 1, 3.0 },
-      { 1, 0, 5.0 },
-      { 1, 1, 7.0 }
-    };
-    const std::vector<std::pair<Index, Real>> vectorEntries{
-      { 0, 11.0 },
-      { 1, -13.0 }
-    };
+      {0, 0, 2.0}, {0, 1, 3.0}, {1, 0, 5.0}, {1, 1, 7.0}};
+    const std::vector<std::pair<Index, Real>> vectorEntries{{0, 11.0}, {1, -13.0}};
 
     BilinearForm uu(u, v);
     uu.getOperator().resize(nSlave, nSlave);
@@ -705,52 +686,35 @@ namespace Rodin::Tests::Unit
     using LinearSystemType =
       Math::LinearSystem<Math::SparseMatrix<Real>, Math::Vector<Real>>;
     using ProblemType =
-      Problem<LinearSystemType,
-              decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
 
-    auto trialFunctions = Tuple{ std::ref(u), std::ref(eta) };
-    auto testFunctions  = Tuple{ std::ref(v), std::ref(zeta) };
+    auto trialFunctions = Tuple{std::ref(u), std::ref(eta)};
+    auto testFunctions = Tuple{std::ref(v), std::ref(zeta)};
 
-    std::array<size_t, 2> trialOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
-    std::array<size_t, 2> testOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
+    std::array<size_t, 2> trialOffsets{0, static_cast<size_t>(nSlave)};
+    std::array<size_t, 2> testOffsets{0, static_cast<size_t>(nSlave)};
 
     boost::bimap<FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, eta.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, zeta.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, eta.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, zeta.getUUID()});
 
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(body)>,
-      decltype(u), decltype(v), decltype(eta), decltype(zeta)> input(
-          body,
-          trialFunctions,
-          testFunctions,
-          trialOffsets,
-          testOffsets,
-          trialUUIDMap,
-          testUUIDMap,
-          static_cast<size_t>(nTotal),
-          static_cast<size_t>(nTotal));
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(body)>, decltype(u), decltype(v),
+      decltype(eta), decltype(zeta)>
+      input(body, trialFunctions, testFunctions, trialOffsets, testOffsets, trialUUIDMap,
+        testUUIDMap, static_cast<size_t>(nTotal), static_cast<size_t>(nTotal));
 
     LinearSystemType ls;
     Assembly::Sequential<LinearSystemType, ProblemType> assembler;
     assembler.execute(ls, input);
 
-    Eigen::MatrixXd expectedA =
-      Eigen::MatrixXd::Zero(
-          static_cast<Eigen::Index>(nTotal),
-          static_cast<Eigen::Index>(nTotal));
-    Eigen::VectorXd expectedB =
-      Eigen::VectorXd::Zero(static_cast<Eigen::Index>(nTotal));
+    Eigen::MatrixXd expectedA = Eigen::MatrixXd::Zero(
+      static_cast<Eigen::Index>(nTotal), static_cast<Eigen::Index>(nTotal));
+    Eigen::VectorXd expectedB = Eigen::VectorXd::Zero(static_cast<Eigen::Index>(nTotal));
 
-    auto expand = [&](Index local)
-    {
+    auto expand = [&](Index local) {
       std::vector<std::pair<Index, Real>> res;
       const auto it = ident.find(local);
       if (it == ident.end())
@@ -759,7 +723,7 @@ namespace Rodin::Tests::Unit
         return res;
       }
       const auto& masters = it->second.first;
-      const auto& coeffs  = it->second.second;
+      const auto& coeffs = it->second.second;
       for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
         res.emplace_back(nSlave + masters[k], coeffs[k]);
       return res;
@@ -779,7 +743,7 @@ namespace Rodin::Tests::Unit
       expectedA.row(static_cast<Eigen::Index>(slave)).setZero();
       expectedA(slave, slave) = 1.0;
       const auto& masters = row.first;
-      const auto& coeffs  = row.second;
+      const auto& coeffs = row.second;
       for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
         expectedA(slave, nSlave + masters[k]) -= coeffs[k];
       expectedB(slave) = 0.0;
@@ -805,33 +769,31 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies self identification matches zero value constraint for assembly problem identification by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(Assembly_Problem_Identification, SelfIdentificationMatchesZeroValueConstraint)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 4, 4 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {4, 4});
     mesh.getConnectivity().compute(1, 2);
 
     P1 refFES(mesh);
     TrialFunction uRef(refFES);
-    TestFunction  vRef(refFES);
+    TestFunction vRef(refFES);
 
     Problem refProblem(uRef, vRef);
-    refProblem = Integral(Grad(uRef), Grad(vRef))
-               - Integral(RealFunction(1.0), vRef)
-               + DirichletBC(uRef, Zero());
+    refProblem = Integral(Grad(uRef), Grad(vRef)) - Integral(RealFunction(1.0), vRef) +
+      DirichletBC(uRef, Zero());
     refProblem.assemble();
 
     P1 idFES(mesh);
     TrialFunction uId(idFES);
-    TestFunction  vId(idFES);
+    TestFunction vId(idFES);
 
     Problem idProblem(uId, vId);
-    idProblem = Integral(Grad(uId), Grad(vId))
-              - Integral(RealFunction(1.0), vId)
-              + DirichletBC(uId, -uId);
+    idProblem = Integral(Grad(uId), Grad(vId)) - Integral(RealFunction(1.0), vId) +
+      DirichletBC(uId, -uId);
     idProblem.assemble();
 
     const auto& ARef = refProblem.getLinearSystem().getOperator();
     const auto& bRef = refProblem.getLinearSystem().getVector();
-    const auto& AId  = idProblem.getLinearSystem().getOperator();
-    const auto& bId  = idProblem.getLinearSystem().getVector();
+    const auto& AId = idProblem.getLinearSystem().getOperator();
+    const auto& bId = idProblem.getLinearSystem().getVector();
 
     ASSERT_EQ(ARef.rows(), AId.rows());
     ASSERT_EQ(ARef.cols(), AId.cols());
@@ -844,17 +806,16 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies overlapping value and identification throws for assembly problem identification by checking exception behavior, form assembly.
   TEST(Assembly_Problem_Identification, OverlappingValueAndIdentificationThrows)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     TrialFunction u(fes);
-    TestFunction  v(fes);
+    TestFunction v(fes);
 
     Problem problem(u, v);
-    problem = Integral(u, v)
-            + DirichletBC(u, RealFunction(0.0))
-            + DirichletBC(u, RealFunction(2.0) * u);
+    problem = Integral(u, v) + DirichletBC(u, RealFunction(0.0)) +
+      DirichletBC(u, RealFunction(2.0) * u);
 
     EXPECT_THROW(problem.assemble(), Alert::Exception);
   }
@@ -1049,17 +1010,8 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates Assembly Sequential All Geometries over the All Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    AllGeometries,
-    Assembly_Sequential_AllGeometries,
-    ::testing::Values(
-      Polytope::Type::Segment,
-      Polytope::Type::Triangle,
-      Polytope::Type::Quadrilateral,
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge
-    )
-  );
+  INSTANTIATE_TEST_SUITE_P(AllGeometries, Assembly_Sequential_AllGeometries,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge));
 }

--- a/tests/unit/Rodin/Geometry/ConnectivityTest.cpp
+++ b/tests/unit/Rodin/Geometry/ConnectivityTest.cpp
@@ -291,9 +291,8 @@ namespace Rodin::Tests::Unit
     constexpr const size_t nodes = 5;
 
     Connectivity<Context::Local> connectivity;
-    connectivity.initialize(meshDim)
-                .nodes(nodes)
-                .polytope(Polytope::Type::Pyramid, {0, 1, 2, 3, 4});
+    connectivity.initialize(meshDim).nodes(nodes).polytope(
+      Polytope::Type::Pyramid, {0, 1, 2, 3, 4});
 
     EXPECT_EQ(connectivity.getDimension(), 3);
 

--- a/tests/unit/Rodin/Geometry/PolytopeQuadratureIndexTest.cpp
+++ b/tests/unit/Rodin/Geometry/PolytopeQuadratureIndexTest.cpp
@@ -145,9 +145,7 @@ namespace Rodin::Tests::Unit
     const auto& quadrature = moved.getQuadrature(2, 0, qf);
     const auto& point = quadrature.getPoint(0);
 
-    EXPECT_EQ(
-      &point.getPolytope().getMesh(),
-      &static_cast<const MeshBase&>(moved));
+    EXPECT_EQ(&point.getPolytope().getMesh(), &static_cast<const MeshBase&>(moved));
   }
 
   /// @brief Verifies mesh move assignment drops stale entries for geometry polytope quadrature index by checking exact expected values, move semantics.
@@ -163,9 +161,7 @@ namespace Rodin::Tests::Unit
     const auto& quadrature = moved.getQuadrature(2, 0, qf);
     const auto& point = quadrature.getPoint(0);
 
-    EXPECT_EQ(
-      &point.getPolytope().getMesh(),
-      &static_cast<const MeshBase&>(moved));
+    EXPECT_EQ(&point.getPolytope().getMesh(), &static_cast<const MeshBase&>(moved));
   }
 
   /// @brief Verifies throws on invalid dimension for geometry polytope quadrature index by checking exception behavior.

--- a/tests/unit/Rodin/Geometry/SharderTest.cpp
+++ b/tests/unit/Rodin/Geometry/SharderTest.cpp
@@ -1242,10 +1242,8 @@ namespace Rodin::Tests::Unit
   TEST(Rodin_Geometry_Sharder, AllUniformGrid3D_MultiplePartitions)
   {
     // Test all 3D uniform grid types with multiple partition counts
-    for (Polytope::Type type : { Polytope::Type::Tetrahedron,
-                                  Polytope::Type::Hexahedron,
-                                  Polytope::Type::Pyramid,
-                                  Polytope::Type::Wedge })
+    for (Polytope::Type type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       auto mesh = makeShardableMesh(type, {3, 3, 3});
       const size_t D = mesh.getDimension();

--- a/tests/unit/Rodin/Geometry/UniformGridTest.cpp
+++ b/tests/unit/Rodin/Geometry/UniformGridTest.cpp
@@ -60,7 +60,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies pyramid one brick for geometry mesh uniform grid by checking exact expected values.
   TEST(Rodin_Geometry_Mesh_UniformGrid, Pyramid_OneBrick)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, { 2, 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, {2, 2, 2});
 
     EXPECT_EQ(mesh.getVertexCount(), 9);
     EXPECT_EQ(mesh.getCellCount(), 6);

--- a/tests/unit/Rodin/Heart/CCMLC2014Test.cpp
+++ b/tests/unit/Rodin/Heart/CCMLC2014Test.cpp
@@ -118,11 +118,16 @@ namespace
     const Real T = 0.85;
     const Real tau = t - T * std::floor(t / T);
 
-    if (tau < 0.13)  return 0.0;
-    if (tau < 0.141) return 35.0 * ((tau - 0.13) / 0.011);
-    if (tau < 0.281) return 35.0;
-    if (tau < 0.361) return 35.0 - 55.0 * ((tau - 0.281) / 0.08);
-    if (tau < 0.45)  return -20.0;
+    if (tau < 0.13)
+      return 0.0;
+    if (tau < 0.141)
+      return 35.0 * ((tau - 0.13) / 0.011);
+    if (tau < 0.281)
+      return 35.0;
+    if (tau < 0.361)
+      return 35.0 - 55.0 * ((tau - 0.281) / 0.08);
+    if (tau < 0.45)
+      return -20.0;
     return 0.0;
   }
 
@@ -239,7 +244,7 @@ namespace
       Heart::CCMLC2014::Model::WindkesselRheology::CarreauYasuda;
 
     cardiacInput.Kat = 9.0e-6;
-    cardiacInput.Kp  = 5.0e-10;
+    cardiacInput.Kp = 5.0e-10;
     cardiacInput.Kar = 1.3e-5;
 
     cardiacInput.cavityCapacity = 5.0e-12;
@@ -281,10 +286,8 @@ namespace
     initialState.par = 11000.0;
     initialState.pd = 10000.0;
     initialState.ec = cardiacInput.initFibDef;
-    initialState.gamma =
-      std::sqrt(std::max<Real>(cardiacInput.initActiveStiffness, 0.0));
-    initialState.beta =
-      (initialState.gamma > 0.0)
+    initialState.gamma = std::sqrt(std::max<Real>(cardiacInput.initActiveStiffness, 0.0));
+    initialState.beta = (initialState.gamma > 0.0)
       ? (cardiacInput.initActiveStress / initialState.gamma)
       : 0.0;
     initialState.kc = initialState.gamma * initialState.gamma;
@@ -463,10 +466,10 @@ TEST(CCMLC2014Test, ExampleSetupCompletesThreeCyclesWithPhysicalState)
   auto cardiacInput = makeExampleCardiacInput();
   Model model(cardiacInput);
   model.setMaxIterations(200)
-       .setAbsoluteTolerance(1e-8)
-       .setRelativeTolerance(1e-8)
-       .setStepTolerance(1e-10)
-       .setDampingFactor(1.0);
+    .setAbsoluteTolerance(1e-8)
+    .setRelativeTolerance(1e-8)
+    .setStepTolerance(1e-10)
+    .setDampingFactor(1.0);
 
   model.initialize(makeExampleInitialState(cardiacInput));
 
@@ -479,8 +482,7 @@ TEST(CCMLC2014Test, ExampleSetupCompletesThreeCyclesWithPhysicalState)
   {
     const auto report = model.step(dt);
     ASSERT_TRUE(report.converged)
-      << "Example setup failed at step " << step
-      << ", t = " << model.getState().t
+      << "Example setup failed at step " << step << ", t = " << model.getState().t
       << ", residual = " << report.finalResidual;
     maxFinalResidual = std::max(maxFinalResidual, report.finalResidual);
     maxIterations = std::max(maxIterations, report.iterations);
@@ -509,10 +511,10 @@ TEST(CCMLC2014Test, ExampleSetupEvolvesWindkesselAndRelaxationStates)
   auto cardiacInput = makeExampleCardiacInput();
   Model model(cardiacInput);
   model.setMaxIterations(200)
-       .setAbsoluteTolerance(1e-8)
-       .setRelativeTolerance(1e-8)
-       .setStepTolerance(1e-10)
-       .setDampingFactor(1.0);
+    .setAbsoluteTolerance(1e-8)
+    .setRelativeTolerance(1e-8)
+    .setStepTolerance(1e-10)
+    .setDampingFactor(1.0);
 
   const auto initialState = makeExampleInitialState(cardiacInput);
   model.initialize(initialState);
@@ -559,18 +561,18 @@ TEST(CCMLC2014Test, NonNewtonianExampleTrajectoryDiffersFromNewtonian)
 
   Model nonNewtonianModel(nonNewtonianInput);
   nonNewtonianModel.setMaxIterations(200)
-                   .setAbsoluteTolerance(1e-8)
-                   .setRelativeTolerance(1e-8)
-                   .setStepTolerance(1e-10)
-                   .setDampingFactor(1.0);
+    .setAbsoluteTolerance(1e-8)
+    .setRelativeTolerance(1e-8)
+    .setStepTolerance(1e-10)
+    .setDampingFactor(1.0);
   nonNewtonianModel.initialize(makeExampleInitialState(nonNewtonianInput));
 
   Model newtonianModel(newtonianInput);
   newtonianModel.setMaxIterations(200)
-                .setAbsoluteTolerance(1e-8)
-                .setRelativeTolerance(1e-8)
-                .setStepTolerance(1e-10)
-                .setDampingFactor(1.0);
+    .setAbsoluteTolerance(1e-8)
+    .setRelativeTolerance(1e-8)
+    .setStepTolerance(1e-10)
+    .setDampingFactor(1.0);
   newtonianModel.initialize(makeExampleInitialState(newtonianInput));
 
   const Real dt = 1e-3;
@@ -579,18 +581,14 @@ TEST(CCMLC2014Test, NonNewtonianExampleTrajectoryDiffersFromNewtonian)
   {
     const auto nonNewtonianReport = nonNewtonianModel.step(dt);
     const auto newtonianReport = newtonianModel.step(dt);
-    ASSERT_TRUE(nonNewtonianReport.converged)
-      << "Non-Newtonian failed at step " << step;
-    ASSERT_TRUE(newtonianReport.converged)
-      << "Newtonian failed at step " << step;
+    ASSERT_TRUE(nonNewtonianReport.converged) << "Non-Newtonian failed at step " << step;
+    ASSERT_TRUE(newtonianReport.converged) << "Newtonian failed at step " << step;
   }
 
   EXPECT_GT(
-      std::abs(nonNewtonianModel.getState().par - newtonianModel.getState().par),
-      10.0);
+    std::abs(nonNewtonianModel.getState().par - newtonianModel.getState().par), 10.0);
   EXPECT_GT(
-      std::abs(nonNewtonianModel.getState().pd - newtonianModel.getState().pd),
-      10.0);
+    std::abs(nonNewtonianModel.getState().pd - newtonianModel.getState().pd), 10.0);
 }
 
 /// @brief Verifies load dependent relaxation accelerates negative activation decay for CCMLC 2014 test.
@@ -618,17 +616,16 @@ TEST(CCMLC2014Test, LoadDependentRelaxationAcceleratesNegativeActivationDecay)
   previousState.w = 1.0;
 
   using InputType = Model::Input;
-  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType>
-      baseSystem(baseInput);
-  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType>
-      relaxedSystem(relaxedInput);
+  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType> baseSystem(baseInput);
+  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType> relaxedSystem(
+    relaxedInput);
 
   Model::EvalData baseData;
   Model::EvalData relaxedData;
   baseSystem.buildEvalData(
-      baseCandidateState, currentState, previousState, currentState.t + dt, dt, baseData);
-  relaxedSystem.buildEvalData(
-      relaxedCandidateState, currentState, previousState, currentState.t + dt, dt, relaxedData);
+    baseCandidateState, currentState, previousState, currentState.t + dt, dt, baseData);
+  relaxedSystem.buildEvalData(relaxedCandidateState, currentState, previousState,
+    currentState.t + dt, dt, relaxedData);
 
   Model::DenseVector baseResidual;
   Model::DenseVector relaxedResidual;
@@ -637,9 +634,8 @@ TEST(CCMLC2014Test, LoadDependentRelaxationAcceleratesNegativeActivationDecay)
 
   EXPECT_GT(relaxedData.active.wCurrent, baseData.active.wCurrent);
   EXPECT_GT(relaxedData.active.relaxationDrive, baseData.active.relaxationDrive);
-  EXPECT_GT(
-      relaxedResidual[CCMLC2014Vars::ActiveStiffness],
-      baseResidual[CCMLC2014Vars::ActiveStiffness]);
+  EXPECT_GT(relaxedResidual[CCMLC2014Vars::ActiveStiffness],
+    baseResidual[CCMLC2014Vars::ActiveStiffness]);
 }
 
 /// @brief Verifies dynamic jacobian matches finite difference for CCMLC 2014 test.
@@ -676,15 +672,15 @@ TEST(CCMLC2014Test, WindkesselResidualAndJacobianUseBranchFlowsAndBDF2)
   previousState.pd = 7.8e3;
 
   using InputType = Model::Input;
-  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType>
-      dynamicSystem(cardiacInput);
+  Heart::CCMLC2014::Numerics::DynamicSystem<PassiveLaw, InputType> dynamicSystem(
+    cardiacInput);
 
   const Real dt = 1e-3;
   const Real nextTime = currentState.t + dt;
 
   Model::EvalData evaluationData;
   dynamicSystem.buildEvalData(
-      candidateState, currentState, previousState, nextTime, dt, evaluationData);
+    candidateState, currentState, previousState, nextTime, dt, evaluationData);
 
   Model::DenseVector residual;
   dynamicSystem.evaluateResidual(evaluationData, residual);
@@ -693,68 +689,40 @@ TEST(CCMLC2014Test, WindkesselResidualAndJacobianUseBranchFlowsAndBDF2)
   dynamicSystem.evaluateJacobian(evaluationData, jacobian, dt);
 
   const Real a0 = 1.5 / dt;
-  const Real parDot =
-      a0 * candidateState[CCMLC2014Vars::ArterialPressure]
-    - 2.0 / dt * currentState.par
-    + 0.5 / dt * previousState.par;
-  const Real pdDot =
-      a0 * candidateState[CCMLC2014Vars::DistalPressure]
-    - 2.0 / dt * currentState.pd
-    + 0.5 / dt * previousState.pd;
+  const Real parDot = a0 * candidateState[CCMLC2014Vars::ArterialPressure] -
+    2.0 / dt * currentState.par + 0.5 / dt * previousState.par;
+  const Real pdDot = a0 * candidateState[CCMLC2014Vars::DistalPressure] -
+    2.0 / dt * currentState.pd + 0.5 / dt * previousState.pd;
 
-  const Real expectedOutflow =
-    cardiacInput.Kar
-    * (candidateState[CCMLC2014Vars::VentricularPressure]
-       - candidateState[CCMLC2014Vars::ArterialPressure]);
-  const Real expectedProximalFlow =
-    (candidateState[CCMLC2014Vars::ArterialPressure]
-     - candidateState[CCMLC2014Vars::DistalPressure]) / cardiacInput.Rp
-    - expectedOutflow;
-  const Real expectedDistalFlow =
-    (candidateState[CCMLC2014Vars::DistalPressure]
-     - candidateState[CCMLC2014Vars::ArterialPressure]) / cardiacInput.Rp
-    - (cardiacInput.pSv(nextTime)
-       - candidateState[CCMLC2014Vars::DistalPressure]) / cardiacInput.Rd;
+  const Real expectedOutflow = cardiacInput.Kar *
+    (candidateState[CCMLC2014Vars::VentricularPressure] -
+      candidateState[CCMLC2014Vars::ArterialPressure]);
+  const Real expectedProximalFlow = (candidateState[CCMLC2014Vars::ArterialPressure] -
+                                      candidateState[CCMLC2014Vars::DistalPressure]) /
+      cardiacInput.Rp -
+    expectedOutflow;
+  const Real expectedDistalFlow = (candidateState[CCMLC2014Vars::DistalPressure] -
+                                    candidateState[CCMLC2014Vars::ArterialPressure]) /
+      cardiacInput.Rp -
+    (cardiacInput.pSv(nextTime) - candidateState[CCMLC2014Vars::DistalPressure]) /
+      cardiacInput.Rd;
 
-  EXPECT_NEAR(
-      residual[CCMLC2014Vars::ArterialPressure],
-      cardiacInput.Cp * parDot + expectedProximalFlow,
-      1e-13);
-  EXPECT_NEAR(
-      residual[CCMLC2014Vars::DistalPressure],
-      cardiacInput.Cd * pdDot + expectedDistalFlow,
-      1e-13);
+  EXPECT_NEAR(residual[CCMLC2014Vars::ArterialPressure],
+    cardiacInput.Cp * parDot + expectedProximalFlow, 1e-13);
+  EXPECT_NEAR(residual[CCMLC2014Vars::DistalPressure],
+    cardiacInput.Cd * pdDot + expectedDistalFlow, 1e-13);
 
   EXPECT_NEAR(
-      jacobian(
-        CCMLC2014Vars::ArterialPressure,
-        CCMLC2014Vars::VentricularPressure),
-      -cardiacInput.Kar,
-      1e-14);
-  EXPECT_NEAR(
-      jacobian(
-        CCMLC2014Vars::ArterialPressure,
-        CCMLC2014Vars::ArterialPressure),
-      cardiacInput.Cp * a0 + 1.0 / cardiacInput.Rp + cardiacInput.Kar,
-      1e-14);
-  EXPECT_NEAR(
-      jacobian(
-        CCMLC2014Vars::ArterialPressure,
-        CCMLC2014Vars::DistalPressure),
-      -1.0 / cardiacInput.Rp,
-      1e-14);
-  EXPECT_NEAR(
-      jacobian(
-        CCMLC2014Vars::DistalPressure,
-        CCMLC2014Vars::ArterialPressure),
-      -1.0 / cardiacInput.Rp,
-      1e-14);
-  EXPECT_NEAR(
-      jacobian(
-        CCMLC2014Vars::DistalPressure,
-        CCMLC2014Vars::DistalPressure),
-      cardiacInput.Cd * a0 + 1.0 / cardiacInput.Rp + 1.0 / cardiacInput.Rd,
-      1e-14);
+    jacobian(CCMLC2014Vars::ArterialPressure, CCMLC2014Vars::VentricularPressure),
+    -cardiacInput.Kar, 1e-14);
+  EXPECT_NEAR(jacobian(CCMLC2014Vars::ArterialPressure, CCMLC2014Vars::ArterialPressure),
+    cardiacInput.Cp * a0 + 1.0 / cardiacInput.Rp + cardiacInput.Kar, 1e-14);
+  EXPECT_NEAR(jacobian(CCMLC2014Vars::ArterialPressure, CCMLC2014Vars::DistalPressure),
+    -1.0 / cardiacInput.Rp, 1e-14);
+  EXPECT_NEAR(jacobian(CCMLC2014Vars::DistalPressure, CCMLC2014Vars::ArterialPressure),
+    -1.0 / cardiacInput.Rp, 1e-14);
+  EXPECT_NEAR(jacobian(CCMLC2014Vars::DistalPressure, CCMLC2014Vars::DistalPressure),
+    cardiacInput.Cd * a0 + 1.0 / cardiacInput.Rp + 1.0 / cardiacInput.Rd, 1e-14);
 }
 
 /// @brief Verifies non newtonian windkessel path produces finite consistent jacobian for CCMLC 2014 test by checking true predicates.
@@ -782,12 +750,7 @@ TEST(CCMLC2014Test, NonNewtonianWindkesselPathProducesFiniteConsistentJacobian)
   Model::State previousState = makePreviousState(currentState);
 
   const Real relativeError = computeDynamicJacobianRelativeError(
-      cardiacInput,
-      candidateState,
-      currentState,
-      previousState,
-      1e-3,
-      1e-7);
+    cardiacInput, candidateState, currentState, previousState, 1e-3, 1e-7);
   EXPECT_TRUE(std::isfinite(relativeError));
   EXPECT_LT(relativeError, 3e-3);
 }

--- a/tests/unit/Rodin/IO/H1GridFunctionIOTest.cpp
+++ b/tests/unit/Rodin/IO/H1GridFunctionIOTest.cpp
@@ -251,18 +251,23 @@ namespace Rodin::Tests::Unit
 
     Mesh<Context::Local> makeUniform3DMeshForH1RoundTrip(Polytope::Type geometry)
     {
-      return LocalMesh::UniformGrid(geometry, { 3, 3, 3 });
+      return LocalMesh::UniformGrid(geometry, {3, 3, 3});
     }
 
     std::string geometryName(Polytope::Type geometry)
     {
       switch (geometry)
       {
-        case Polytope::Type::Tetrahedron: return "Tetrahedron";
-        case Polytope::Type::Hexahedron:  return "Hexahedron";
-        case Polytope::Type::Pyramid:     return "Pyramid";
-        case Polytope::Type::Wedge:       return "Wedge";
-        default:                          return "Unknown";
+        case Polytope::Type::Tetrahedron:
+          return "Tetrahedron";
+        case Polytope::Type::Hexahedron:
+          return "Hexahedron";
+        case Polytope::Type::Pyramid:
+          return "Pyramid";
+        case Polytope::Type::Wedge:
+          return "Wedge";
+        default:
+          return "Unknown";
       }
     }
 
@@ -1440,8 +1445,7 @@ namespace Rodin::Tests::Unit
     H1 fes(std::integral_constant<size_t, 2>{}, mesh);
     GridFunction gf(fes);
 
-    RealFunction func([](const Geometry::Point& p)
-    {
+    RealFunction func([](const Geometry::Point& p) {
       return p.x() * p.x() + p.y() * p.y() + p.z() * p.z();
     });
     gf.project(func);
@@ -1460,7 +1464,8 @@ namespace Rodin::Tests::Unit
     ss.seekg(0);
 
     GridFunction gf_loaded(fes);
-    GridFunctionLoader<FileFormat::MFEM, H1<2, Real>, Math::Vector<Real>> loader(gf_loaded);
+    GridFunctionLoader<FileFormat::MFEM, H1<2, Real>, Math::Vector<Real>> loader(
+      gf_loaded);
     loader.load(ss);
 
     ASSERT_EQ(gf.getSize(), gf_loaded.getSize());
@@ -1469,16 +1474,10 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates H1 Degree 2 Round Trip 3 D Geometry Coverage over the All 3 D Polytopes parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-    All3DPolytopes,
-    H1Degree2RoundTrip3DGeometryCoverage,
-    ::testing::Values(
-      Polytope::Type::Tetrahedron,
-      Polytope::Type::Hexahedron,
-      Polytope::Type::Pyramid,
-      Polytope::Type::Wedge),
-    [](const ::testing::TestParamInfo<Polytope::Type>& info)
-    {
+  INSTANTIATE_TEST_SUITE_P(All3DPolytopes, H1Degree2RoundTrip3DGeometryCoverage,
+    ::testing::Values(Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+      Polytope::Type::Pyramid, Polytope::Type::Wedge),
+    [](const ::testing::TestParamInfo<Polytope::Type>& info) {
       return geometryName(info.param);
     });
 

--- a/tests/unit/Rodin/IO/HDF5IOTest.cpp
+++ b/tests/unit/Rodin/IO/HDF5IOTest.cpp
@@ -936,7 +936,8 @@ namespace
       case Polytope::Type::Triangle:      return "Triangle2D";
       case Polytope::Type::Quadrilateral: return "Quad2D";
       case Polytope::Type::Tetrahedron:   return "Tet3D";
-      case Polytope::Type::Pyramid:       return "Pyramid3D";
+      case Polytope::Type::Pyramid:
+        return "Pyramid3D";
       case Polytope::Type::Hexahedron:    return "Hex3D";
       case Polytope::Type::Wedge:         return "Wedge3D";
       default:                            return "Unknown";
@@ -1420,20 +1421,17 @@ namespace
   };
 
   // Instantiate parameterized tests for 1D, 2D, and 3D polytope types
-  INSTANTIATE_TEST_SUITE_P(
-      AllDimensions,
-      HDF5MultiDim,
-      ::testing::Values(
-          Polytope::Type::Segment,       // 1D
-          Polytope::Type::Point,         // 0D
-          Polytope::Type::Triangle,      // 2D
-          Polytope::Type::Quadrilateral, // 2D
-          Polytope::Type::Tetrahedron,   // 3D
-          Polytope::Type::Pyramid,       // 3D
-          Polytope::Type::Hexahedron,    // 3D
-          Polytope::Type::Wedge          // 3D
+  INSTANTIATE_TEST_SUITE_P(AllDimensions, HDF5MultiDim,
+    ::testing::Values(Polytope::Type::Segment, // 1D
+      Polytope::Type::Point, // 0D
+      Polytope::Type::Triangle, // 2D
+      Polytope::Type::Quadrilateral, // 2D
+      Polytope::Type::Tetrahedron, // 3D
+      Polytope::Type::Pyramid, // 3D
+      Polytope::Type::Hexahedron, // 3D
+      Polytope::Type::Wedge // 3D
       ),
-      PolytopeNameGenerator());
+    PolytopeNameGenerator());
 
   INSTANTIATE_TEST_SUITE_P(Dimensions, HDF5AttributeRegression,
     ::testing::Values(1, 2, 3), [](const ::testing::TestParamInfo<size_t>& info) {

--- a/tests/unit/Rodin/IO/MeshLoaderTest.cpp
+++ b/tests/unit/Rodin/IO/MeshLoaderTest.cpp
@@ -121,7 +121,8 @@ namespace Rodin::Tests::Unit
         case Polytope::Type::Triangle:      return "Triangle";
         case Polytope::Type::Quadrilateral: return "Quadrilateral";
         case Polytope::Type::Tetrahedron:   return "Tetrahedron";
-        case Polytope::Type::Pyramid:       return "Pyramid";
+        case Polytope::Type::Pyramid:
+          return "Pyramid";
         case Polytope::Type::Hexahedron:    return "Hexahedron";
         case Polytope::Type::Wedge:         return "Wedge";
       }
@@ -340,22 +341,14 @@ namespace Rodin::Tests::Unit
     });
 
   /// @brief Instantiates Mesh Format Coverage over the All Supported Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-      AllSupportedGeometries,
-      MeshFormatCoverage,
-      ::testing::Values(
-        Polytope::Type::Point,
-        Polytope::Type::Segment,
-        Polytope::Type::Triangle,
-        Polytope::Type::Quadrilateral,
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Wedge),
-      [](const ::testing::TestParamInfo<Polytope::Type>& info)
-      {
-        return geometryName(info.param);
-      });
+  INSTANTIATE_TEST_SUITE_P(AllSupportedGeometries, MeshFormatCoverage,
+    ::testing::Values(Polytope::Type::Point, Polytope::Type::Segment,
+      Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Hexahedron,
+      Polytope::Type::Wedge),
+    [](const ::testing::TestParamInfo<Polytope::Type>& info) {
+      return geometryName(info.param);
+    });
 
   /// @brief Verifies sanity test MEDIT 2 D square for IO mesh loader by checking exact expected values.
   TEST(Rodin_IO_MeshLoader, SanityTest_MEDIT_2D_Square)

--- a/tests/unit/Rodin/IO/P0GridFunctionIOTest.cpp
+++ b/tests/unit/Rodin/IO/P0GridFunctionIOTest.cpp
@@ -61,7 +61,8 @@ namespace Rodin::Tests::Unit
         case Polytope::Type::Triangle:      return "Triangle";
         case Polytope::Type::Quadrilateral: return "Quadrilateral";
         case Polytope::Type::Tetrahedron:   return "Tetrahedron";
-        case Polytope::Type::Pyramid:       return "Pyramid";
+        case Polytope::Type::Pyramid:
+          return "Pyramid";
         case Polytope::Type::Hexahedron:    return "Hexahedron";
         case Polytope::Type::Wedge:         return "Wedge";
       }
@@ -96,22 +97,14 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates P0 MFEM Grid Function Coverage over the All Supported Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-      AllSupportedGeometries,
-      P0MFEMGridFunctionCoverage,
-      ::testing::Values(
-        Polytope::Type::Point,
-        Polytope::Type::Segment,
-        Polytope::Type::Triangle,
-        Polytope::Type::Quadrilateral,
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Wedge),
-      [](const ::testing::TestParamInfo<Polytope::Type>& info)
-      {
-        return geometryName(info.param);
-      });
+  INSTANTIATE_TEST_SUITE_P(AllSupportedGeometries, P0MFEMGridFunctionCoverage,
+    ::testing::Values(Polytope::Type::Point, Polytope::Type::Segment,
+      Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Hexahedron,
+      Polytope::Type::Wedge),
+    [](const ::testing::TestParamInfo<Polytope::Type>& info) {
+      return geometryName(info.param);
+    });
 
   /// @brief Verifies scalar multiline load for IO MFEM P0 grid function by checking tolerance-based numerical results.
   TEST(Rodin_IO_MFEM_P0_GridFunction, ScalarMultilineLoad)

--- a/tests/unit/Rodin/IO/P1GridFunctionIOTest.cpp
+++ b/tests/unit/Rodin/IO/P1GridFunctionIOTest.cpp
@@ -206,7 +206,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies save load round trip pyramid for IO MFEM P1 grid function by checking tolerance-based numerical results, exact expected values, grid-function projection.
   TEST(Rodin_IO_MFEM_P1_GridFunction, SaveLoadRoundTrip_Pyramid)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, { 3, 3, 3 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, {3, 3, 3});
 
     mesh.getConnectivity().compute(3, 2);
     mesh.getConnectivity().compute(2, 1);
@@ -217,9 +217,8 @@ namespace Rodin::Tests::Unit
     P1 fes(mesh);
     GridFunction gf(fes);
 
-    RealFunction func([](const Geometry::Point& p) {
-      return p.x() + 2.0 * p.y() + 3.0 * p.z();
-    });
+    RealFunction func(
+      [](const Geometry::Point& p) { return p.x() + 2.0 * p.y() + 3.0 * p.z(); });
     gf.project(func);
 
     std::stringstream ss;
@@ -449,7 +448,8 @@ namespace Rodin::Tests::Unit
         case Polytope::Type::Triangle:      return "Triangle";
         case Polytope::Type::Quadrilateral: return "Quadrilateral";
         case Polytope::Type::Tetrahedron:   return "Tetrahedron";
-        case Polytope::Type::Pyramid:       return "Pyramid";
+        case Polytope::Type::Pyramid:
+          return "Pyramid";
         case Polytope::Type::Hexahedron:    return "Hexahedron";
         case Polytope::Type::Wedge:         return "Wedge";
       }
@@ -484,22 +484,14 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Instantiates P1 MEDIT Grid Function Coverage over the All Supported Geometries parameter coverage.
-  INSTANTIATE_TEST_SUITE_P(
-      AllSupportedGeometries,
-      P1MEDITGridFunctionCoverage,
-      ::testing::Values(
-        Polytope::Type::Point,
-        Polytope::Type::Segment,
-        Polytope::Type::Triangle,
-        Polytope::Type::Quadrilateral,
-        Polytope::Type::Tetrahedron,
-        Polytope::Type::Pyramid,
-        Polytope::Type::Hexahedron,
-        Polytope::Type::Wedge),
-      [](const ::testing::TestParamInfo<Polytope::Type>& info)
-      {
-        return meditGeometryName(info.param);
-      });
+  INSTANTIATE_TEST_SUITE_P(AllSupportedGeometries, P1MEDITGridFunctionCoverage,
+    ::testing::Values(Polytope::Type::Point, Polytope::Type::Segment,
+      Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Hexahedron,
+      Polytope::Type::Wedge),
+    [](const ::testing::TestParamInfo<Polytope::Type>& info) {
+      return meditGeometryName(info.param);
+    });
 
   /// @brief Verifies vector 3 D round trip for IO MEDIT P1 grid function by checking tolerance-based numerical results, exact expected values.
   TEST(Rodin_IO_MEDIT_P1_GridFunction, Vector3DRoundTrip)

--- a/tests/unit/Rodin/MPI/Assembly/MPIAssemblyTest.cpp
+++ b/tests/unit/Rodin/MPI/Assembly/MPIAssemblyTest.cpp
@@ -88,11 +88,16 @@ namespace
   {
     switch (type)
     {
-      case Polytope::Type::Tetrahedron: return "Tetrahedron";
-      case Polytope::Type::Hexahedron:  return "Hexahedron";
-      case Polytope::Type::Pyramid:     return "Pyramid";
-      case Polytope::Type::Wedge:       return "Wedge";
-      default:                          return "Other";
+      case Polytope::Type::Tetrahedron:
+        return "Tetrahedron";
+      case Polytope::Type::Hexahedron:
+        return "Hexahedron";
+      case Polytope::Type::Pyramid:
+        return "Pyramid";
+      case Polytope::Type::Wedge:
+        return "Wedge";
+      default:
+        return "Other";
     }
   }
 }
@@ -266,8 +271,7 @@ namespace Rodin::Tests::Unit
     DirichletBC dbc(u, RealFunction(gValue));
     dbc.assemble();
 
-    for (const auto& [local, value]
-           : std::get<IndexMap<Real>>(dbc.getDOFs()))
+    for (const auto& [local, value] : std::get<IndexMap<Real>>(dbc.getDOFs()))
       EXPECT_NEAR(value, gValue, 1e-12);
   }
 
@@ -342,14 +346,11 @@ namespace Rodin::Tests::Unit
       GTEST_SKIP() << "Test designed for at most 3 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
-      auto mpiMesh = distributeFromRoot(ctx, type, { 4, 3, 3 });
+      auto mpiMesh = distributeFromRoot(ctx, type, {4, 3, 3});
 
       size_t localCount = 0;
       Assembly::MPIIteration iter(mpiMesh, Geometry::Region::Cells);
@@ -394,8 +395,7 @@ namespace Rodin::Tests::Unit
       EXPECT_GT(globalFixed, 0u);
     }
 
-    for (const auto& [local, value]
-           : std::get<IndexMap<Real>>(dbc.getDOFs()))
+    for (const auto& [local, value] : std::get<IndexMap<Real>>(dbc.getDOFs()))
       EXPECT_NEAR(value, gValue, 1e-12);
   }
 
@@ -410,15 +410,12 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
 
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
 
-      auto mpiMesh = distributeFromRoot(ctx, type, { 4, 3, 3 });
+      auto mpiMesh = distributeFromRoot(ctx, type, {4, 3, 3});
 
       P1<Real, Mesh<Context::MPI>> fes(mpiMesh);
       TrialFunction u(fes);
@@ -426,16 +423,10 @@ namespace Rodin::Tests::Unit
       DirichletBC dbc(u, RealFunction(1.0));
       dbc.assemble();
 
-      const size_t localFixed =
-        std::get<IndexMap<Real>>(dbc.getDOFs()).size();
+      const size_t localFixed = std::get<IndexMap<Real>>(dbc.getDOFs()).size();
 
       size_t globalFixed = 0;
-      boost::mpi::reduce(
-          world,
-          localFixed,
-          globalFixed,
-          std::plus<size_t>(),
-          0);
+      boost::mpi::reduce(world, localFixed, globalFixed, std::plus<size_t>(), 0);
 
       if (world.rank() == 0)
       {

--- a/tests/unit/Rodin/MPI/Geometry/SharderTest.cpp
+++ b/tests/unit/Rodin/MPI/Geometry/SharderTest.cpp
@@ -1581,35 +1581,27 @@ namespace Rodin::Tests::Unit
       Mesh<Context::MPI>::UniformGrid(ctx, Polytope::Type::Pyramid, {4, 3, 3});
 
     EXPECT_EQ(mpiMesh.getDimension(), 3u)
-      << "Rank " << world.rank()
-      << ": Pyramid UniformGrid dimension should be 3.";
+      << "Rank " << world.rank() << ": Pyramid UniformGrid dimension should be 3.";
     EXPECT_EQ(mpiMesh.getSpaceDimension(), 3u)
-      << "Rank " << world.rank()
-      << ": Pyramid UniformGrid space dimension should be 3.";
+      << "Rank " << world.rank() << ": Pyramid UniformGrid space dimension should be 3.";
 
     const auto refMesh =
       Mesh<Context::Local>::UniformGrid(Polytope::Type::Pyramid, {4, 3, 3});
     const size_t D = 3;
 
     EXPECT_EQ(mpiMesh.getPolytopeCount(D), refMesh.getPolytopeCount(D))
-      << "Rank " << world.rank()
-      << ": Pyramid UniformGrid global cell count mismatch.";
+      << "Rank " << world.rank() << ": Pyramid UniformGrid global cell count mismatch.";
     EXPECT_EQ(mpiMesh.getPolytopeCount(Polytope::Type::Pyramid),
-              refMesh.getPolytopeCount(Polytope::Type::Pyramid))
-      << "Rank " << world.rank()
-      << ": Pyramid UniformGrid geometry count mismatch.";
+      refMesh.getPolytopeCount(Polytope::Type::Pyramid))
+      << "Rank " << world.rank() << ": Pyramid UniformGrid geometry count mismatch.";
     EXPECT_EQ(mpiMesh.getPolytopeCount(0), refMesh.getPolytopeCount(0))
-      << "Rank " << world.rank()
-      << ": Pyramid UniformGrid global vertex count mismatch.";
+      << "Rank " << world.rank() << ": Pyramid UniformGrid global vertex count mismatch.";
 
     const auto& shard = mpiMesh.getShard();
-    for (Index i = 0;
-         i < static_cast<Index>(shard.getPolytopeCount(D));
-         ++i)
+    for (Index i = 0; i < static_cast<Index>(shard.getPolytopeCount(D)); ++i)
     {
       EXPECT_EQ(shard.getGeometry(D, i), Polytope::Type::Pyramid)
-        << "Rank " << world.rank() << " cell " << i
-        << ": expected Pyramid geometry.";
+        << "Rank " << world.rank() << " cell " << i << ": expected Pyramid geometry.";
     }
   }
 

--- a/tests/unit/Rodin/MPI/Geometry/SubMeshTest.cpp
+++ b/tests/unit/Rodin/MPI/Geometry/SubMeshTest.cpp
@@ -39,13 +39,13 @@
 using namespace Rodin;
 using namespace Rodin::Geometry;
 
-static boost::mpi::environment*  g_env   = nullptr;
+static boost::mpi::environment* g_env = nullptr;
 static boost::mpi::communicator* g_world = nullptr;
 
 namespace
 {
   Mesh<Context::Local> makeShardableMesh(
-      Polytope::Type type, std::initializer_list<size_t> shape)
+    Polytope::Type type, std::initializer_list<size_t> shape)
   {
     auto mesh = Mesh<Context::Local>::UniformGrid(type, shape);
     const size_t D = mesh.getDimension();
@@ -58,9 +58,7 @@ namespace
   }
 
   Mesh<Context::MPI> distributeFromRoot(
-      const Context::MPI& ctx,
-      Polytope::Type type,
-      std::initializer_list<size_t> shape)
+    const Context::MPI& ctx, Polytope::Type type, std::initializer_list<size_t> shape)
   {
     const auto& comm = ctx.getCommunicator();
 
@@ -294,7 +292,7 @@ TEST(MPI_Geometry_SubMesh, CellSubmeshByDimension)
   // The global cell count of the submesh should equal the global cell count
   // of the parent mesh.
   const size_t parentGlobalCells = mesh.getPolytopeCount(cellDim);
-  const size_t subGlobalCells    = sub.getPolytopeCount(cellDim);
+  const size_t subGlobalCells = sub.getPolytopeCount(cellDim);
   EXPECT_EQ(subGlobalCells, parentGlobalCells);
 }
 
@@ -388,8 +386,8 @@ TEST(MPI_Geometry_SubMesh, RestrictionOfParentQuadraturePoint)
 
   const Index subLocal = 0;
   const Index parentLocal = pmap.left.at(subLocal);
-  const auto& qf = QF::PolytopeQuadratureFormula::get(
-      1, mesh.getGeometry(faceDim, parentLocal));
+  const auto& qf =
+    QF::PolytopeQuadratureFormula::get(1, mesh.getGeometry(faceDim, parentLocal));
   const auto& parentQ = mesh.getQuadrature(faceDim, parentLocal, qf);
   ASSERT_GT(parentQ.getSize(), 0u);
 
@@ -423,7 +421,8 @@ TEST(MPI_Geometry_SubMesh, RestrictionRejectsParentCellPointOnBoundarySubMesh)
   Point parentCellPoint(*mesh.getPolytope(cellDim, 0), refCoords);
 
   EXPECT_FALSE(boundary.restriction(parentCellPoint).has_value())
-    << "Boundary SubMesh should reject parent cell points outside its selected dimension.";
+    << "Boundary SubMesh should reject parent cell points outside its selected "
+       "dimension.";
 }
 
 /// @brief Verifies quadrature points use MPI parent mesh identity for MPI geometry sub mesh by checking exact expected values, true predicates, false predicates.
@@ -438,8 +437,7 @@ TEST(MPI_Geometry_SubMesh, QuadraturePointsUseMPIParentMeshIdentity)
     return;
 
   const Index localIdx = 0;
-  const auto& qf = QF::PolytopeQuadratureFormula::get(
-      1, mesh.getGeometry(d, localIdx));
+  const auto& qf = QF::PolytopeQuadratureFormula::get(1, mesh.getGeometry(d, localIdx));
   const auto& q = mesh.getQuadrature(d, localIdx, qf);
   ASSERT_GT(q.getSize(), 0u);
 
@@ -474,15 +472,15 @@ TEST(MPI_Geometry_SubMesh, QuadraturePointsUseMPISubMeshIdentity)
     return;
 
   const Index localIdx = 0;
-  const auto& qf = QF::PolytopeQuadratureFormula::get(
-      1, boundary.getGeometry(d, localIdx));
+  const auto& qf =
+    QF::PolytopeQuadratureFormula::get(1, boundary.getGeometry(d, localIdx));
   const auto& q = boundary.getQuadrature(d, localIdx, qf);
   ASSERT_GT(q.getSize(), 0u);
 
   const Point& p = q.getPoint(0);
   const MeshBase& pointMesh = p.getPolytope().getMesh();
   const MeshBase& submeshIdentity =
-      static_cast<const MeshBase&>(static_cast<const Mesh<Context::MPI>&>(boundary));
+    static_cast<const MeshBase&>(static_cast<const Mesh<Context::MPI>&>(boundary));
   const MeshBase& shardMesh = static_cast<const MeshBase&>(boundary.getShard());
 
   EXPECT_TRUE(pointMesh == submeshIdentity);
@@ -513,10 +511,10 @@ TEST(MPI_Geometry_SubMesh, QuadratureCacheSeparatesParentAndSubMeshIdentities)
   const Index subLocalIdx = 0;
   const Index parentLocalIdx = boundary.getPolytopeMap(d).left.at(subLocalIdx);
 
-  const auto& parentQF = QF::PolytopeQuadratureFormula::get(
-      1, mesh.getGeometry(d, parentLocalIdx));
-  const auto& subQF = QF::PolytopeQuadratureFormula::get(
-      1, boundary.getGeometry(d, subLocalIdx));
+  const auto& parentQF =
+    QF::PolytopeQuadratureFormula::get(1, mesh.getGeometry(d, parentLocalIdx));
+  const auto& subQF =
+    QF::PolytopeQuadratureFormula::get(1, boundary.getGeometry(d, subLocalIdx));
 
   const auto& parentQ = mesh.getQuadrature(d, parentLocalIdx, parentQF);
   const auto& subQ = boundary.getQuadrature(d, subLocalIdx, subQF);
@@ -525,7 +523,7 @@ TEST(MPI_Geometry_SubMesh, QuadratureCacheSeparatesParentAndSubMeshIdentities)
 
   const MeshBase& parentIdentity = static_cast<const MeshBase&>(mesh);
   const MeshBase& submeshIdentity =
-      static_cast<const MeshBase&>(static_cast<const Mesh<Context::MPI>&>(boundary));
+    static_cast<const MeshBase&>(static_cast<const Mesh<Context::MPI>&>(boundary));
 
   EXPECT_TRUE(parentQ.getPoint(0).getPolytope().getMesh() == parentIdentity);
   EXPECT_EQ(parentQ.getPoint(0).getPolytope().getIndex(), parentLocalIdx);
@@ -543,7 +541,7 @@ int main(int argc, char** argv)
 
   boost::mpi::environment env(argc, argv);
   boost::mpi::communicator world;
-  g_env   = &env;
+  g_env = &env;
   g_world = &world;
 
   return RUN_ALL_TESTS();

--- a/tests/unit/Rodin/MPI/IO/HDF5IOTest.cpp
+++ b/tests/unit/Rodin/MPI/IO/HDF5IOTest.cpp
@@ -59,7 +59,8 @@ namespace
       case Polytope::Type::Quadrilateral: return "Quad2D";
       case Polytope::Type::Tetrahedron:   return "Tet3D";
       case Polytope::Type::Hexahedron:    return "Hex3D";
-      case Polytope::Type::Pyramid:       return "Pyramid3D";
+      case Polytope::Type::Pyramid:
+        return "Pyramid3D";
       case Polytope::Type::Wedge:         return "Wedge3D";
       default:                            return "Unknown";
     }
@@ -420,19 +421,11 @@ namespace
     }
   };
 
-  INSTANTIATE_TEST_SUITE_P(
-      AllDimensions,
-      MPIMeshHDF5,
-      ::testing::Values(
-          Polytope::Type::Segment,
-          Polytope::Type::Triangle,
-          Polytope::Type::Quadrilateral,
-          Polytope::Type::Tetrahedron,
-          Polytope::Type::Hexahedron,
-          Polytope::Type::Pyramid,
-          Polytope::Type::Wedge
-      ),
-      MPIPolytopeNameGenerator());
+  INSTANTIATE_TEST_SUITE_P(AllDimensions, MPIMeshHDF5,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge),
+    MPIPolytopeNameGenerator());
 
   // ===========================================================================
   // Distributed XDMF tests using MPI_COMM_SELF (single-rank distributed mode)
@@ -536,19 +529,11 @@ namespace
     boost::filesystem::remove_all(testDir);
   }
 
-  INSTANTIATE_TEST_SUITE_P(
-      AllDimensions,
-      MPIDistributedXDMF,
-      ::testing::Values(
-          Polytope::Type::Segment,
-          Polytope::Type::Triangle,
-          Polytope::Type::Quadrilateral,
-          Polytope::Type::Tetrahedron,
-          Polytope::Type::Hexahedron,
-          Polytope::Type::Pyramid,
-          Polytope::Type::Wedge
-      ),
-      MPIPolytopeNameGenerator());
+  INSTANTIATE_TEST_SUITE_P(AllDimensions, MPIDistributedXDMF,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge),
+    MPIPolytopeNameGenerator());
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/Rodin/MPI/Variational/P0Test.cpp
+++ b/tests/unit/Rodin/MPI/Variational/P0Test.cpp
@@ -94,11 +94,16 @@ namespace
   {
     switch (type)
     {
-      case Polytope::Type::Tetrahedron: return "Tetrahedron";
-      case Polytope::Type::Hexahedron:  return "Hexahedron";
-      case Polytope::Type::Pyramid:     return "Pyramid";
-      case Polytope::Type::Wedge:       return "Wedge";
-      default:                          return "Other";
+      case Polytope::Type::Tetrahedron:
+        return "Tetrahedron";
+      case Polytope::Type::Hexahedron:
+        return "Hexahedron";
+      case Polytope::Type::Pyramid:
+        return "Pyramid";
+      case Polytope::Type::Wedge:
+        return "Wedge";
+      default:
+        return "Other";
     }
   }
 }
@@ -138,14 +143,11 @@ namespace Rodin::Tests::Unit
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
-      auto mpiMesh = distributeFromRoot(ctx, type, { 4, 3, 3 });
+      auto mpiMesh = distributeFromRoot(ctx, type, {4, 3, 3});
 
       P0<Real, Mesh<Context::MPI>> fes(mpiMesh);
 

--- a/tests/unit/Rodin/MPI/Variational/P0gTest.cpp
+++ b/tests/unit/Rodin/MPI/Variational/P0gTest.cpp
@@ -91,11 +91,16 @@ namespace
   {
     switch (type)
     {
-      case Polytope::Type::Tetrahedron: return "Tetrahedron";
-      case Polytope::Type::Hexahedron:  return "Hexahedron";
-      case Polytope::Type::Pyramid:     return "Pyramid";
-      case Polytope::Type::Wedge:       return "Wedge";
-      default:                          return "Other";
+      case Polytope::Type::Tetrahedron:
+        return "Tetrahedron";
+      case Polytope::Type::Hexahedron:
+        return "Hexahedron";
+      case Polytope::Type::Pyramid:
+        return "Pyramid";
+      case Polytope::Type::Wedge:
+        return "Wedge";
+      default:
+        return "Other";
     }
   }
 } // anonymous namespace
@@ -329,14 +334,11 @@ namespace Rodin::Tests::Unit
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
-      auto mpiMesh = distributeFromRoot(ctx, type, { 4, 3, 3 });
+      auto mpiMesh = distributeFromRoot(ctx, type, {4, 3, 3});
 
       P0g<Real, Mesh<Context::MPI>> fes(mpiMesh);
       EXPECT_EQ(fes.getSize(), 1u);

--- a/tests/unit/Rodin/MPI/Variational/SubMeshGridFunctionTest.cpp
+++ b/tests/unit/Rodin/MPI/Variational/SubMeshGridFunctionTest.cpp
@@ -51,14 +51,13 @@ using namespace Rodin::Variational;
 // ---------------------------------------------------------------------------
 // Global MPI handles (initialized in main())
 // ---------------------------------------------------------------------------
-static boost::mpi::environment*  g_env   = nullptr;
+static boost::mpi::environment* g_env = nullptr;
 static boost::mpi::communicator* g_world = nullptr;
 
 namespace
 {
   static Mesh<Context::Local> makeShardableMesh(
-      Polytope::Type type,
-      std::initializer_list<size_t> shape)
+    Polytope::Type type, std::initializer_list<size_t> shape)
   {
     auto mesh = Mesh<Context::Local>::UniformGrid(type, shape);
     const size_t D = mesh.getDimension();
@@ -76,9 +75,7 @@ namespace
   }
 
   static Mesh<Context::MPI> distributeFromRoot(
-      const Context::MPI& ctx,
-      Polytope::Type type,
-      std::initializer_list<size_t> shape)
+    const Context::MPI& ctx, Polytope::Type type, std::initializer_list<size_t> shape)
   {
     const auto& comm = ctx.getCommunicator();
     Sharder<Context::MPI> sharder(ctx);
@@ -97,16 +94,20 @@ namespace
   {
     switch (type)
     {
-      case Polytope::Type::Tetrahedron: return "Tetrahedron";
-      case Polytope::Type::Hexahedron:  return "Hexahedron";
-      case Polytope::Type::Pyramid:     return "Pyramid";
-      case Polytope::Type::Wedge:       return "Wedge";
-      default:                          return "Other";
+      case Polytope::Type::Tetrahedron:
+        return "Tetrahedron";
+      case Polytope::Type::Hexahedron:
+        return "Hexahedron";
+      case Polytope::Type::Pyramid:
+        return "Pyramid";
+      case Polytope::Type::Wedge:
+        return "Wedge";
+      default:
+        return "Other";
     }
   }
 
-  static SubMesh<Context::MPI> makeBoundarySubMesh(
-      const Mesh<Context::MPI>& mesh)
+  static SubMesh<Context::MPI> makeBoundarySubMesh(const Mesh<Context::MPI>& mesh)
   {
     const size_t faceDim = mesh.getDimension() - 1;
     SubMesh<Context::MPI>::Builder builder;
@@ -116,8 +117,7 @@ namespace
     return builder.finalize();
   }
 
-  static SubMesh<Context::MPI> makeCellSubMesh(
-      const Mesh<Context::MPI>& mesh)
+  static SubMesh<Context::MPI> makeCellSubMesh(const Mesh<Context::MPI>& mesh)
   {
     const size_t cellDim = mesh.getDimension();
     const auto& shard = mesh.getShard();
@@ -132,8 +132,7 @@ namespace
   }
 
   static SubMesh<Context::MPI> makeSparseBoundarySubMesh(
-      const Mesh<Context::MPI>& mesh,
-      const boost::mpi::communicator& comm)
+    const Mesh<Context::MPI>& mesh, const boost::mpi::communicator& comm)
   {
     const size_t faceDim = mesh.getDimension() - 1;
     const auto& shard = mesh.getShard();
@@ -184,7 +183,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeSparseBoundarySubMesh(mesh, world);
+    auto sub = makeSparseBoundarySubMesh(mesh, world);
 
     const size_t faceDim = mesh.getDimension() - 1;
     ASSERT_EQ(sub.getDimension(), faceDim);
@@ -218,7 +217,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0g<Real, Mesh<Context::MPI>> fes(sub);
     EXPECT_EQ(fes.getSize(), 1u);
@@ -258,7 +257,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     const size_t vdim = 3;
     P0g<Math::SpatialVector<Real>, Mesh<Context::MPI>> fes(sub, vdim);
@@ -288,8 +287,8 @@ namespace Rodin::Tests::Unit
       for (size_t k = 0; k < vdim; ++k)
       {
         EXPECT_EQ(dofs[k], static_cast<Index>(k));
-        EXPECT_EQ(fes.getGlobalIndex({d, i}, static_cast<Index>(k)),
-                  static_cast<Index>(k));
+        EXPECT_EQ(
+          fes.getGlobalIndex({d, i}, static_cast<Index>(k)), static_cast<Index>(k));
       }
     }
   }
@@ -305,7 +304,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeSparseBoundarySubMesh(mesh, world);
+    auto sub = makeSparseBoundarySubMesh(mesh, world);
 
     const size_t d = sub.getDimension();
     ASSERT_EQ(sub.getPolytopeCount(d), 1u);
@@ -330,15 +329,12 @@ namespace Rodin::Tests::Unit
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
       auto mesh = distributeFromRoot(ctx, type, {4, 3, 3});
-      auto sub  = makeBoundarySubMesh(mesh);
+      auto sub = makeBoundarySubMesh(mesh);
 
       ASSERT_EQ(sub.getDimension(), 2u);
 
@@ -374,7 +370,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -394,7 +390,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     EXPECT_EQ(fes.getVectorDimension(), 1u);
@@ -412,12 +408,12 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard  = sub.getShard();
-    const size_t fDim  = sub.getDimension();
+    const auto& shard = sub.getShard();
+    const size_t fDim = sub.getDimension();
     const size_t nFace = shard.getCellCount();
 
     size_t ownedCount = 0;
@@ -446,22 +442,21 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard  = sub.getShard();
-    const size_t fDim  = sub.getDimension();
+    const auto& shard = sub.getShard();
+    const size_t fDim = sub.getDimension();
     const size_t nFace = shard.getCellCount();
 
     for (size_t i = 0; i < nFace; ++i)
     {
       const auto& dofs = fes.getDOFs(fDim, static_cast<Index>(i));
       ASSERT_EQ(dofs.size(), 1u);
-      const Index via_dofs   = dofs[0];
-      const Index via_global = fes.getGlobalIndex({ fDim, static_cast<Index>(i) }, 0);
-      EXPECT_EQ(via_dofs, via_global)
-          << "Mismatch for face " << i;
+      const Index via_dofs = dofs[0];
+      const Index via_global = fes.getGlobalIndex({fDim, static_cast<Index>(i)}, 0);
+      EXPECT_EQ(via_dofs, via_global) << "Mismatch for face " << i;
     }
   }
 
@@ -476,12 +471,12 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard  = sub.getShard();
-    const size_t fDim  = sub.getDimension();
+    const auto& shard = sub.getShard();
+    const size_t fDim = sub.getDimension();
     const size_t nFace = shard.getCellCount();
 
     // Cache getSize() once — it does all_reduce internally and must not be
@@ -494,7 +489,7 @@ namespace Rodin::Tests::Unit
       for (const Index d : dofs)
       {
         EXPECT_LT(d, globalSize)
-            << "Global P0 DOF " << d << " out of range for local face " << i;
+          << "Global P0 DOF " << d << " out of range for local face " << i;
       }
     }
   }
@@ -515,7 +510,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -538,13 +533,13 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard     = sub.getShard();
-    const size_t cellDim  = sub.getDimension();
-    const size_t nCells   = shard.getCellCount();
+    const auto& shard = sub.getShard();
+    const size_t cellDim = sub.getDimension();
+    const size_t nCells = shard.getCellCount();
 
     std::vector<Index> ownedDofs;
     for (size_t i = 0; i < nCells; ++i)
@@ -571,10 +566,10 @@ namespace Rodin::Tests::Unit
 
       std::sort(combined.begin(), combined.end());
       const size_t uniqueCount = static_cast<size_t>(
-          std::unique(combined.begin(), combined.end()) - combined.begin());
+        std::unique(combined.begin(), combined.end()) - combined.begin());
 
       EXPECT_EQ(uniqueCount, combined.size())
-          << "Duplicate global P0 DOF indices on cell SubMesh.";
+        << "Duplicate global P0 DOF indices on cell SubMesh.";
       EXPECT_EQ(combined.size(), globalCells);
     }
   }
@@ -593,15 +588,12 @@ namespace Rodin::Tests::Unit
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
       auto mesh = distributeFromRoot(ctx, type, {4, 3, 3});
-      auto sub  = makeBoundarySubMesh(mesh);
+      auto sub = makeBoundarySubMesh(mesh);
 
       P0<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -626,7 +618,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -646,7 +638,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -676,7 +668,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -691,7 +683,7 @@ namespace Rodin::Tests::Unit
       for (const Index d : dofs)
       {
         EXPECT_LT(d, globalSize)
-            << "Global P1 DOF " << d << " out of range for local vertex " << i;
+          << "Global P1 DOF " << d << " out of range for local vertex " << i;
       }
     }
   }
@@ -712,7 +704,7 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
@@ -733,12 +725,12 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard    = sub.getShard();
-    const size_t nVerts  = shard.getVertexCount();
+    const auto& shard = sub.getShard();
+    const size_t nVerts = shard.getVertexCount();
 
     std::vector<Index> ownedDofs;
     for (size_t i = 0; i < nVerts; ++i)
@@ -764,10 +756,10 @@ namespace Rodin::Tests::Unit
 
       std::sort(combined.begin(), combined.end());
       const size_t uniqueCount = static_cast<size_t>(
-          std::unique(combined.begin(), combined.end()) - combined.begin());
+        std::unique(combined.begin(), combined.end()) - combined.begin());
 
       EXPECT_EQ(uniqueCount, combined.size())
-          << "Duplicate global P1 DOF indices on cell SubMesh.";
+        << "Duplicate global P1 DOF indices on cell SubMesh.";
       EXPECT_EQ(combined.size(), globalVerts);
     }
   }
@@ -793,11 +785,11 @@ namespace Rodin::Tests::Unit
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard   = sub.getShard();
+    const auto& shard = sub.getShard();
     const size_t nVerts = shard.getVertexCount();
 
     std::vector<Index> ownedDofs;
@@ -825,12 +817,12 @@ namespace Rodin::Tests::Unit
 
       std::sort(combined.begin(), combined.end());
       const size_t uniqueCount = static_cast<size_t>(
-          std::unique(combined.begin(), combined.end()) - combined.begin());
+        std::unique(combined.begin(), combined.end()) - combined.begin());
 
       EXPECT_EQ(uniqueCount, combined.size())
-          << "Duplicate global P1 DOF indices on boundary SubMesh.";
+        << "Duplicate global P1 DOF indices on boundary SubMesh.";
       EXPECT_EQ(combined.size(), globalBoundaryVerts)
-          << "Owned P1 DOF count does not match global boundary vertex count.";
+        << "Owned P1 DOF count does not match global boundary vertex count.";
     }
   }
 
@@ -850,8 +842,8 @@ namespace Rodin::Tests::Unit
    * must produce valid DOFs even when constructed after P0 cell and P0
    * boundary SubMesh spaces.
    */
-  TEST(MPIP1FESSubMesh,
-       Regression_P0CellThenP1Boundary_AllLocalVertices_HaveValidGlobalDOF)
+  TEST(
+    MPIP1FESSubMesh, Regression_P0CellThenP1Boundary_AllLocalVertices_HaveValidGlobalDOF)
   {
     const auto& world = *g_world;
     if (world.size() > 4)
@@ -861,22 +853,22 @@ namespace Rodin::Tests::Unit
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
 
     // Build both SubMeshes.
-    auto cellSub     = makeCellSubMesh(mesh);
+    auto cellSub = makeCellSubMesh(mesh);
     auto boundarySub = makeBoundarySubMesh(mesh);
 
     // Construct P0 on cell SubMesh first (this was the source of stale sends).
     P0<Real, Mesh<Context::MPI>> p0cell(cellSub);
-    (void) p0cell;
+    (void)p0cell;
 
     // Construct P0 on boundary SubMesh (additional potential source of stale sends).
     P0<Real, Mesh<Context::MPI>> p0bnd(boundarySub);
-    (void) p0bnd;
+    (void)p0bnd;
 
     // Now construct P1 on boundary SubMesh.  After the symmetric-drain fix,
     // this must not consume any stale P0 messages and must produce valid DOFs.
     P1<Real, Mesh<Context::MPI>> p1bnd(boundarySub);
 
-    const auto& shard   = boundarySub.getShard();
+    const auto& shard = boundarySub.getShard();
     const size_t nVerts = shard.getVertexCount();
     const size_t globalSize = p1bnd.getSize();
 
@@ -886,9 +878,8 @@ namespace Rodin::Tests::Unit
       for (const Index d : dofs)
       {
         EXPECT_LT(d, globalSize)
-            << "P1 boundary SubMesh DOF " << d
-            << " out of range for local vertex " << i
-            << " (constructed after P0 cell and boundary SubMesh spaces).";
+          << "P1 boundary SubMesh DOF " << d << " out of range for local vertex " << i
+          << " (constructed after P0 cell and boundary SubMesh spaces).";
       }
     }
   }
@@ -897,34 +888,31 @@ namespace Rodin::Tests::Unit
    * @brief Same regression test over all supported 3D cell meshes.
    */
   TEST(MPIP1FESSubMesh,
-       Regression_P0CellThenP1Boundary_AllLocalVertices_HaveValidGlobalDOF_All3D)
+    Regression_P0CellThenP1Boundary_AllLocalVertices_HaveValidGlobalDOF_All3D)
   {
     const auto& world = *g_world;
     if (world.size() > 4)
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    for (auto type :
-         { Polytope::Type::Tetrahedron,
-           Polytope::Type::Hexahedron,
-           Polytope::Type::Pyramid,
-           Polytope::Type::Wedge })
+    for (auto type : {Polytope::Type::Tetrahedron, Polytope::Type::Hexahedron,
+           Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       SCOPED_TRACE(polytopeName(type));
       auto mesh = distributeFromRoot(ctx, type, {4, 3, 3});
 
-      auto cellSub     = makeCellSubMesh(mesh);
+      auto cellSub = makeCellSubMesh(mesh);
       auto boundarySub = makeBoundarySubMesh(mesh);
 
       P0<Real, Mesh<Context::MPI>> p0cell(cellSub);
-      (void) p0cell;
+      (void)p0cell;
 
       P0<Real, Mesh<Context::MPI>> p0bnd(boundarySub);
-      (void) p0bnd;
+      (void)p0bnd;
 
       P1<Real, Mesh<Context::MPI>> p1bnd(boundarySub);
 
-      const auto& shard   = boundarySub.getShard();
+      const auto& shard = boundarySub.getShard();
       const size_t nVerts = shard.getVertexCount();
       const size_t globalSize = p1bnd.getSize();
 
@@ -934,8 +922,7 @@ namespace Rodin::Tests::Unit
         for (const Index d : dofs)
         {
           EXPECT_LT(d, globalSize)
-              << "P1 boundary SubMesh DOF " << d
-              << " out of range for local vertex " << i;
+            << "P1 boundary SubMesh DOF " << d << " out of range for local vertex " << i;
         }
       }
     }
@@ -956,8 +943,8 @@ namespace Rodin::Tests::Unit
    *
    * Passing this test requires the 2-round ownership fix in SubMesh::finalize.
    */
-  TEST(MPIP1FESSubMesh,
-       Regression_OrphanVertex_AllLocalVertices_HaveValidGlobalDOF_Triangle)
+  TEST(
+    MPIP1FESSubMesh, Regression_OrphanVertex_AllLocalVertices_HaveValidGlobalDOF_Triangle)
   {
     const auto& world = *g_world;
     if (world.size() > 4)
@@ -968,11 +955,11 @@ namespace Rodin::Tests::Unit
     // A finer 8×8 mesh increases the probability of hitting corner vertices
     // where the volume-partition owner is not adjacent to any boundary face.
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {8, 8});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
 
-    const auto& shard   = sub.getShard();
+    const auto& shard = sub.getShard();
     const size_t nVerts = shard.getVertexCount();
     const size_t globalSize = fes.getSize();
 
@@ -982,8 +969,8 @@ namespace Rodin::Tests::Unit
       for (const Index d : dofs)
       {
         EXPECT_LT(d, globalSize)
-            << "P1 DOF " << d << " out of range for local vertex " << i
-            << " (orphan-vertex regression, 8x8 triangle mesh).";
+          << "P1 DOF " << d << " out of range for local vertex " << i
+          << " (orphan-vertex regression, 8x8 triangle mesh).";
       }
     }
 
@@ -1012,12 +999,12 @@ namespace Rodin::Tests::Unit
 
       std::sort(combined.begin(), combined.end());
       const size_t uniqueCount = static_cast<size_t>(
-          std::unique(combined.begin(), combined.end()) - combined.begin());
+        std::unique(combined.begin(), combined.end()) - combined.begin());
 
       EXPECT_EQ(uniqueCount, combined.size())
-          << "Duplicate owned P1 DOFs on 8x8 boundary SubMesh (orphan-vertex regression).";
+        << "Duplicate owned P1 DOFs on 8x8 boundary SubMesh (orphan-vertex regression).";
       EXPECT_EQ(combined.size(), globalBoundaryVerts)
-          << "Owned P1 DOF count does not match global boundary vertex count.";
+        << "Owned P1 DOF count does not match global boundary vertex count.";
     }
   }
 }
@@ -1029,7 +1016,7 @@ int main(int argc, char** argv)
 {
   boost::mpi::environment env(argc, argv);
   boost::mpi::communicator world;
-  g_env   = &env;
+  g_env = &env;
   g_world = &world;
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit/Rodin/Models/Solid/SolidTest.cpp
+++ b/tests/unit/Rodin/Models/Solid/SolidTest.cpp
@@ -169,7 +169,10 @@ namespace Rodin::Tests::Unit
   {
     Solid::KinematicState state(2);
     Math::SpatialMatrix<Real> H(2, 2);
-    H(0,0)=0.2; H(0,1)=0.0; H(1,0)=0.0; H(1,1)=0.0;
+    H(0, 0) = 0.2;
+    H(0, 1) = 0.0;
+    H(1, 0) = 0.0;
+    H(1, 1) = 0.0;
     state.setDisplacementGradient(H);
 
     Solid::ConstitutivePoint cp(state);
@@ -467,7 +470,9 @@ namespace Rodin::Tests::Unit
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(3);
-    fiber[0] = 1.0; fiber[1] = 0.0; fiber[2] = 0.0;
+    fiber[0] = 1.0;
+    fiber[1] = 0.0;
+    fiber[2] = 0.0;
     cp.set<Solid::Tags::FiberDirection>(fiber);
 
     Solid::HolzapfelOgden::Cache cache;
@@ -488,23 +493,37 @@ namespace Rodin::Tests::Unit
 
     Solid::KinematicState state(3);
     Math::SpatialMatrix<Real> H(3, 3);
-    H(0,0)=0.08; H(0,1)=0.03; H(0,2)=0.01;
-    H(1,0)=-0.02; H(1,1)=0.06; H(1,2)=0.04;
-    H(2,0)=0.01; H(2,1)=-0.03; H(2,2)=0.05;
+    H(0, 0) = 0.08;
+    H(0, 1) = 0.03;
+    H(0, 2) = 0.01;
+    H(1, 0) = -0.02;
+    H(1, 1) = 0.06;
+    H(1, 2) = 0.04;
+    H(2, 0) = 0.01;
+    H(2, 1) = -0.03;
+    H(2, 2) = 0.05;
     state.setDisplacementGradient(H);
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(3);
-    fiber[0] = 0.8; fiber[1] = 0.4; fiber[2] = 0.2;
+    fiber[0] = 0.8;
+    fiber[1] = 0.4;
+    fiber[2] = 0.2;
     cp.set<Solid::Tags::FiberDirection>(fiber);
 
     Solid::HolzapfelOgden::Cache cache;
     law.setCache(cache, cp);
 
     Math::SpatialMatrix<Real> dF(3, 3);
-    dF(0,0)=0.2; dF(0,1)=-0.1; dF(0,2)=0.05;
-    dF(1,0)=0.03; dF(1,1)=0.15; dF(1,2)=-0.07;
-    dF(2,0)=-0.04; dF(2,1)=0.08; dF(2,2)=0.12;
+    dF(0, 0) = 0.2;
+    dF(0, 1) = -0.1;
+    dF(0, 2) = 0.05;
+    dF(1, 0) = 0.03;
+    dF(1, 1) = 0.15;
+    dF(1, 2) = -0.07;
+    dF(2, 0) = -0.04;
+    dF(2, 1) = 0.08;
+    dF(2, 2) = 0.12;
 
     Math::SpatialMatrix<Real> dP;
     law.getMaterialTangent(dP, cache, cp, dF);
@@ -545,7 +564,8 @@ namespace Rodin::Tests::Unit
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(2);
-    fiber[0] = 1.0; fiber[1] = 0.0;
+    fiber[0] = 1.0;
+    fiber[1] = 0.0;
     cp.set<Solid::Tags::FiberDirection>(fiber);
     cp.set<Solid::Tags::ActiveExtension>(0.0);
 
@@ -577,13 +597,16 @@ namespace Rodin::Tests::Unit
 
     Solid::KinematicState state(2);
     Math::SpatialMatrix<Real> H(2, 2);
-    H(0, 0) = 0.07; H(0, 1) = 0.02;
-    H(1, 0) = -0.03; H(1, 1) = 0.05;
+    H(0, 0) = 0.07;
+    H(0, 1) = 0.02;
+    H(1, 0) = -0.03;
+    H(1, 1) = 0.05;
     state.setDisplacementGradient(H);
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(2);
-    fiber[0] = 0.8; fiber[1] = 0.6;
+    fiber[0] = 0.8;
+    fiber[1] = 0.6;
     cp.set<Solid::Tags::FiberDirection>(fiber);
     cp.set<Solid::Tags::ActiveExtension>(-0.06);
 
@@ -591,8 +614,10 @@ namespace Rodin::Tests::Unit
     law.setCache(cache, cp);
 
     Math::SpatialMatrix<Real> dF(2, 2);
-    dF(0, 0) = 0.21; dF(0, 1) = -0.13;
-    dF(1, 0) = 0.07; dF(1, 1) = 0.18;
+    dF(0, 0) = 0.21;
+    dF(0, 1) = -0.13;
+    dF(1, 0) = 0.07;
+    dF(1, 1) = 0.18;
 
     Math::SpatialMatrix<Real> dP;
     law.getMaterialTangent(dP, cache, cp, dF);
@@ -629,14 +654,22 @@ namespace Rodin::Tests::Unit
 
     Solid::KinematicState state(3);
     Math::SpatialMatrix<Real> H(3, 3);
-    H(0,0)=0.04; H(0,1)=0.02; H(0,2)=-0.01;
-    H(1,0)=-0.03; H(1,1)=0.06; H(1,2)=0.02;
-    H(2,0)=0.01; H(2,1)=-0.02; H(2,2)=0.05;
+    H(0, 0) = 0.04;
+    H(0, 1) = 0.02;
+    H(0, 2) = -0.01;
+    H(1, 0) = -0.03;
+    H(1, 1) = 0.06;
+    H(1, 2) = 0.02;
+    H(2, 0) = 0.01;
+    H(2, 1) = -0.02;
+    H(2, 2) = 0.05;
     state.setDisplacementGradient(H);
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(3);
-    fiber[0] = 0.7; fiber[1] = 0.5; fiber[2] = 0.3;
+    fiber[0] = 0.7;
+    fiber[1] = 0.5;
+    fiber[2] = 0.3;
     cp.set<Solid::Tags::FiberDirection>(fiber);
     cp.set<Solid::Tags::ActiveExtension>(-0.04);
 
@@ -644,9 +677,15 @@ namespace Rodin::Tests::Unit
     law.setCache(cache, cp);
 
     Math::SpatialMatrix<Real> dF(3, 3);
-    dF(0,0)=0.18; dF(0,1)=-0.09; dF(0,2)=0.05;
-    dF(1,0)=0.04; dF(1,1)=0.13; dF(1,2)=-0.07;
-    dF(2,0)=-0.05; dF(2,1)=0.06; dF(2,2)=0.10;
+    dF(0, 0) = 0.18;
+    dF(0, 1) = -0.09;
+    dF(0, 2) = 0.05;
+    dF(1, 0) = 0.04;
+    dF(1, 1) = 0.13;
+    dF(1, 2) = -0.07;
+    dF(2, 0) = -0.05;
+    dF(2, 1) = 0.06;
+    dF(2, 2) = 0.10;
 
     Math::SpatialMatrix<Real> dP;
     law.getMaterialTangent(dP, cache, cp, dF);
@@ -678,24 +717,27 @@ namespace Rodin::Tests::Unit
     // difference of P with respect to F at fixed previous state.
     Solid::NeoHookean passive(0.0, 0.0);
     Solid::ActiveFiberLaw::Parameters activeInput;
-    activeInput.stiffness            = 200.0;
-    activeInput.damping              = 0.5;
-    activeInput.destructionRate      = 0.4;
+    activeInput.stiffness = 200.0;
+    activeInput.damping = 0.5;
+    activeInput.destructionRate = 0.4;
     activeInput.crossBridgeStiffness = 100.0;
-    activeInput.contractility        = 80.0;
+    activeInput.contractility = 80.0;
     Solid::ActiveFiberLaw active(activeInput);
     Solid::ActiveContraction law(passive, active);
 
     Solid::KinematicState state(2);
     Math::SpatialMatrix<Real> H(2, 2);
-    H(0, 0) = 0.06; H(0, 1) = 0.02;
-    H(1, 0) = -0.03; H(1, 1) = 0.04;
+    H(0, 0) = 0.06;
+    H(0, 1) = 0.02;
+    H(1, 0) = -0.03;
+    H(1, 1) = 0.04;
     state.setDisplacementGradient(H);
 
     auto buildPoint = [&](const Solid::KinematicState& s) {
       Solid::ConstitutivePoint cp(s);
       Math::SpatialVector<Real> fiber(2);
-      fiber[0] = 0.8; fiber[1] = 0.6;
+      fiber[0] = 0.8;
+      fiber[1] = 0.6;
       cp.set<Solid::Tags::FiberDirection>(fiber);
       cp.set<Solid::Tags::TimeStep>(0.01);
       cp.set<Solid::Tags::PreviousActiveExtension>(-0.04);
@@ -712,8 +754,10 @@ namespace Rodin::Tests::Unit
     EXPECT_LT(cache.localIterations, 30u);
 
     Math::SpatialMatrix<Real> dF(2, 2);
-    dF(0, 0) = 0.21; dF(0, 1) = -0.13;
-    dF(1, 0) = 0.07; dF(1, 1) = 0.18;
+    dF(0, 0) = 0.21;
+    dF(0, 1) = -0.13;
+    dF(1, 0) = 0.07;
+    dF(1, 1) = 0.18;
 
     Math::SpatialMatrix<Real> dP;
     law.getMaterialTangent(dP, cache, cp, dF);
@@ -740,25 +784,33 @@ namespace Rodin::Tests::Unit
   {
     Solid::NeoHookean passive(20.0, 8.0);
     Solid::ActiveFiberLaw::Parameters activeInput;
-    activeInput.stiffness            = 60.0;
-    activeInput.damping              = 0.3;
-    activeInput.destructionRate      = 0.5;
+    activeInput.stiffness = 60.0;
+    activeInput.damping = 0.3;
+    activeInput.destructionRate = 0.5;
     activeInput.crossBridgeStiffness = 40.0;
-    activeInput.contractility        = 30.0;
+    activeInput.contractility = 30.0;
     Solid::ActiveFiberLaw active(activeInput);
     Solid::ActiveContraction law(passive, active);
 
     Solid::KinematicState state(3);
     Math::SpatialMatrix<Real> H(3, 3);
-    H(0,0)=0.04; H(0,1)=0.02; H(0,2)=-0.01;
-    H(1,0)=-0.03; H(1,1)=0.05; H(1,2)=0.02;
-    H(2,0)=0.01; H(2,1)=-0.02; H(2,2)=0.03;
+    H(0, 0) = 0.04;
+    H(0, 1) = 0.02;
+    H(0, 2) = -0.01;
+    H(1, 0) = -0.03;
+    H(1, 1) = 0.05;
+    H(1, 2) = 0.02;
+    H(2, 0) = 0.01;
+    H(2, 1) = -0.02;
+    H(2, 2) = 0.03;
     state.setDisplacementGradient(H);
 
     auto buildPoint = [&](const Solid::KinematicState& s) {
       Solid::ConstitutivePoint cp(s);
       Math::SpatialVector<Real> fiber(3);
-      fiber[0] = 0.7; fiber[1] = 0.5; fiber[2] = 0.3;
+      fiber[0] = 0.7;
+      fiber[1] = 0.5;
+      fiber[2] = 0.3;
       cp.set<Solid::Tags::FiberDirection>(fiber);
       cp.set<Solid::Tags::TimeStep>(0.005);
       cp.set<Solid::Tags::PreviousActiveExtension>(-0.03);
@@ -774,9 +826,15 @@ namespace Rodin::Tests::Unit
     EXPECT_TRUE(cache.dynamic);
 
     Math::SpatialMatrix<Real> dF(3, 3);
-    dF(0,0)=0.18; dF(0,1)=-0.09; dF(0,2)=0.05;
-    dF(1,0)=0.04; dF(1,1)=0.13; dF(1,2)=-0.07;
-    dF(2,0)=-0.05; dF(2,1)=0.06; dF(2,2)=0.10;
+    dF(0, 0) = 0.18;
+    dF(0, 1) = -0.09;
+    dF(0, 2) = 0.05;
+    dF(1, 0) = 0.04;
+    dF(1, 1) = 0.13;
+    dF(1, 2) = -0.07;
+    dF(2, 0) = -0.05;
+    dF(2, 1) = 0.06;
+    dF(2, 2) = 0.10;
 
     Math::SpatialMatrix<Real> dP;
     law.getMaterialTangent(dP, cache, cp, dF);
@@ -805,23 +863,26 @@ namespace Rodin::Tests::Unit
     // machine precision regardless of where the global state sits.
     Solid::NeoHookean passive(0.0, 0.0);
     Solid::ActiveFiberLaw::Parameters activeInput;
-    activeInput.stiffness            = 200.0;
-    activeInput.damping              = 0.5;
-    activeInput.destructionRate      = 0.4;
+    activeInput.stiffness = 200.0;
+    activeInput.damping = 0.5;
+    activeInput.destructionRate = 0.4;
     activeInput.crossBridgeStiffness = 100.0;
-    activeInput.contractility        = 80.0;
+    activeInput.contractility = 80.0;
     Solid::ActiveFiberLaw active(activeInput);
     Solid::ActiveContraction law(passive, active);
 
     Solid::KinematicState state(2);
     Math::SpatialMatrix<Real> H(2, 2);
-    H(0, 0) = 0.10; H(0, 1) = 0.03;
-    H(1, 0) = -0.02; H(1, 1) = 0.06;
+    H(0, 0) = 0.10;
+    H(0, 1) = 0.03;
+    H(1, 0) = -0.02;
+    H(1, 1) = 0.06;
     state.setDisplacementGradient(H);
 
     Solid::ConstitutivePoint cp(state);
     Math::SpatialVector<Real> fiber(2);
-    fiber[0] = 1.0; fiber[1] = 0.0;
+    fiber[0] = 1.0;
+    fiber[1] = 0.0;
     cp.set<Solid::Tags::FiberDirection>(fiber);
     cp.set<Solid::Tags::TimeStep>(0.01);
     cp.set<Solid::Tags::PreviousActiveExtension>(-0.05);

--- a/tests/unit/Rodin/PETSc/FormTest.cpp
+++ b/tests/unit/Rodin/PETSc/FormTest.cpp
@@ -127,22 +127,21 @@ namespace
   template <template <class, class> class Assembler>
   void checkPETScAffineIdentificationDefect()
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     PETSc::Variational::TrialFunction eta(fes);
-    PETSc::Variational::TestFunction  zeta(fes);
+    PETSc::Variational::TestFunction zeta(fes);
 
     constexpr PetscScalar gamma = 2.0;
     constexpr PetscScalar defect = 3.0;
     const PetscInt n = static_cast<PetscInt>(fes.getSize());
     const PetscInt nTotal = 2 * n;
 
-    auto bc =
-      DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect));
+    auto bc = DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect));
 
     BilinearForm uu(u, v);
     auto& op = uu.getOperator();
@@ -181,33 +180,24 @@ namespace
 
     using LinearSystemType = PETSc::Math::LinearSystem;
     using ProblemType =
-      Problem<LinearSystemType,
-              decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
 
-    auto trialFunctions = Tuple{ std::ref(u), std::ref(eta) };
-    auto testFunctions  = Tuple{ std::ref(v), std::ref(zeta) };
+    auto trialFunctions = Tuple{std::ref(u), std::ref(eta)};
+    auto testFunctions = Tuple{std::ref(v), std::ref(zeta)};
 
-    std::array<size_t, 2> offsets{ 0, static_cast<size_t>(n) };
+    std::array<size_t, 2> offsets{0, static_cast<size_t>(n)};
 
     boost::bimap<FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, eta.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, zeta.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, eta.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, zeta.getUUID()});
 
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(body)>,
-      decltype(u), decltype(v), decltype(eta), decltype(zeta)> input(
-          body,
-          trialFunctions,
-          testFunctions,
-          offsets,
-          offsets,
-          trialUUIDMap,
-          testUUIDMap,
-          static_cast<size_t>(nTotal),
-          static_cast<size_t>(nTotal));
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(body)>, decltype(u), decltype(v),
+      decltype(eta), decltype(zeta)>
+      input(body, trialFunctions, testFunctions, offsets, offsets, trialUUIDMap,
+        testUUIDMap, static_cast<size_t>(nTotal), static_cast<size_t>(nTotal));
 
     LinearSystemType ls(PETSC_COMM_SELF);
     Assembler<LinearSystemType, ProblemType> assembler;
@@ -249,21 +239,18 @@ namespace
   template <template <class, class> class Assembler>
   void checkPETScVectorMasterIdentification()
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 slaveFES(mesh);
     P1 masterFES(mesh, mesh.getSpaceDimension());
 
     PETSc::Variational::TrialFunction u(slaveFES);
-    PETSc::Variational::TestFunction  v(slaveFES);
+    PETSc::Variational::TestFunction v(slaveFES);
     PETSc::Variational::TrialFunction eta(masterFES);
-    PETSc::Variational::TestFunction  zeta(masterFES);
+    PETSc::Variational::TestFunction zeta(masterFES);
 
-    auto bc =
-      DirichletBC(
-          u,
-          RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
+    auto bc = DirichletBC(u, RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
     bc.assemble();
 
     using IdentifiedDOFs = DirichletBCBase<Real>::IdentifiedDOFs;
@@ -274,32 +261,26 @@ namespace
     bool sawMultiMaster = false;
     for (const auto& [slave, row] : ident)
     {
-      (void) slave;
+      (void)slave;
       if (row.first.size() >= 2)
         sawMultiMaster = true;
     }
     ASSERT_TRUE(sawMultiMaster);
 
-    const PetscInt nSlave  = static_cast<PetscInt>(slaveFES.getSize());
+    const PetscInt nSlave = static_cast<PetscInt>(slaveFES.getSize());
     const PetscInt nMaster = static_cast<PetscInt>(masterFES.getSize());
-    const PetscInt nTotal  = nSlave + nMaster;
+    const PetscInt nTotal = nSlave + nMaster;
 
     struct MatrixEntry
     {
-      PetscInt row;
-      PetscInt col;
-      PetscScalar value;
+        PetscInt row;
+        PetscInt col;
+        PetscScalar value;
     };
     const std::vector<MatrixEntry> matrixEntries{
-      { 0, 0, 2.0 },
-      { 0, 1, 3.0 },
-      { 1, 0, 5.0 },
-      { 1, 1, 7.0 }
-    };
+      {0, 0, 2.0}, {0, 1, 3.0}, {1, 0, 5.0}, {1, 1, 7.0}};
     const std::vector<std::pair<PetscInt, PetscScalar>> vectorEntries{
-      { 0, 11.0 },
-      { 1, -13.0 }
-    };
+      {0, 11.0}, {1, -13.0}};
 
     BilinearForm uu(u, v);
     auto& op = uu.getOperator();
@@ -339,50 +320,34 @@ namespace
 
     using LinearSystemType = PETSc::Math::LinearSystem;
     using ProblemType =
-      Problem<LinearSystemType,
-              decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
+      Problem<LinearSystemType, decltype(u), decltype(v), decltype(eta), decltype(zeta)>;
 
-    auto trialFunctions = Tuple{ std::ref(u), std::ref(eta) };
-    auto testFunctions  = Tuple{ std::ref(v), std::ref(zeta) };
+    auto trialFunctions = Tuple{std::ref(u), std::ref(eta)};
+    auto testFunctions = Tuple{std::ref(v), std::ref(zeta)};
 
-    std::array<size_t, 2> trialOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
-    std::array<size_t, 2> testOffsets{
-      0, static_cast<size_t>(nSlave)
-    };
+    std::array<size_t, 2> trialOffsets{0, static_cast<size_t>(nSlave)};
+    std::array<size_t, 2> testOffsets{0, static_cast<size_t>(nSlave)};
 
     boost::bimap<FormLanguage::Base::UUID, size_t> trialUUIDMap;
     boost::bimap<FormLanguage::Base::UUID, size_t> testUUIDMap;
-    trialUUIDMap.right.insert({ 0, u.getUUID() });
-    trialUUIDMap.right.insert({ 1, eta.getUUID() });
-    testUUIDMap.right.insert({ 0, v.getUUID() });
-    testUUIDMap.right.insert({ 1, zeta.getUUID() });
+    trialUUIDMap.right.insert({0, u.getUUID()});
+    trialUUIDMap.right.insert({1, eta.getUUID()});
+    testUUIDMap.right.insert({0, v.getUUID()});
+    testUUIDMap.right.insert({1, zeta.getUUID()});
 
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(body)>,
-      decltype(u), decltype(v), decltype(eta), decltype(zeta)> input(
-          body,
-          trialFunctions,
-          testFunctions,
-          trialOffsets,
-          testOffsets,
-          trialUUIDMap,
-          testUUIDMap,
-          static_cast<size_t>(nTotal),
-          static_cast<size_t>(nTotal));
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(body)>, decltype(u), decltype(v),
+      decltype(eta), decltype(zeta)>
+      input(body, trialFunctions, testFunctions, trialOffsets, testOffsets, trialUUIDMap,
+        testUUIDMap, static_cast<size_t>(nTotal), static_cast<size_t>(nTotal));
 
     LinearSystemType ls(PETSC_COMM_SELF);
     Assembler<LinearSystemType, ProblemType> assembler;
     assembler.execute(ls, input);
 
-    Eigen::MatrixXd expectedA =
-      Eigen::MatrixXd::Zero(nTotal, nTotal);
-    Eigen::VectorXd expectedB =
-      Eigen::VectorXd::Zero(nTotal);
+    Eigen::MatrixXd expectedA = Eigen::MatrixXd::Zero(nTotal, nTotal);
+    Eigen::VectorXd expectedB = Eigen::VectorXd::Zero(nTotal);
 
-    auto expand = [&](PetscInt local)
-    {
+    auto expand = [&](PetscInt local) {
       std::vector<std::pair<PetscInt, PetscScalar>> res;
       const auto it = ident.find(static_cast<Index>(local));
       if (it == ident.end())
@@ -391,7 +356,7 @@ namespace
         return res;
       }
       const auto& masters = it->second.first;
-      const auto& coeffs  = it->second.second;
+      const auto& coeffs = it->second.second;
       for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
         res.emplace_back(nSlave + static_cast<PetscInt>(masters[k]), coeffs[k]);
       return res;
@@ -411,7 +376,7 @@ namespace
       expectedA.row(static_cast<Eigen::Index>(slave)).setZero();
       expectedA(slave, slave) = 1.0;
       const auto& masters = row.first;
-      const auto& coeffs  = row.second;
+      const auto& coeffs = row.second;
       for (Index k = 0; k < static_cast<Index>(masters.size()); k++)
         expectedA(slave, nSlave + static_cast<PetscInt>(masters[k])) -= coeffs[k];
       expectedB(slave) = 0.0;
@@ -431,8 +396,7 @@ namespace
         PetscScalar aValue = 0;
         ierr = MatGetValues(A, 1, &i, 1, &j, &aValue);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_NEAR(aValue, expectedA(i, j), 1e-14)
-          << "entry (" << i << ", " << j << ")";
+        EXPECT_NEAR(aValue, expectedA(i, j), 1e-14) << "entry (" << i << ", " << j << ")";
       }
     }
   }
@@ -440,17 +404,16 @@ namespace
   template <template <class, class> class Assembler>
   void checkPETScSelfIdentificationMatchesZeroValueConstraint()
   {
-    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    auto mesh = Mesh<Context::Local>::UniformGrid(Polytope::Type::Triangle, {2, 2});
     mesh.getConnectivity().compute(1, 2);
 
     P1 refFES(mesh);
     PETSc::Variational::TrialFunction uRef(refFES);
-    PETSc::Variational::TestFunction  vRef(refFES);
+    PETSc::Variational::TestFunction vRef(refFES);
 
     const PetscInt n = static_cast<PetscInt>(refFES.getSize());
 
-    auto setOperator = [&](auto& form)
-    {
+    auto setOperator = [&](auto& form) {
       auto& op = form.getOperator();
       PetscErrorCode ierr = MatSetSizes(op, n, n, n, n);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
@@ -458,9 +421,9 @@ namespace
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       ierr = MatSetUp(op);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
-      const PetscInt rows[4] = { 0, 0, 1, 1 };
-      const PetscInt cols[4] = { 0, 1, 0, 1 };
-      const PetscScalar vals[4] = { 2.0, 3.0, 5.0, 7.0 };
+      const PetscInt rows[4] = {0, 0, 1, 1};
+      const PetscInt cols[4] = {0, 1, 0, 1};
+      const PetscScalar vals[4] = {2.0, 3.0, 5.0, 7.0};
       for (PetscInt k = 0; k < 4; k++)
       {
         ierr = MatSetValue(op, rows[k], cols[k], vals[k], INSERT_VALUES);
@@ -472,15 +435,14 @@ namespace
       ASSERT_EQ(ierr, PETSC_SUCCESS);
     };
 
-    auto setVector = [&](auto& form)
-    {
+    auto setVector = [&](auto& form) {
       auto& vec = form.getVector();
       PetscErrorCode ierr = VecSetSizes(vec, n, n);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       ierr = VecSetFromOptions(vec);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
-      const PetscInt rows[2] = { 0, 1 };
-      const PetscScalar vals[2] = { 11.0, -13.0 };
+      const PetscInt rows[2] = {0, 1};
+      const PetscScalar vals[2] = {11.0, -13.0};
       ierr = VecSetValues(vec, 2, rows, vals, INSERT_VALUES);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       ierr = VecAssemblyBegin(vec);
@@ -498,7 +460,7 @@ namespace
 
     P1 idFES(mesh);
     PETSc::Variational::TrialFunction uId(idFES);
-    PETSc::Variational::TestFunction  vId(idFES);
+    PETSc::Variational::TestFunction vId(idFES);
 
     BilinearForm uuId(uId, vId);
     setOperator(uuId);
@@ -508,32 +470,31 @@ namespace
     auto idBody = uuId + DirichletBC(uId, -uId) - loadId;
 
     using LinearSystemType = PETSc::Math::LinearSystem;
-    using ProblemType =
-      Problem<LinearSystemType, decltype(uRef), decltype(vRef)>;
+    using ProblemType = Problem<LinearSystemType, decltype(uRef), decltype(vRef)>;
 
     LinearSystemType refLS(PETSC_COMM_SELF);
     LinearSystemType idLS(PETSC_COMM_SELF);
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(refBody)>,
-      decltype(uRef), decltype(vRef)> refInput(refBody, uRef, vRef);
-    Assembly::ProblemAssemblyInput<
-      std::decay_t<decltype(idBody)>,
-      decltype(uId), decltype(vId)> idInput(idBody, uId, vId);
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(refBody)>, decltype(uRef),
+      decltype(vRef)>
+      refInput(refBody, uRef, vRef);
+    Assembly::ProblemAssemblyInput<std::decay_t<decltype(idBody)>, decltype(uId),
+      decltype(vId)>
+      idInput(idBody, uId, vId);
 
     Assembler<LinearSystemType, ProblemType> assembler;
     assembler.execute(refLS, refInput);
     assembler.execute(idLS, idInput);
 
     auto& ARef = refLS.getOperator();
-    auto& AId  = idLS.getOperator();
+    auto& AId = idLS.getOperator();
     auto& bRef = refLS.getVector();
-    auto& bId  = idLS.getVector();
+    auto& bId = idLS.getVector();
 
     for (PetscInt i = 0; i < n; i++)
     {
       PetscErrorCode ierr;
       PetscScalar refValue = 0;
-      PetscScalar idValue  = 0;
+      PetscScalar idValue = 0;
 
       ierr = VecGetValues(bRef, 1, &i, &refValue);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
@@ -547,8 +508,7 @@ namespace
         ASSERT_EQ(ierr, PETSC_SUCCESS);
         ierr = MatGetValues(AId, 1, &i, 1, &j, &idValue);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_NEAR(refValue, idValue, 1e-12)
-          << "entry (" << i << ", " << j << ")";
+        EXPECT_NEAR(refValue, idValue, 1e-12) << "entry (" << i << ", " << j << ")";
       }
     }
   }

--- a/tests/unit/Rodin/PETSc/IO/HDF5IOTest.cpp
+++ b/tests/unit/Rodin/PETSc/IO/HDF5IOTest.cpp
@@ -61,7 +61,8 @@ namespace
       case Polytope::Type::Quadrilateral: return "Quad2D";
       case Polytope::Type::Tetrahedron:   return "Tet3D";
       case Polytope::Type::Hexahedron:    return "Hex3D";
-      case Polytope::Type::Pyramid:       return "Pyramid3D";
+      case Polytope::Type::Pyramid:
+        return "Pyramid3D";
       case Polytope::Type::Wedge:         return "Wedge3D";
       default:                            return "Unknown";
     }
@@ -211,19 +212,11 @@ namespace
     }
   };
 
-  INSTANTIATE_TEST_SUITE_P(
-      AllDimensions,
-      PETScHDF5,
-      ::testing::Values(
-          Polytope::Type::Segment,
-          Polytope::Type::Triangle,
-          Polytope::Type::Quadrilateral,
-          Polytope::Type::Tetrahedron,
-          Polytope::Type::Hexahedron,
-          Polytope::Type::Pyramid,
-          Polytope::Type::Wedge
-      ),
-      PETScPolytopeNameGenerator());
+  INSTANTIATE_TEST_SUITE_P(AllDimensions, PETScHDF5,
+    ::testing::Values(Polytope::Type::Segment, Polytope::Type::Triangle,
+      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
+      Polytope::Type::Hexahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge),
+    PETScPolytopeNameGenerator());
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/Rodin/PETSc/MPIFormTest.cpp
+++ b/tests/unit/Rodin/PETSc/MPIFormTest.cpp
@@ -146,9 +146,9 @@ namespace
     auto mesh = distributeFromRoot(ctx);
     P1 fes(mesh);
     PETSc::Variational::TrialFunction u(fes);
-    PETSc::Variational::TestFunction  v(fes);
+    PETSc::Variational::TestFunction v(fes);
     PETSc::Variational::TrialFunction eta(fes);
-    PETSc::Variational::TestFunction  zeta(fes);
+    PETSc::Variational::TestFunction zeta(fes);
 
     constexpr PetscScalar gamma = 2.0;
     constexpr PetscScalar defect = 3.0;
@@ -158,8 +158,7 @@ namespace
     fes.getOwnershipRange(begin, end);
     const PetscInt localSize = static_cast<PetscInt>(end - begin);
 
-    auto dbc =
-      DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect));
+    auto dbc = DirichletBC(u, RealFunction(gamma) * eta, RealFunction(defect));
     dbc.assemble();
     using IdentifiedDOFs = DirichletBCBase<Real>::IdentifiedDOFs;
     ASSERT_TRUE(std::holds_alternative<IdentifiedDOFs>(dbc.getDOFs()));
@@ -228,17 +227,20 @@ namespace
       PetscInt c;
       PetscScalar value;
 
-      r = master; c = master;
+      r = master;
+      c = master;
       ierr = MatGetValues(A, 1, &r, 1, &c, &value);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       EXPECT_NEAR(value, coefficient * 2.0 * coefficient, 1e-14);
 
-      r = slave; c = slave;
+      r = slave;
+      c = slave;
       ierr = MatGetValues(A, 1, &r, 1, &c, &value);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       EXPECT_NEAR(value, 1.0, 1e-14);
 
-      r = slave; c = master;
+      r = slave;
+      c = master;
       ierr = MatGetValues(A, 1, &r, 1, &c, &value);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
       EXPECT_NEAR(value, -coefficient, 1e-14);
@@ -321,40 +323,37 @@ namespace
 
     P1 refFES(mesh);
     PETSc::Variational::TrialFunction uRef(refFES);
-    PETSc::Variational::TestFunction  vRef(refFES);
+    PETSc::Variational::TestFunction vRef(refFES);
 
     Problem refProblem(uRef, vRef);
-    refProblem = Integral(Grad(uRef), Grad(vRef))
-               - Integral(RealFunction(1.0), vRef)
-               + DirichletBC(uRef, Zero());
+    refProblem = Integral(Grad(uRef), Grad(vRef)) - Integral(RealFunction(1.0), vRef) +
+      DirichletBC(uRef, Zero());
     refProblem.assemble();
 
     P1 idFES(mesh);
     PETSc::Variational::TrialFunction uId(idFES);
-    PETSc::Variational::TestFunction  vId(idFES);
+    PETSc::Variational::TestFunction vId(idFES);
 
     Problem idProblem(uId, vId);
-    idProblem = Integral(Grad(uId), Grad(vId))
-              - Integral(RealFunction(1.0), vId)
-              + DirichletBC(uId, -uId);
+    idProblem = Integral(Grad(uId), Grad(vId)) - Integral(RealFunction(1.0), vId) +
+      DirichletBC(uId, -uId);
     idProblem.assemble();
 
     auto& ARef = refProblem.getLinearSystem().getOperator();
-    auto& AId  = idProblem.getLinearSystem().getOperator();
+    auto& AId = idProblem.getLinearSystem().getOperator();
     auto& bRef = refProblem.getLinearSystem().getVector();
-    auto& bId  = idProblem.getLinearSystem().getVector();
+    auto& bId = idProblem.getLinearSystem().getVector();
 
     size_t begin = 0;
-    size_t end   = 0;
+    size_t end = 0;
     refFES.getOwnershipRange(begin, end);
 
     const PetscInt n = static_cast<PetscInt>(refFES.getSize());
-    for (PetscInt i = static_cast<PetscInt>(begin);
-         i < static_cast<PetscInt>(end); i++)
+    for (PetscInt i = static_cast<PetscInt>(begin); i < static_cast<PetscInt>(end); i++)
     {
       PetscErrorCode ierr;
       PetscScalar refValue = 0;
-      PetscScalar idValue  = 0;
+      PetscScalar idValue = 0;
 
       ierr = VecGetValues(bRef, 1, &i, &refValue);
       ASSERT_EQ(ierr, PETSC_SUCCESS);
@@ -368,8 +367,7 @@ namespace
         ASSERT_EQ(ierr, PETSC_SUCCESS);
         ierr = MatGetValues(AId, 1, &i, 1, &j, &idValue);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_NEAR(refValue, idValue, 1e-12)
-          << "entry (" << i << ", " << j << ")";
+        EXPECT_NEAR(refValue, idValue, 1e-12) << "entry (" << i << ", " << j << ")";
       }
     }
   }
@@ -385,27 +383,23 @@ namespace
     P1 masterFES(mesh, mesh.getSpaceDimension());
 
     PETSc::Variational::TrialFunction u(slaveFES);
-    PETSc::Variational::TestFunction  v(slaveFES);
+    PETSc::Variational::TestFunction v(slaveFES);
     PETSc::Variational::TrialFunction eta(masterFES);
-    PETSc::Variational::TestFunction  zeta(masterFES);
+    PETSc::Variational::TestFunction zeta(masterFES);
 
-    const PetscInt nSlave  = static_cast<PetscInt>(slaveFES.getSize());
+    const PetscInt nSlave = static_cast<PetscInt>(slaveFES.getSize());
     const PetscInt nMaster = static_cast<PetscInt>(masterFES.getSize());
 
     size_t slaveBegin = 0;
     size_t slaveEnd = 0;
     slaveFES.getOwnershipRange(slaveBegin, slaveEnd);
-    const PetscInt localSlaveSize =
-      static_cast<PetscInt>(slaveEnd - slaveBegin);
+    const PetscInt localSlaveSize = static_cast<PetscInt>(slaveEnd - slaveBegin);
 
     size_t masterBegin = 0;
     size_t masterEnd = 0;
     masterFES.getOwnershipRange(masterBegin, masterEnd);
 
-    auto dbc =
-      DirichletBC(
-          u,
-          RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
+    auto dbc = DirichletBC(u, RealFunction(2.0) * eta.x() + RealFunction(-0.5) * eta.y());
     dbc.assemble();
     using IdentifiedDOFs = DirichletBCBase<Real>::IdentifiedDOFs;
     ASSERT_TRUE(std::holds_alternative<IdentifiedDOFs>(dbc.getDOFs()));
@@ -432,8 +426,7 @@ namespace
 
     BilinearForm uu(u, v);
     auto& op = uu.getOperator();
-    PetscErrorCode ierr =
-      MatSetSizes(op, localSlaveSize, localSlaveSize, nSlave, nSlave);
+    PetscErrorCode ierr = MatSetSizes(op, localSlaveSize, localSlaveSize, nSlave, nSlave);
     ASSERT_EQ(ierr, PETSC_SUCCESS);
     ierr = MatSetFromOptions(op);
     ASSERT_EQ(ierr, PETSC_SUCCESS);
@@ -483,8 +476,7 @@ namespace
         PetscInt r = masters[a];
         ierr = VecGetValues(b, 1, &r, &value);
         ASSERT_EQ(ierr, PETSC_SUCCESS);
-        EXPECT_NEAR(value, coefficients[a] * 7.0, 1e-14)
-          << "projected vector row " << r;
+        EXPECT_NEAR(value, coefficients[a] * 7.0, 1e-14) << "projected vector row " << r;
 
         for (size_t cidx = 0; cidx < masters.size(); cidx++)
         {
@@ -492,10 +484,7 @@ namespace
           PetscInt c = masters[cidx];
           ierr = MatGetValues(A, 1, &r, 1, &c, &value);
           ASSERT_EQ(ierr, PETSC_SUCCESS);
-          EXPECT_NEAR(
-              value,
-              coefficients[a] * 2.0 * coefficients[cidx],
-              1e-14)
+          EXPECT_NEAR(value, coefficients[a] * 2.0 * coefficients[cidx], 1e-14)
             << "projected matrix entry (" << r << ", " << c << ")";
         }
       }
@@ -522,9 +511,9 @@ namespace
       EXPECT_NEAR(value, 0.0, 1e-14);
     }
 
-    (void) nMaster;
-    (void) masterBegin;
-    (void) masterEnd;
+    (void)nMaster;
+    (void)masterBegin;
+    (void)masterEnd;
   }
 }
 

--- a/tests/unit/Rodin/PETSc/MPISubMeshGridFunctionTest.cpp
+++ b/tests/unit/Rodin/PETSc/MPISubMeshGridFunctionTest.cpp
@@ -66,15 +66,13 @@ using namespace Rodin::Variational;
 // ---------------------------------------------------------------------------
 // Global MPI handles (initialized in main())
 // ---------------------------------------------------------------------------
-static boost::mpi::environment*  g_env   = nullptr;
+static boost::mpi::environment* g_env = nullptr;
 static boost::mpi::communicator* g_world = nullptr;
 
 namespace
 {
   static Mesh<Context::Local> makeShardableMesh(
-      Polytope::Type type,
-      std::initializer_list<size_t> shape,
-      Real scale = Real(1))
+    Polytope::Type type, std::initializer_list<size_t> shape, Real scale = Real(1))
   {
     auto mesh = Mesh<Context::Local>::UniformGrid(type, shape);
     if (scale != Real(1))
@@ -88,11 +86,8 @@ namespace
     return mesh;
   }
 
-  static Mesh<Context::MPI> distributeFromRoot(
-      const Context::MPI& ctx,
-      Polytope::Type type,
-      std::initializer_list<size_t> shape,
-      Real scale = Real(1))
+  static Mesh<Context::MPI> distributeFromRoot(const Context::MPI& ctx,
+    Polytope::Type type, std::initializer_list<size_t> shape, Real scale = Real(1))
   {
     const auto& comm = ctx.getCommunicator();
     Sharder<Context::MPI> sharder(ctx);
@@ -107,8 +102,7 @@ namespace
     return sharder.gather(0);
   }
 
-  static SubMesh<Context::MPI> makeBoundarySubMesh(
-      const Mesh<Context::MPI>& mesh)
+  static SubMesh<Context::MPI> makeBoundarySubMesh(const Mesh<Context::MPI>& mesh)
   {
     const size_t faceDim = mesh.getDimension() - 1;
     SubMesh<Context::MPI>::Builder builder;
@@ -118,8 +112,7 @@ namespace
     return builder.finalize();
   }
 
-  static SubMesh<Context::MPI> makeCellSubMesh(
-      const Mesh<Context::MPI>& mesh)
+  static SubMesh<Context::MPI> makeCellSubMesh(const Mesh<Context::MPI>& mesh)
   {
     const size_t cellDim = mesh.getDimension();
     const auto& shard = mesh.getShard();
@@ -152,9 +145,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 2.25;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0g<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -175,9 +168,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real subValue = 3.5;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P0g<Real, Mesh<Context::MPI>> parentFes(mesh);
     GridFunction<decltype(parentFes), ::Vec> parentGF(parentFes);
@@ -214,9 +207,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeBoundarySubMesh(mesh);
 
     H1<1, Real, Mesh<Context::MPI>> fes(std::integral_constant<size_t, 1>{}, sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -240,7 +233,7 @@ namespace Rodin::Tests::Unit::PETSc::MPI
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -269,9 +262,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -299,7 +292,7 @@ namespace Rodin::Tests::Unit::PETSc::MPI
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -330,9 +323,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 3.0;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -356,9 +349,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -380,9 +373,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 2.5;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -410,7 +403,7 @@ namespace Rodin::Tests::Unit::PETSc::MPI
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -439,9 +432,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
       GTEST_SKIP() << "Test designed for at most 4 MPI ranks.";
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeBoundarySubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -469,7 +462,7 @@ namespace Rodin::Tests::Unit::PETSc::MPI
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Triangle, {4, 4});
-    auto sub  = makeCellSubMesh(mesh);
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -500,9 +493,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 1.41421;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -537,9 +530,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 5.5;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> parentFes(mesh);
     GridFunction<decltype(parentFes), ::Vec> parentGF(parentFes);
@@ -570,9 +563,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 4.0;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> parentFes(mesh);
     GridFunction<decltype(parentFes), ::Vec> parentGF(parentFes);
@@ -615,9 +608,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 6.28;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> subFes(sub);
     GridFunction<decltype(subFes), ::Vec> subGF(subFes);
@@ -647,9 +640,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 1.73205;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Triangle, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> subFes(sub);
     GridFunction<decltype(subFes), ::Vec> subGF(subFes);
@@ -684,7 +677,7 @@ namespace Rodin::Tests::Unit::PETSc::MPI
 
     Context::MPI ctx(*g_env, world);
     auto mesh = distributeFromRoot(ctx, Polytope::Type::Quadrilateral, {4, 4});
-    auto sub  = makeBoundarySubMesh(mesh);
+    auto sub = makeBoundarySubMesh(mesh);
 
     P0<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -710,9 +703,9 @@ namespace Rodin::Tests::Unit::PETSc::MPI
     const Real c = 2.71828;
 
     Context::MPI ctx(*g_env, world);
-    auto mesh = distributeFromRoot(
-        ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
-    auto sub  = makeCellSubMesh(mesh);
+    auto mesh =
+      distributeFromRoot(ctx, Polytope::Type::Quadrilateral, {6, 6}, Real(1) / Real(5));
+    auto sub = makeCellSubMesh(mesh);
 
     P1<Real, Mesh<Context::MPI>> fes(sub);
     GridFunction<decltype(fes), ::Vec> u(fes);
@@ -730,7 +723,7 @@ int main(int argc, char** argv)
 {
   boost::mpi::environment env(argc, argv);
   boost::mpi::communicator world;
-  g_env   = &env;
+  g_env = &env;
   g_world = &world;
 
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, nullptr, nullptr);

--- a/tests/unit/Rodin/QF/GaussLegendreTest.cpp
+++ b/tests/unit/Rodin/QF/GaussLegendreTest.cpp
@@ -272,7 +272,7 @@ TEST_F(GaussLegendreTest, HexahedronGeometry)
 TEST_F(GaussLegendreTest, PyramidGeometry)
 {
   GaussLegendre gl_pyr(Polytope::Type::Pyramid, 2, 2, 2);
-  EXPECT_EQ(gl_pyr.getSize(), 8);  // 2x2x2 collapsed tensor points
+  EXPECT_EQ(gl_pyr.getSize(), 8); // 2x2x2 collapsed tensor points
   EXPECT_EQ(gl_pyr.getGeometry(), Polytope::Type::Pyramid);
 
   double total_weight = 0.0;

--- a/tests/unit/Rodin/Variational/DirichletBCTest.cpp
+++ b/tests/unit/Rodin/Variational/DirichletBCTest.cpp
@@ -25,18 +25,15 @@ namespace Rodin::Tests::Unit
     {
       assert(n >= 2);
       Geometry::Mesh<Context::Local> mesh =
-        LocalMesh::UniformGrid(Polytope::Type::Triangle, { n, n });
+        LocalMesh::UniformGrid(Polytope::Type::Triangle, {n, n});
       mesh.scale(1.0 / (n - 1));
       mesh.getConnectivity().compute(mesh.getDimension() - 1, mesh.getDimension());
       return mesh;
     }
 
-    void labelBoundaryAttributes(
-      Geometry::Mesh<Context::Local>& mesh,
-      Attribute left = LeftAttribute,
-      Attribute right = RightAttribute,
-      Attribute bottom = BottomAttribute,
-      Attribute top = TopAttribute)
+    void labelBoundaryAttributes(Geometry::Mesh<Context::Local>& mesh,
+      Attribute left = LeftAttribute, Attribute right = RightAttribute,
+      Attribute bottom = BottomAttribute, Attribute top = TopAttribute)
     {
       for (auto it = mesh.getBoundary(); !it.end(); ++it)
       {
@@ -66,8 +63,7 @@ namespace Rodin::Tests::Unit
     }
 
     FlatSet<Index> getBoundaryVertices(
-      const Geometry::Mesh<Context::Local>& mesh,
-      const FlatSet<Attribute>& attrs)
+      const Geometry::Mesh<Context::Local>& mesh, const FlatSet<Attribute>& attrs)
     {
       FlatSet<Index> res;
       for (auto it = mesh.getBoundary(); !it.end(); ++it)
@@ -133,7 +129,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies dirichlet BC shape function identity for variational real P1 sanity test by checking tolerance-based numerical results, exact expected values, true predicates.
   TEST(Rodin_Variational_Real_P1_SanityTest, DirichletBCShapeFunctionIdentity)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     const Attribute attr = 1;
 
@@ -174,7 +170,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies dirichlet BC shape function point evaluation for variational real P1 sanity test by checking tolerance-based numerical results, exact expected values, true predicates.
   TEST(Rodin_Variational_Real_P1_SanityTest, DirichletBCShapeFunctionPointEvaluation)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     const Attribute attr = 1;
 
@@ -215,7 +211,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies H1 matches basis for variational point integration point by checking tolerance-based numerical results.
   TEST(Rodin_Variational_PointIntegrationPoint, H1MatchesBasis)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     mesh.getConnectivity().compute(D - 1, 0);
 
@@ -240,7 +236,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies H1 grad matches basis gradient for variational point integration point by checking tolerance-based numerical results.
   TEST(Rodin_Variational_PointIntegrationPoint, H1GradMatchesBasisGradient)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     mesh.getConnectivity().compute(D - 1, 0);
 
@@ -286,7 +282,7 @@ namespace Rodin::Tests::Unit
     DirichletBC dbc(u, g);
     dbc.on(LeftAttribute, RightAttribute);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute, RightAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute, RightAttribute};
     EXPECT_EQ(dbc.getAttributes(), attrs);
     EXPECT_FALSE(dbc.isComponent());
     EXPECT_FALSE(dbc.getValueUUID().has_value());
@@ -325,7 +321,7 @@ namespace Rodin::Tests::Unit
     P1 fes(mesh);
     TrialFunction u(fes);
 
-    const FlatSet<Attribute> attrs{ BottomAttribute, TopAttribute };
+    const FlatSet<Attribute> attrs{BottomAttribute, TopAttribute};
     DirichletBC dbc(u, RealFunction(3.0));
     dbc.on(attrs);
     dbc.assemble();
@@ -353,7 +349,7 @@ namespace Rodin::Tests::Unit
     TrialFunction u(fes);
     TrialFunction v(fes);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute, TopAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute, TopAttribute};
     DirichletBC dbc(u, (RealFunction(1.0) + F::x) * v);
     dbc.on(attrs);
 
@@ -406,8 +402,7 @@ namespace Rodin::Tests::Unit
     TrialFunction v(vectorFes);
 
     const FlatSet<Attribute> attrs{
-      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute
-    };
+      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute};
     const auto expectedVertices = getBoundaryVertices(mesh, attrs);
     const auto vertexCount = mesh.getVertexCount();
 
@@ -465,7 +460,7 @@ namespace Rodin::Tests::Unit
     TrialFunction u(fes);
     TrialFunction v(fes);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute, RightAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute, RightAttribute};
     DirichletBC dbc(u, -v);
     dbc.on(attrs);
     dbc.assemble();
@@ -501,7 +496,7 @@ namespace Rodin::Tests::Unit
     TrialFunction v(fes);
 
     const Real c = 3.5;
-    const FlatSet<Attribute> attrs{ LeftAttribute, RightAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute, RightAttribute};
     DirichletBC dbc(u, RealFunction(c) * v);
     dbc.on(attrs);
     dbc.assemble();
@@ -541,7 +536,7 @@ namespace Rodin::Tests::Unit
     P1 fes(mesh);
     TrialFunction u(fes);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute};
     DirichletBC dbc(u, u);
     dbc.on(attrs);
 
@@ -585,7 +580,7 @@ namespace Rodin::Tests::Unit
     TrialFunction u(vfes);
     TrialFunction v(vfes);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute};
     DirichletBC dbc(u, v);
     dbc.on(attrs);
     dbc.assemble();
@@ -634,8 +629,7 @@ namespace Rodin::Tests::Unit
     const auto& dofs = std::get<IdentifiedDOFs>(dbc.getDOFs());
 
     const FlatSet<Attribute> all{
-      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute
-    };
+      LeftAttribute, RightAttribute, BottomAttribute, TopAttribute};
     const auto expectedVertices = getBoundaryVertices(mesh, all);
     EXPECT_EQ(dofs.size(), expectedVertices.size());
   }
@@ -656,7 +650,7 @@ namespace Rodin::Tests::Unit
       if (mesh.isBoundary(face))
         continue;
 
-      mesh.setAttribute({ faceDim, face }, InterfaceAttribute);
+      mesh.setAttribute({faceDim, face}, InterfaceAttribute);
       for (const auto vertex : it->getVertices())
         interfaceVertices.insert(vertex);
       tagged = true;
@@ -746,7 +740,7 @@ namespace Rodin::Tests::Unit
     TrialFunction u(fes);
     TrialFunction v(fes);
 
-    const FlatSet<Attribute> attrs{ LeftAttribute };
+    const FlatSet<Attribute> attrs{LeftAttribute};
     // A(v) = 1*v + 1*v = 2*v at every basis. (A SUM of two ShapeFunction
     // expressions sharing the same underlying TrialFunction.)
     DirichletBC dbc(u, RealFunction(1.0) * v + RealFunction(1.0) * v);
@@ -785,12 +779,9 @@ namespace Rodin::Tests::Unit
     TrialFunction v(fes);
 
     constexpr Real gamma = 2.5;
-    RealFunction defect = [](const Point& p)
-    {
-      return 3.0 + 2.0 * p.x();
-    };
+    RealFunction defect = [](const Point& p) { return 3.0 + 2.0 * p.x(); };
 
-    const FlatSet<Attribute> attrs{ TopAttribute };
+    const FlatSet<Attribute> attrs{TopAttribute};
     DirichletBC dbc(u, RealFunction(gamma) * v, defect);
     dbc.on(attrs);
     dbc.assemble();
@@ -838,20 +829,20 @@ namespace Rodin::Tests::Unit
     dbc.on(LeftAttribute);
     dbc.assemble();
     const size_t leftSize = std::get<IdentifiedDOFs>(dbc.getDOFs()).size();
-    EXPECT_EQ(leftSize, getBoundaryVertices(mesh, { LeftAttribute }).size());
+    EXPECT_EQ(leftSize, getBoundaryVertices(mesh, {LeftAttribute}).size());
 
     dbc.on(LeftAttribute, RightAttribute);
     dbc.assemble();
     const size_t bothSize = std::get<IdentifiedDOFs>(dbc.getDOFs()).size();
-    EXPECT_EQ(bothSize,
-        getBoundaryVertices(mesh, { LeftAttribute, RightAttribute }).size());
+    EXPECT_EQ(
+      bothSize, getBoundaryVertices(mesh, {LeftAttribute, RightAttribute}).size());
     EXPECT_GT(bothSize, leftSize);
   }
 
   /// @brief Verifies H1 matches basis for variational shape function set point by checking tolerance-based numerical results.
   TEST(Rodin_Variational_ShapeFunctionSetPoint, H1MatchesBasis)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     mesh.getConnectivity().compute(D - 1, 0);
 
@@ -875,7 +866,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies H1 grad matches basis gradient for variational shape function set point by checking tolerance-based numerical results.
   TEST(Rodin_Variational_ShapeFunctionSetPoint, H1GradMatchesBasisGradient)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, { 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Triangle, {2, 2});
     const size_t D = mesh.getDimension();
     mesh.getConnectivity().compute(D - 1, 0);
 

--- a/tests/unit/Rodin/Variational/H1ElementTest.cpp
+++ b/tests/unit/Rodin/Variational/H1ElementTest.cpp
@@ -2273,9 +2273,9 @@ namespace Rodin::Tests::Unit
     // Comprehensive tests for H1Element<1> across all geometries
     // K=1 is piecewise linear element
 
-    for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
-                      Polytope::Type::Pyramid, Polytope::Type::Wedge})
+    for (auto geom :
+      {Polytope::Type::Segment, Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+        Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       RealH1Element<1> pk(geom);
 

--- a/tests/unit/Rodin/Variational/H1Test.cpp
+++ b/tests/unit/Rodin/Variational/H1Test.cpp
@@ -256,7 +256,7 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies pyramid H1 2 uniform grid build for variational H1 space by checking exact expected values.
   TEST(Rodin_Variational_H1_Space, Pyramid_H1_2_UniformGrid_Build)
   {
-    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, { 2, 2, 2 });
+    Mesh mesh = LocalMesh::UniformGrid(Polytope::Type::Pyramid, {2, 2, 2});
     mesh.getConnectivity().compute(3, 2);
     mesh.getConnectivity().compute(2, 1);
     mesh.getConnectivity().compute(1, 0);

--- a/tests/unit/Rodin/Variational/P0ElementTest.cpp
+++ b/tests/unit/Rodin/Variational/P0ElementTest.cpp
@@ -303,7 +303,8 @@ namespace Rodin::Tests::Unit
   {
     RealP0Element k(Polytope::Type::Pyramid);
 
-    EXPECT_NEAR(k.getBasis(0)(Math::Vector<Real>{{0.25, 0.25, 0.25}}), 1, RODIN_FUZZY_CONSTANT);
+    EXPECT_NEAR(
+      k.getBasis(0)(Math::Vector<Real>{{0.25, 0.25, 0.25}}), 1, RODIN_FUZZY_CONSTANT);
 
     const auto& node = k.getNode(0);
     EXPECT_NEAR(node.x(), 0.375, RODIN_FUZZY_CONSTANT);
@@ -651,9 +652,9 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies partition of unity all vector dimensions for final test P0 element vector by checking tolerance-based numerical results.
   TEST(FinalTest_P0Element_Vector, PartitionOfUnity_AllVectorDimensions)
   {
-    for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
-                      Polytope::Type::Pyramid, Polytope::Type::Wedge})
+    for (auto geom :
+      {Polytope::Type::Segment, Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+        Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       for (size_t vdim : {1, 2, 3})
       {
@@ -703,9 +704,8 @@ namespace Rodin::Tests::Unit
   {
     // Test LinearForm evaluation for P0 elements across all geometries
     for (auto geom : {Polytope::Type::Point, Polytope::Type::Segment,
-                      Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
-                      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid,
-                      Polytope::Type::Wedge})
+           Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+           Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       RealP0Element elem(geom);
 
@@ -727,7 +727,7 @@ namespace Rodin::Tests::Unit
   {
     // Test LinearForm for vector P0 elements with different vector dimensions
     for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
+           Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
     {
       for (size_t vdim : {1, 2, 3})
       {
@@ -766,9 +766,9 @@ namespace Rodin::Tests::Unit
   TEST(FinalTest_P0Element_Interpolation, ScalarConstantInterpolation)
   {
     // Test that P0 element correctly interpolates constant functions
-    for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
-                      Polytope::Type::Pyramid, Polytope::Type::Wedge})
+    for (auto geom :
+      {Polytope::Type::Segment, Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+        Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       RealP0Element elem(geom);
 

--- a/tests/unit/Rodin/Variational/P1ElementTest.cpp
+++ b/tests/unit/Rodin/Variational/P1ElementTest.cpp
@@ -891,7 +891,7 @@ namespace Rodin::Tests::Unit
   TEST(FinalTest_P1Element_Vector, VectorDimensions_Pyramid)
   {
     VectorP1Element<Real> elem(Polytope::Type::Pyramid, 3);
-    EXPECT_EQ(elem.getCount(), 15);  // 3 components × 5 nodes
+    EXPECT_EQ(elem.getCount(), 15); // 3 components × 5 nodes
   }
 
   // ========================================================================
@@ -902,9 +902,9 @@ namespace Rodin::Tests::Unit
   TEST(FinalTest_P1Element_LinearForm, ScalarLinearForm_AllGeometries)
   {
     // Test LinearForm evaluation for P1 elements across all geometries
-    for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Quadrilateral, Polytope::Type::Tetrahedron,
-                      Polytope::Type::Pyramid, Polytope::Type::Wedge})
+    for (auto geom :
+      {Polytope::Type::Segment, Polytope::Type::Triangle, Polytope::Type::Quadrilateral,
+        Polytope::Type::Tetrahedron, Polytope::Type::Pyramid, Polytope::Type::Wedge})
     {
       RealP1Element elem(geom);
 
@@ -981,7 +981,7 @@ namespace Rodin::Tests::Unit
   {
     // Test that gradient functions work correctly across geometries
     for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
+           Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
     {
       RealP1Element elem(geom);
 
@@ -1149,7 +1149,7 @@ namespace Rodin::Tests::Unit
   {
     // Test that P1 element exactly interpolates linear functions
     for (auto geom : {Polytope::Type::Segment, Polytope::Type::Triangle,
-                      Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
+           Polytope::Type::Tetrahedron, Polytope::Type::Pyramid})
     {
       RealP1Element elem(geom);
 

--- a/tests/unit/Rodin/Variational/P1QuadratureRuleTest.cpp
+++ b/tests/unit/Rodin/Variational/P1QuadratureRuleTest.cpp
@@ -143,15 +143,14 @@ namespace Rodin::Tests::Unit
   /// @brief Verifies vector mass matches grid function linear form for variational P1 quadrature rule by checking tolerance-based numerical results, exact expected values, form assembly.
   TEST(Rodin_Variational_P1QuadratureRule, VectorMass_MatchesGridFunctionLinearForm)
   {
-    Mesh mesh =
-      Mesh<Rodin::Context::Local>::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
-      .finalize();
+    Mesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
+                  .finalize();
 
     const size_t vdim = 2;
     P1<Math::SpatialVector<Real>> fes(mesh, vdim);
@@ -177,17 +176,17 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Verifies scalar weighted vector mass matches grid function linear form for variational P1 quadrature rule by checking tolerance-based numerical results, exact expected values, form assembly.
-  TEST(Rodin_Variational_P1QuadratureRule, ScalarWeightedVectorMass_MatchesGridFunctionLinearForm)
+  TEST(Rodin_Variational_P1QuadratureRule,
+    ScalarWeightedVectorMass_MatchesGridFunctionLinearForm)
   {
-    Mesh mesh =
-      Mesh<Rodin::Context::Local>::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
-      .finalize();
+    Mesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
+                  .finalize();
 
     const size_t vdim = 2;
     P1<Math::SpatialVector<Real>> fes(mesh, vdim);
@@ -200,7 +199,8 @@ namespace Rodin::Tests::Unit
     for (Eigen::Index i = 0; i < x.size(); ++i)
       x(i) = static_cast<Real>(i + 1);
 
-    RealFunction coeff([](const Geometry::Point& p) { return 1.0 + p.x() + 2.0 * p.y(); });
+    RealFunction coeff(
+      [](const Geometry::Point& p) { return 1.0 + p.x() + 2.0 * p.y(); });
 
     BilinearForm mass(u, v);
     mass = Integral(Dot(Mult(coeff, u), v));
@@ -215,17 +215,17 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Verifies outer scalar weighted vector mass matches grid function linear form for variational P1 quadrature rule by checking tolerance-based numerical results, exact expected values, form assembly.
-  TEST(Rodin_Variational_P1QuadratureRule, OuterScalarWeightedVectorMass_MatchesGridFunctionLinearForm)
+  TEST(Rodin_Variational_P1QuadratureRule,
+    OuterScalarWeightedVectorMass_MatchesGridFunctionLinearForm)
   {
-    Mesh mesh =
-      Mesh<Rodin::Context::Local>::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
-      .finalize();
+    Mesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
+                  .finalize();
 
     const size_t vdim = 2;
     P1<Math::SpatialVector<Real>> fes(mesh, vdim);
@@ -238,7 +238,8 @@ namespace Rodin::Tests::Unit
     for (Eigen::Index i = 0; i < x.size(); ++i)
       x(i) = static_cast<Real>(i + 1);
 
-    RealFunction coeff([](const Geometry::Point& p) { return 1.0 + p.x() + 2.0 * p.y(); });
+    RealFunction coeff(
+      [](const Geometry::Point& p) { return 1.0 + p.x() + 2.0 * p.y(); });
 
     BilinearForm mass(u, v);
     mass = Integral(coeff * Dot(u, v));
@@ -253,17 +254,17 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Verifies matrix weighted vector mass matches grid function linear form for variational P1 quadrature rule by checking tolerance-based numerical results, exact expected values, form assembly.
-  TEST(Rodin_Variational_P1QuadratureRule, MatrixWeightedVectorMass_MatchesGridFunctionLinearForm)
+  TEST(Rodin_Variational_P1QuadratureRule,
+    MatrixWeightedVectorMass_MatchesGridFunctionLinearForm)
   {
-    Mesh mesh =
-      Mesh<Rodin::Context::Local>::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
-      .finalize();
+    Mesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
+                  .finalize();
 
     const size_t vdim = 2;
     P1<Math::SpatialVector<Real>> fes(mesh, vdim);
@@ -296,17 +297,17 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Verifies vector potential constant kernel uses separate trial and test basis values for variational P1 quadrature rule by checking tolerance-based numerical results, exact expected values, form assembly.
-  TEST(Rodin_Variational_P1QuadratureRule, VectorPotentialConstantKernel_UsesSeparateTrialAndTestBasisValues)
+  TEST(Rodin_Variational_P1QuadratureRule,
+    VectorPotentialConstantKernel_UsesSeparateTrialAndTestBasisValues)
   {
-    Mesh mesh =
-      Mesh<Rodin::Context::Local>::Builder()
-      .initialize(2)
-      .nodes(3)
-      .vertex({0, 0})
-      .vertex({1, 0})
-      .vertex({0, 1})
-      .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
-      .finalize();
+    Mesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                  .initialize(2)
+                  .nodes(3)
+                  .vertex({0, 0})
+                  .vertex({1, 0})
+                  .vertex({0, 1})
+                  .polytope(Polytope::Type::Triangle, {{0, 1, 2}})
+                  .finalize();
 
     const size_t vdim = 2;
     P1<Math::SpatialVector<Real>> fes(mesh, vdim);
@@ -323,15 +324,13 @@ namespace Rodin::Tests::Unit
     scalarProblem.assemble();
     const auto& scalarA = scalarProblem.getLinearSystem().getOperator();
 
-    auto kernel =
-      [](Math::SpatialMatrix<Real>& out, const Point&, const Point&)
-      {
-        out.resize(2, 2);
-        out(0, 0) = 2.0;
-        out(0, 1) = -3.0;
-        out(1, 0) = 5.0;
-        out(1, 1) = 7.0;
-      };
+    auto kernel = [](Math::SpatialMatrix<Real>& out, const Point&, const Point&) {
+      out.resize(2, 2);
+      out(0, 0) = 2.0;
+      out(0, 1) = -3.0;
+      out(1, 0) = 5.0;
+      out(1, 1) = 7.0;
+    };
 
     DenseProblem problem(u, v);
     problem = Integral(Potential(kernel, u), v);
@@ -352,15 +351,13 @@ namespace Rodin::Tests::Unit
         {
           for (size_t trialComp = 0; trialComp < vdim; ++trialComp)
           {
-            const Eigen::Index row =
-              static_cast<Eigen::Index>(testVertex + testComp * 3);
+            const Eigen::Index row = static_cast<Eigen::Index>(testVertex + testComp * 3);
             const Eigen::Index col =
               static_cast<Eigen::Index>(trialVertex + trialComp * 3);
-            EXPECT_NEAR(
-              A(row, col),
-              scalarA(
-                static_cast<Eigen::Index>(testVertex),
-                static_cast<Eigen::Index>(trialVertex)) * k[testComp][trialComp],
+            EXPECT_NEAR(A(row, col),
+              scalarA(static_cast<Eigen::Index>(testVertex),
+                static_cast<Eigen::Index>(trialVertex)) *
+                k[testComp][trialComp],
               1e-12);
           }
         }

--- a/tests/unit/Rodin/Variational/SubMeshGridFunctionTest.cpp
+++ b/tests/unit/Rodin/Variational/SubMeshGridFunctionTest.cpp
@@ -186,7 +186,8 @@ namespace Rodin::Tests::Unit
   }
 
   /// @brief Skin SubMesh: (d-1)-dimensional boundary of the full 2D mesh.
-  TEST(Rodin_Variational_P1_ParentMesh, GridFunction_EvaluateAtBoundarySubMeshPoint_Inclusion)
+  TEST(Rodin_Variational_P1_ParentMesh,
+    GridFunction_EvaluateAtBoundarySubMeshPoint_Inclusion)
   {
     // Skin SubMesh: (d-1)-dimensional boundary of the full 2D mesh.
     // The FES is on the parent 2D mesh; evaluate at a boundary edge point.
@@ -200,7 +201,7 @@ namespace Rodin::Tests::Unit
 
     SubMesh<Context::Local> skin = mesh.skin();
 
-    const size_t edgeDim = skin.getDimension();   // = 1 for 2D mesh
+    const size_t edgeDim = skin.getDimension(); // = 1 for 2D mesh
     auto it = skin.getPolytope(edgeDim, 0);
     const auto& edgePolytope = *it;
     // Midpoint of the segment in reference coordinates


### PR DESCRIPTION
## Why the develop→master Format check (#317) fails

`.clang-format` was introduced only in #310 (`a4783ebfd`). **212 of develop's 215 commits predate it** and were never formatted to it. The per-PR Format job only validates each PR's own changed lines *against develop*, so the backlog was never checked. #317 (develop→master) is the first time the full diff is checked against master — which has **no `.clang-format` at all** — so the entire un-formatted backlog surfaces: 141 files.

## What this does

`git clang-format` of the changed-vs-master lines, using the CI-pinned **clang-format 18.1.8**. 141 files, whitespace/wrapping only — clang-format is token-preserving, no semantic changes. Verified locally:
- `dev/check_format.py --base <master-base> --head HEAD` → OK
- `dev/style_lint.py` → OK (9 baselined, no new)

Merging this into develop makes #317's Format check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)