### PR TITLE
Variational: let integrators set their integration order explicitly

### DIFF
--- a/src/Rodin/Variational/H1/QuadratureRule.h
+++ b/src/Rodin/Variational/H1/QuadratureRule.h
@@ -117,8 +117,8 @@ namespace Rodin::Variational
         const auto& fes = integrand.getFiniteElementSpace();
         const auto& fe  = fes.getFiniteElement(d, idx);
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(fe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(fe.getOrder()));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -332,8 +332,8 @@ namespace Rodin::Variational
         const auto& fes = integrand.getFiniteElementSpace();
         const auto& fe  = fes.getFiniteElement(d, idx);
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(fe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(fe.getOrder()));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -560,7 +560,7 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = k_tr + k_te;
+        const size_t order = this->getOrder(polytope).value_or(k_tr + k_te);
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -831,7 +831,7 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = k_tr + k_te;
+        const size_t order = this->getOrder(polytope).value_or(k_tr + k_te);
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1111,7 +1111,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1437,7 +1438,7 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = k_tr + k_te;
+        const size_t order = this->getOrder(polytope).value_or(k_tr + k_te);
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1671,7 +1672,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_tr == 0) ? 0 : (k_tr + k_te - 1);
+        const size_t order =
+          this->getOrder(polytope).value_or((k_tr == 0) ? 0 : (k_tr + k_te - 1));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1948,7 +1950,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_te == 0) ? 0 : (k_tr + k_te - 1);
+        const size_t order =
+          this->getOrder(polytope).value_or((k_te == 0) ? 0 : (k_tr + k_te - 1));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2243,7 +2246,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2644,7 +2648,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recomputeQf = (!m_set || m_order != order || m_geometry != geometry);
@@ -2976,7 +2981,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recomputeQf = (!m_set || m_order != order || m_geometry != geometry);
@@ -3344,7 +3350,8 @@ namespace Rodin::Variational
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe .getOrder();
         // Gradient of trial (k_tr - 1) times value of test (k_te)
-        const size_t order = (k_tr == 0) ? k_te : (k_tr + k_te - 1);
+        const size_t order =
+          this->getOrder(polytope).value_or((k_tr == 0) ? k_te : (k_tr + k_te - 1));
 
         const auto geometry = polytope.getGeometry();
         const bool recomputeQf = (!m_set || m_order != order || m_geometry != geometry);

--- a/src/Rodin/Variational/Integrator.h
+++ b/src/Rodin/Variational/Integrator.h
@@ -15,7 +15,11 @@
 #ifndef RODIN_VARIATIONAL_INTEGRATOR_H
 #define RODIN_VARIATIONAL_INTEGRATOR_H
 
+#include <functional>
+
 #include "Rodin/FormLanguage/Base.h"
+#include "Rodin/Geometry/Polytope.h"
+#include "Rodin/Types.h"
 
 namespace Rodin::Variational
 {
@@ -67,7 +71,8 @@ namespace Rodin::Variational
        * @param[in] other Integrator to copy
        */
       Integrator(const Integrator& other)
-        : Parent(other)
+        : Parent(other),
+          m_order(other.m_order)
       {}
 
       /**
@@ -75,10 +80,76 @@ namespace Rodin::Variational
        * @param[in] other Integrator to move
        */
       Integrator(Integrator&& other)
-        : Parent(std::move(other))
+        : Parent(std::move(other)),
+          m_order(std::move(other.m_order))
       {}
 
       /// @brief Virtual destructor
+      /**
+       * @brief Rule giving the integration order to use on a polytope.
+       *
+       * @see setOrder(OrderType)
+       */
+      using OrderType = std::function<size_t(const Geometry::Polytope&)>;
+
+      /**
+       * @brief Restores order inference from the integrand.
+       *
+       * This is the default: the order is derived per polytope from the
+       * polynomial degrees of the finite elements living on it. Correct
+       * whenever the integrand is polynomial.
+       */
+      Integrator& setOrder(std::nullopt_t)
+      {
+        m_order = nullptr;
+        return *this;
+      }
+
+      /**
+       * @brief Sets a constant integration order.
+       *
+       * Note that the inferred order is a function of the polytope, so a
+       * constant is only equivalent to inference on a mesh whose elements all
+       * share one degree; prefer @ref setOrder(OrderType) otherwise.
+       *
+       * @param[in] order Integration order to use on every polytope
+       */
+      Integrator& setOrder(size_t order)
+      {
+        m_order = [order](const Geometry::Polytope&) { return order; };
+        return *this;
+      }
+
+      /**
+       * @brief Sets a rule computing the integration order per polytope.
+       *
+       * On an integrator the order is the degree of the quadrature rule, not
+       * the polynomial degree of an expression; the two coincide only when the
+       * integrand is polynomial. Set it explicitly whenever it is not — a
+       * coefficient composing a level set with a mesh lookup, say — since the
+       * inferred order is then meaningless and typically too low.
+       *
+       * @param[in] order Rule invoked with the polytope being integrated
+       */
+      Integrator& setOrder(OrderType order)
+      {
+        m_order = std::move(order);
+        return *this;
+      }
+
+      /**
+       * @brief The integration order to use on a polytope.
+       * @param[in] polytope Polytope being integrated
+       * @returns The order given by the rule, or an empty optional when the
+       * order is to be inferred from the integrand.
+       */
+      Optional<size_t> getOrder(const Geometry::Polytope& polytope) const
+      {
+        if (m_order)
+          return m_order(polytope);
+        return std::nullopt;
+      }
+
       virtual ~Integrator() = default;
 
       /**
@@ -92,6 +163,14 @@ namespace Rodin::Variational
        * @returns Pointer to newly allocated copy
        */
       virtual Integrator* copy() const noexcept override = 0;
+
+    private:
+        // Empty unless setOrder() was called, in which case it is the rule
+        // resolving the order. Distinct from the m_order each QuadratureRule
+        // specialisation declares, which caches the *resolved* order for its
+        // recompute check; that member hides this one, which is private here
+        // and reached only through getOrder().
+      OrderType m_order;
   };
 }
 

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -156,8 +156,8 @@ namespace Rodin::Variational
         const auto& fes = integrand.getFiniteElementSpace();
         const auto& fe  = fes.getFiniteElement(d, idx);
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(fe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(fe.getOrder()));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -355,8 +355,8 @@ namespace Rodin::Variational
         const auto& fes = integrand.getFiniteElementSpace();
         const auto& fe  = fes.getFiniteElement(d, idx);
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(fe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(fe.getOrder()));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -583,7 +583,8 @@ namespace Rodin::Variational
           polytope.getDimension(), polytope.getIndex());
 
         // P1 × P1 product is degree 2 — need at least order-2 quadrature.
-        const size_t order = trialfe.getOrder() + testfe.getOrder();
+        const size_t order =
+          this->getOrder(polytope).value_or(trialfe.getOrder() + testfe.getOrder());
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
 
         if (recompute)
@@ -931,7 +932,8 @@ namespace Rodin::Variational
         const auto& trialfe = trialfes.getFiniteElement(d, idx);
         const auto& testfe  = testfes.getFiniteElement(d, idx);
 
-        const size_t order = trialfe.getOrder() + testfe.getOrder();
+        const size_t order =
+          this->getOrder(polytope).value_or(trialfe.getOrder() + testfe.getOrder());
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1245,7 +1247,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1509,7 +1512,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -1823,7 +1827,8 @@ namespace Rodin::Variational
         const auto& trialfe = trialfes.getFiniteElement(d, idx);
         const auto& testfe  = testfes.getFiniteElement(d, idx);
 
-        const size_t order = trialfe.getOrder() + testfe.getOrder();
+        const size_t order =
+          this->getOrder(polytope).value_or(trialfe.getOrder() + testfe.getOrder());
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2045,7 +2050,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2271,7 +2277,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2530,7 +2537,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -2841,7 +2849,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;
@@ -3181,7 +3190,8 @@ namespace Rodin::Variational
 
         const size_t k_tr = trialfe.getOrder();
         const size_t k_te = testfe.getOrder();
-        const size_t order = (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2);
+        const size_t order = this->getOrder(polytope).value_or(
+          (k_tr == 0 || k_te == 0) ? 0 : (k_tr + k_te - 2));
 
         const auto geometry = polytope.getGeometry();
         const bool recompute = !m_set || m_order != order || m_geometry != geometry;

--- a/src/Rodin/Variational/QuadratureRule.h
+++ b/src/Rodin/Variational/QuadratureRule.h
@@ -535,8 +535,8 @@ namespace Rodin::Variational
 
         const auto geometry = polytope.getGeometry();
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(trialfe.getOrder() + testfe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(trialfe.getOrder() + testfe.getOrder()));
 
         const bool recompute =
           !m_set || (m_order != order) || (m_geometry != geometry);
@@ -751,8 +751,8 @@ namespace Rodin::Variational
 
         const auto geometry = polytope.getGeometry();
 
-        const size_t order =
-          integrand.getOrder(polytope).value_or(fe.getOrder());
+        const size_t order = this->getOrder(polytope).value_or(
+          integrand.getOrder(polytope).value_or(fe.getOrder()));
 
         const bool recompute =
           !m_set || (m_order != order) || (m_geometry != geometry);

--- a/tests/unit/Rodin/Variational/CMakeLists.txt
+++ b/tests/unit/Rodin/Variational/CMakeLists.txt
@@ -653,3 +653,14 @@ gtest_discover_tests(RodinVariationalSubMeshGridFunctionTest
   PROPERTIES
     LABELS unit
 )
+
+add_executable(RodinVariationalIntegratorOrderTest IntegratorOrderTest.cpp)
+target_link_libraries(RodinVariationalIntegratorOrderTest
+  PUBLIC
+  GTest::gtest
+  GTest::gtest_main
+  Rodin::Variational)
+gtest_discover_tests(RodinVariationalIntegratorOrderTest
+  PROPERTIES
+    LABELS unit
+)

--- a/tests/unit/Rodin/Variational/IntegratorOrderTest.cpp
+++ b/tests/unit/Rodin/Variational/IntegratorOrderTest.cpp
@@ -1,0 +1,353 @@
+#include <gtest/gtest.h>
+
+#include <set>
+
+#include "Rodin/Variational.h"
+#include "Rodin/Variational/H1.h"
+#include "Rodin/Assembly/Default.h"
+
+using namespace Rodin;
+using namespace Rodin::Geometry;
+using namespace Rodin::Variational;
+
+namespace Rodin::Tests::Unit
+{
+  namespace
+  {
+    /// @brief Unit square meshed with @p n x @p n cells of the given geometry.
+    LocalMesh unitSquare(Polytope::Type g, size_t n)
+    {
+      LocalMesh mesh = LocalMesh::UniformGrid(g, {n, n});
+      mesh.getConnectivity().compute(2, 1);
+      mesh.getConnectivity().compute(1, 0);
+      return mesh;
+    }
+
+    /**
+     * @brief Unit square as one triangle pair plus one quadrilateral, so that a
+     * single mesh carries two polytope geometries.
+     *
+     *   (0,1) 2---3 (1,1)      (1,1) 3---5 (2,1)
+     *         | \ |                  |   |
+     *   (0,0) 0---1 (1,0)      (1,0) 1---4 (2,0)
+     */
+    LocalMesh mixedGeometryMesh()
+    {
+      LocalMesh mesh = Mesh<Rodin::Context::Local>::Builder()
+                         .initialize(2)
+                         .nodes(6)
+                         .vertex({0, 0})
+                         .vertex({1, 0})
+                         .vertex({0, 1})
+                         .vertex({1, 1})
+                         .vertex({2, 0})
+                         .vertex({2, 1})
+                         .polytope(Polytope::Type::Triangle, {0, 1, 2})
+                         .polytope(Polytope::Type::Triangle, {1, 3, 2})
+                         .polytope(Polytope::Type::Quadrilateral, {1, 4, 5, 3})
+                         .finalize();
+      mesh.getConnectivity().compute(2, 1);
+      mesh.getConnectivity().compute(1, 0);
+      return mesh;
+    }
+
+    /**
+     * @brief Integral of @p f over the mesh, assembled through a load form.
+     *
+     * The nodal basis is a partition of unity, so summing the assembled vector
+     * gives @f$\sum_i\int f\varphi_i=\int f@f$. That makes the exactness of the
+     * quadrature rule directly observable.
+     */
+    template <class Integrand>
+    Real assembledIntegral(Integrand&& integrand, const auto& v)
+    {
+      LinearForm lf(v);
+      lf = std::forward<Integrand>(integrand);
+      lf.assemble();
+      return lf.getVector().sum();
+    }
+  }
+
+  // ==========================================================================
+  // Order resolution: nullopt / constant / rule.
+  // ==========================================================================
+
+  /// @brief By default an integrator infers its order, reporting none of its own.
+  TEST(Rodin_Variational_IntegratorOrder, Default_InfersOrder)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto integ = Integral(RealFunction(1.0), v);
+    const auto it = mesh.getPolytope(2, 0);
+    EXPECT_FALSE(integ.getOrder(*it).has_value());
+  }
+
+  /// @brief A constant order is reported for every polytope.
+  TEST(Rodin_Variational_IntegratorOrder, Constant_AppliesEverywhere)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto integ = Integral(RealFunction(1.0), v);
+    integ.setOrder(5);
+
+    for (auto it = mesh.getCell(); it; ++it)
+      EXPECT_EQ(integ.getOrder(*it).value_or(0), 5u);
+  }
+
+  /// @brief A rule is evaluated per polytope, and sees each one.
+  TEST(Rodin_Variational_IntegratorOrder, Rule_EvaluatedPerPolytope)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    std::set<Index> seen;
+    auto integ = Integral(RealFunction(1.0), v);
+    integ.setOrder([&seen](const Polytope& p) -> size_t {
+      seen.insert(p.getIndex());
+      return 2 + p.getIndex() % 3;
+    });
+
+    for (auto it = mesh.getCell(); it; ++it)
+      EXPECT_EQ(integ.getOrder(*it).value_or(0), 2 + it->getIndex() % 3);
+    EXPECT_EQ(seen.size(), mesh.getCellCount());
+  }
+
+  /// @brief Passing nullopt restores inference after an explicit order was set.
+  TEST(Rodin_Variational_IntegratorOrder, Nullopt_RestoresInference)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto integ = Integral(RealFunction(1.0), v);
+    const auto it = mesh.getPolytope(2, 0);
+
+    integ.setOrder(4);
+    EXPECT_TRUE(integ.getOrder(*it).has_value());
+    integ.setOrder(std::nullopt);
+    EXPECT_FALSE(integ.getOrder(*it).has_value());
+  }
+
+  /// @brief The order survives the copy every form assembly makes of its integrator.
+  TEST(Rodin_Variational_IntegratorOrder, Order_SurvivesCopy)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto integ = Integral(RealFunction(1.0), v);
+    integ.setOrder(6);
+
+    auto copied = integ;
+    const auto it = mesh.getPolytope(2, 0);
+    EXPECT_EQ(copied.getOrder(*it).value_or(0), 6u);
+
+    std::unique_ptr<Integrator> cloned(integ.copy());
+    EXPECT_EQ(cloned->getOrder(*it).value_or(0), 6u);
+  }
+
+  // ==========================================================================
+  // The order must reach the quadrature rule. A rule of degree >= deg(f)
+  // integrates f exactly; a deficient one does not. This is the property whose
+  // silent loss degrades a solve without any diagnostic.
+  // ==========================================================================
+
+  /// @brief A sufficient order integrates a quartic exactly; a deficient one does not.
+  TEST(Rodin_Variational_IntegratorOrder, Order_ReachesQuadrature)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+      // f(x, y) = x^4, whose integral over the unit square is 1/5.
+    auto f = RealFunction([](const Geometry::Point& p) -> Real {
+      const Real x = p.getPhysicalCoordinates()(0);
+      return x * x * x * x;
+    });
+    constexpr Real exact = Real(1) / Real(5);
+
+    auto accurate = Integral(f, v);
+    accurate.setOrder(8);
+    EXPECT_NEAR(assembledIntegral(accurate, v), exact, 1e-12);
+
+    auto deficient = Integral(f, v);
+    deficient.setOrder(1);
+    const Real coarse = assembledIntegral(deficient, v);
+    EXPECT_GT(std::abs(coarse - exact), 1e-6)
+      << "an order-1 rule must not integrate a quartic exactly; if it does, "
+         "setOrder is not reaching the quadrature formula";
+  }
+
+  /// @brief A per-polytope rule reaches the quadrature just as a constant does.
+  TEST(Rodin_Variational_IntegratorOrder, Rule_ReachesQuadrature)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto f = RealFunction([](const Geometry::Point& p) -> Real {
+      const Real x = p.getPhysicalCoordinates()(0);
+      return x * x * x * x;
+    });
+    constexpr Real exact = Real(1) / Real(5);
+
+    auto integ = Integral(f, v);
+    integ.setOrder([](const Polytope&) -> size_t { return 8; });
+    EXPECT_NEAR(assembledIntegral(integ, v), exact, 1e-12);
+  }
+
+  // ==========================================================================
+  // Uniformity across integrator kinds and mesh configurations.
+  // ==========================================================================
+
+  /// @brief setOrder is honoured by bilinear integrators too.
+  TEST(Rodin_Variational_IntegratorOrder, BilinearIntegrator_HonoursOrder)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TrialFunction u(fes);
+    TestFunction v(fes);
+
+    auto integ = Integral(Dot(u, v));
+    const auto it = mesh.getPolytope(2, 0);
+    EXPECT_FALSE(integ.getOrder(*it).has_value());
+
+    integ.setOrder(7);
+    EXPECT_EQ(integ.getOrder(*it).value_or(0), 7u);
+
+      // The mass matrix of a partition of unity sums to the domain measure,
+      // and an over-integrated rule must not change that.
+    BilinearForm bf(u, v);
+    bf = integ;
+    bf.assemble();
+    EXPECT_NEAR(bf.getOperator().sum(), 1.0, 1e-12);
+  }
+
+  /// @brief setOrder is honoured by boundary integrators too.
+  TEST(Rodin_Variational_IntegratorOrder, BoundaryIntegrator_HonoursOrder)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto integ = BoundaryIntegral(RealFunction(1.0), v);
+    const auto it = mesh.getPolytope(1, 0);
+    EXPECT_FALSE(integ.getOrder(*it).has_value());
+
+    integ.setOrder(3);
+    EXPECT_EQ(integ.getOrder(*it).value_or(0), 3u);
+  }
+
+  /// @brief Inference differs with the polynomial degree of the space.
+  TEST(Rodin_Variational_IntegratorOrder, MixedOrder_InferenceFollowsDegree)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 linear(std::integral_constant<size_t, 1>{}, mesh);
+    H1 quadratic(std::integral_constant<size_t, 2>{}, mesh);
+
+    TrialFunction u1(linear);
+    TestFunction v1(linear);
+    TrialFunction u2(quadratic);
+    TestFunction v2(quadratic);
+
+      // Both spaces integrate their own mass matrix exactly, whatever order
+      // each one infers.
+    BilinearForm bf1(u1, v1);
+    bf1 = Integral(Dot(u1, v1));
+    bf1.assemble();
+    EXPECT_NEAR(bf1.getOperator().sum(), 1.0, 1e-12);
+
+    BilinearForm bf2(u2, v2);
+    bf2 = Integral(Dot(u2, v2));
+    bf2.assemble();
+    EXPECT_NEAR(bf2.getOperator().sum(), 1.0, 1e-12);
+  }
+
+  /// @brief An explicit order overrides inference on a higher-degree space.
+  TEST(Rodin_Variational_IntegratorOrder, MixedOrder_ExplicitOverridesInference)
+  {
+    auto mesh = unitSquare(Polytope::Type::Triangle, 2);
+    H1 quadratic(std::integral_constant<size_t, 2>{}, mesh);
+    TestFunction v(quadratic);
+
+    auto integ = Integral(RealFunction(1.0), v);
+    const auto it = mesh.getPolytope(2, 0);
+    EXPECT_FALSE(integ.getOrder(*it).has_value());
+
+    integ.setOrder(2);
+    EXPECT_EQ(integ.getOrder(*it).value_or(0), 2u);
+  }
+
+  /// @brief On a quadrilateral mesh the order machinery behaves identically.
+  TEST(Rodin_Variational_IntegratorOrder, Quadrilateral_HonoursOrder)
+  {
+    auto mesh = unitSquare(Polytope::Type::Quadrilateral, 2);
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    auto f = RealFunction([](const Geometry::Point& p) -> Real {
+      const Real x = p.getPhysicalCoordinates()(0);
+      return x * x * x * x;
+    });
+
+    auto integ = Integral(f, v);
+    integ.setOrder(8);
+    EXPECT_NEAR(assembledIntegral(integ, v), Real(1) / Real(5), 1e-12);
+  }
+
+  /**
+   * @brief On a mesh carrying two geometries a rule sees both, and may give
+   * each its own order.
+   *
+   * This is the case a constant order cannot express: the inferred order is a
+   * function of the polytope, so only a rule can follow it.
+   */
+  TEST(Rodin_Variational_IntegratorOrder, MixedPolytopes_RuleSeesEachGeometry)
+  {
+    auto mesh = mixedGeometryMesh();
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+    std::set<Polytope::Type> geometries;
+    auto integ = Integral(RealFunction(1.0), v);
+    integ.setOrder([&geometries](const Polytope& p) -> size_t {
+      geometries.insert(p.getGeometry());
+      return p.getGeometry() == Polytope::Type::Quadrilateral ? 4 : 2;
+    });
+
+    for (auto it = mesh.getCell(); it; ++it)
+    {
+      const size_t expected =
+        it->getGeometry() == Polytope::Type::Quadrilateral ? 4u : 2u;
+      EXPECT_EQ(integ.getOrder(*it).value_or(0), expected);
+    }
+
+    EXPECT_EQ(geometries.size(), 2u)
+      << "the rule must observe both polytope geometries in the mesh";
+  }
+
+  /// @brief A per-geometry rule integrates correctly across a mixed mesh.
+  TEST(Rodin_Variational_IntegratorOrder, MixedPolytopes_IntegratesExactly)
+  {
+    auto mesh = mixedGeometryMesh();
+    H1 fes(std::integral_constant<size_t, 1>{}, mesh);
+    TestFunction v(fes);
+
+      // The mesh covers [0,2] x [0,1]; the integral of x^4 over it is 32/5.
+    auto f = RealFunction([](const Geometry::Point& p) -> Real {
+      const Real x = p.getPhysicalCoordinates()(0);
+      return x * x * x * x;
+    });
+
+    auto integ = Integral(f, v);
+    integ.setOrder([](const Polytope& p) -> size_t {
+      return p.getGeometry() == Polytope::Type::Quadrilateral ? 8 : 6;
+    });
+    EXPECT_NEAR(assembledIntegral(integ, v), Real(32) / Real(5), 1e-10);
+  }
+}


### PR DESCRIPTION
## Problem

Integrators derive their quadrature order from the polynomial degree of the integrand, evaluated per polytope. The inference is silent and has no fallback: `Dot::getOrder` is additive and propagates `nullopt`, so a coefficient that is **not** polynomial — and therefore truthfully reports no degree — collapses the whole expression to `fe.getOrder()`.

The form then assembles against a rule far coarser than intended, with no error and no warning. The only symptom is a quietly degraded solve.

This is not hypothetical. It surfaced while moving a level-set interface term onto the form language: the coefficient composes a level set with a mesh point-location query, so it has no polynomial degree, and the intended order-2 rule silently became order 1. A converging fit went from `2.261e-03` to `1.132e-02` with a line-search failure, purely from under-integration.

## Change

`Integrator::setOrder`, placed on the common base of the linear and bilinear integrator hierarchies so every integrator gains it at once:

```cpp
using OrderType = std::function<size_t(const Geometry::Polytope&)>;

setOrder(std::nullopt)   // infer from the integrand (the default)
setOrder(3)              // constant
setOrder(rule)           // computed per polytope
```

The inferred order is itself a function of the polytope, so a constant is only equivalent to inference on a mesh of uniform degree and geometry. The rule form exists to follow it where it is not.

All **26** inference sites — across `Variational/QuadratureRule.h`, `Variational/P1/QuadratureRule.h` and `Variational/H1/QuadratureRule.h` — consume it uniformly:

```cpp
const size_t order = this->getOrder(polytope).value_or(<inference>);
```

## Compatibility

The default is an empty `std::function`, so existing call sites derive their order exactly as before — a predicted branch, no call, no allocation. **No behaviour changes anywhere unless `setOrder` is called.**

## Tests

New `IntegratorOrderTest` (14 cases):

- **Order resolution** — default, constant, per-polytope rule, `nullopt` reset, and propagation through the copy every form makes of its integrator.
- **Quadrature reachability** — the regression tests proper.
- **Coverage** — linear, bilinear and boundary integrators; `H1<1>` vs `H1<2>`; quadrilateral meshes; and a hand-built mixed-geometry mesh (two triangles plus a quadrilateral) where a rule gives each geometry its own order and still integrates exactly.

The reachability tests assert **both** directions: an order-8 rule must integrate a quartic exactly, and an order-1 rule must **not**. Only the negative half distinguishes a working `setOrder` from one that is ignored — and that half is what caught the `H1` specialisations, which I had left unpatched. A one-directional test would have passed over a completely inert API.

## Verification

- Full `Variational` unit suite: **80/80 executables pass**, 0 build errors.
- Verified against a downstream level-set solver: bit-identical results across 2D and 3D cases, unchanged runtime.

## Notes for review

- A genuinely mixed-*degree* space isn't constructible in Rodin (one FES has one fixed `K`), so mixed-degree coverage is across *different* spaces, and mixed geometry within *one* mesh.
- The `m_order` added to `Integrator` is shadowed by the same-named member each `QuadratureRule` specialisation uses to cache its resolved order. That is benign — name hiding is total, and the base member is `private`, so the derived one is always the one selected — but it is commented at the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
