### PR TITLE
Document specialization tables in Doxygen

### DIFF
--- a/.github/agents/rodin.agent.md
+++ b/.github/agents/rodin.agent.md
@@ -116,6 +116,12 @@ python3 dev/check_clang_tidy.py --build-dir build   # identifier naming
 python3 dev/check_doxygen_warnings.py               # needs doxygen 1.14.0 exactly
 ```
 
+For documentation changes, also preserve the rendered Doxygen/m.css contract:
+class pages that document multiple supported specializations include a complete
+`Specialization` / `Description` table with linked specialization entries, and
+public class/template/header references in `@see` blocks or prose lists are
+explicit `@ref` references or generated-page HTML links, not bare names.
+
 Every check is a **ratchet** measured against a committed baseline in `dev/`:
 
 - **A baseline may only shrink.** Never add an entry to

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -322,6 +322,11 @@ Use `override` on all overrides, `= 0` for pure virtuals, `virtual` destructors 
 - Classes: `@brief`, `@tparam`.
 - Methods: `@param[in]`, `@param[out]`, `@returns`.
 - Math: `@f$ ... @f$` for inline LaTeX.
+- Class pages documenting multiple supported specializations include a complete
+  `Specialization` / `Description` table with linked specialization entries.
+- Public class, template, specialization-family, and generated header-page
+  references in `@see` blocks or prose lists must be explicit `@ref` references
+  or generated-page HTML links, not bare comma-separated names.
 
 ### Optional and common types
 

--- a/doc/Examples/PDEs/NavierStokes.dox
+++ b/doc/Examples/PDEs/NavierStokes.dox
@@ -119,8 +119,8 @@
   The older semi-implicit examples now use Oseen names to reflect that they
   freeze the transport velocity and solve one linearized problem per step:
 
-  - `examples/PETSc/PDEs/Seq_OseenFlow.cpp`
-  - `examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp`
+  - [Seq_OseenFlow.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_OseenFlow.cpp)
+  - [Seq_OseenLidDrivenCavity.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp)
 
   @section examples-pdes-navierstokes-see-also See Also
 

--- a/doc/ExamplesIndex.dox
+++ b/doc/ExamplesIndex.dox
@@ -83,7 +83,7 @@
   | Problem | Constitutive Law | Example |
   |---------|-----------------|---------|
   | Linear cantilever beam | @f$ \sigma = \lambda(\operatorname{tr}\varepsilon)I + 2\mu\varepsilon @f$ | @ref examples-pdes-elasticity |
-  | Hyperelastic cantilever (NeoHookean, transient) | @f$ W = \frac{\mu}{2}(I_1-d) - \mu\ln J + \frac{\lambda}{2}(\ln J)^2 @f$ | `examples/Solid/CantileverBeam.cpp` |
+  | Hyperelastic cantilever (NeoHookean, transient) | @f$ W = \frac{\mu}{2}(I_1-d) - \mu\ln J + \frac{\lambda}{2}(\ln J)^2 @f$ | [CantileverBeam.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Solid/CantileverBeam.cpp) |
 
   @section examples-index-eikonal Distance and Eikonal
 
@@ -93,8 +93,8 @@
 
   | Method | Description | Example |
   |--------|-------------|---------|
-  | FMM | Exact distance on unstructured meshes | `examples/Models/Eikonal/FMM.cpp` |
-  | Spalding-Tucker | Boundary-layer wall distance | `examples/Models/Distance/SpaldingTucker.cpp` |
+  | FMM | Exact distance on unstructured meshes | [FMM.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Models/Eikonal/FMM.cpp) |
+  | Spalding-Tucker | Boundary-layer wall distance | [SpaldingTucker.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Models/Distance/SpaldingTucker.cpp) |
 
   @section examples-index-petsc PETSc Examples
 
@@ -103,12 +103,12 @@
 
   | Problem | Description | Example |
   |---------|-------------|---------|
-  | Sequential Poisson | PETSc CG solver on local mesh | `examples/PETSc/PDEs/Seq_Poisson.cpp` |
-  | MPI Poisson | Distributed mesh + PETSc KSP | `examples/PETSc/PDEs/MPI_Poisson.cpp` |
-  | Sequential Stokes | Multi-field (velocity-pressure-Lagrange) | `examples/PETSc/PDEs/Seq_Stokes.cpp` |
-  | Oseen flow | Transient Picard/Oseen linearization | `examples/PETSc/PDEs/Seq_OseenFlow.cpp` |
-  | Oseen lid-driven cavity | Transient cavity with Picard/Oseen linearization | `examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp` |
-  | Navier-Stokes | Transient nonlinear lid-driven cavity with PETSc SNES | `examples/PETSc/PDEs/Seq_NavierStokes.cpp` |
+  | Sequential Poisson | PETSc CG solver on local mesh | [Seq_Poisson.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_Poisson.cpp) |
+  | MPI Poisson | Distributed mesh + PETSc KSP | [MPI_Poisson.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/MPI_Poisson.cpp) |
+  | Sequential Stokes | Multi-field (velocity-pressure-Lagrange) | [Seq_Stokes.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_Stokes.cpp) |
+  | Oseen flow | Transient Picard/Oseen linearization | [Seq_OseenFlow.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_OseenFlow.cpp) |
+  | Oseen lid-driven cavity | Transient cavity with Picard/Oseen linearization | [Seq_OseenLidDrivenCavity.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_OseenLidDrivenCavity.cpp) |
+  | Navier-Stokes | Transient nonlinear lid-driven cavity with PETSc SNES | [Seq_NavierStokes.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/PETSc/PDEs/Seq_NavierStokes.cpp) |
 
   @see @ref guides-petsc "PETSc Guide", @ref guides-mpi "MPI Guide"
 
@@ -120,7 +120,7 @@
 
   | Equation | Method | Example |
   |----------|--------|---------|
-  | @f$ -\Delta u = f @f$ | SIP-DG | `examples/DG/Poisson.cpp` |
+  | @f$ -\Delta u = f @f$ | SIP-DG | [Poisson.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/DG/Poisson.cpp) |
 
   @see @ref guides-variational "Variational Formulations Guide" for the DG section.
 
@@ -132,8 +132,8 @@
 
   | Problem | Kernel | Example |
   |---------|--------|---------|
-  | Newtonian potential | @f$ \frac{1}{4\pi\lVert\mathbf{x}-\mathbf{y}\rVert} @f$ | `examples/IntegralEquations/NewtonianPotential.cpp` |
-  | Elastic distribution | Navier 3×3 kernel | `examples/IntegralEquations/ElasticDistribution.cpp` |
+  | Newtonian potential | @f$ \frac{1}{4\pi\lVert\mathbf{x}-\mathbf{y}\rVert} @f$ | [NewtonianPotential.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/IntegralEquations/NewtonianPotential.cpp) |
+  | Elastic distribution | Navier 3×3 kernel | [ElasticDistribution.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/IntegralEquations/ElasticDistribution.cpp) |
 
   @section examples-index-surfevol Surface Evolution
 
@@ -143,9 +143,9 @@
 
   | Problem | Description | Example |
   |---------|-------------|---------|
-  | Conormal advection | Move boundary along conormal | `examples/SurfaceEvolution/ConormalAdvection/Main.cpp` |
-  | Convergence study | Parametric sweep over resolution and CFL | `examples/SurfaceEvolution/ConormalAdvection/Test.cpp` |
-  | Plane evolution | Planar surface motion | `examples/SurfaceEvolution/ConormalAdvection/Plane.cpp` |
+  | Conormal advection | Move boundary along conormal | [Main.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/SurfaceEvolution/ConormalAdvection/Main.cpp) |
+  | Convergence study | Parametric sweep over resolution and CFL | [Test.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/SurfaceEvolution/ConormalAdvection/Test.cpp) |
+  | Plane evolution | Planar surface motion | [Plane.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/SurfaceEvolution/ConormalAdvection/Plane.cpp) |
 
   @section examples-index-boundaryopt Boundary Optimization
 
@@ -155,6 +155,6 @@
 
   | Problem | Description | Example |
   |---------|-------------|---------|
-  | Acoustic cloaking | Complex Helmholtz + adjoint-based shape gradient + conormal advection | `examples/BoundaryOptimization/AcousticCloaking.cpp` |
+  | Acoustic cloaking | Complex Helmholtz + adjoint-based shape gradient + conormal advection | [AcousticCloaking.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/BoundaryOptimization/AcousticCloaking.cpp) |
 
   */

--- a/doc/Guides/Backends.dox
+++ b/doc/Guides/Backends.dox
@@ -1,0 +1,96 @@
+/**
+  @page guides-backends Backends and supported configurations
+  @brief How Rodin varies execution, storage, and solver backends
+
+  @tableofcontents
+
+  @m_footernavigation
+
+  Rodin exposes one mathematical surface and selects concrete behavior through
+  template specializations. The main axes are mesh context, assembly strategy,
+  linear algebra storage, and solver backend.
+
+  @section guides-backends-map Backend Map
+
+  | Axis | Local Eigen | OpenMP | MPI | PETSc |
+  |------|-------------|--------|-----|-------|
+  | Context | `Context::Local` | `Context::Local` | `Context::MPI` | Local or MPI |
+  | Mesh | `Mesh<Context::Local>` | same | `Mesh<Context::MPI>` | same mesh contexts |
+  | Assembly | `Assembly::Sequential` | `Assembly::OpenMP` | `Assembly::MPI` | PETSc assembly specializations |
+  | Linear algebra | `Math::SparseMatrix`, `Math::Matrix`, `Math::Vector` | same | usually PETSc for distributed solves | PETSc `Mat`/`Vec` wrappers |
+  | Solvers | Eigen and SuiteSparse wrappers | same after assembly | usually PETSc KSP/SNES | `Solver::KSP`, PETSc `CG`, `GMRES`, `SNES` |
+  | I/O | MFEM, MEDIT, HDF5, XDMF | same | HDF5/XDMF shard-aware paths | PETSc grid-function data paths |
+
+  @section guides-backends-local Local Eigen Path
+
+  The local path is the default. It uses
+  @ref Rodin::Geometry::Mesh "Mesh<Context::Local>",
+  `TrialFunction`, `TestFunction`, local
+  @ref Rodin::Math "Math" matrices and vectors, and the native
+  @ref Rodin::Solver "Solver" wrappers.
+
+  This is the best path for examples, small and medium problems, unit tests,
+  and backend-independent feature development.
+
+  @section guides-backends-openmp OpenMP Assembly
+
+  When Rodin is built with OpenMP support, `Assembly::Default` can select
+  shared-memory assembly for local meshes. OpenMP changes the assembly
+  iteration strategy, not the mathematical problem or the linear algebra
+  objects.
+
+  OpenMP support should preserve deterministic results within floating-point
+  accumulation expectations. A feature that supports local assembly should be
+  checked under OpenMP if it changes element iteration, thread-local storage,
+  or merge behavior.
+
+  @section guides-backends-mpi MPI Mesh Context
+
+  The MPI path uses @ref Rodin::Context::MPI "Context::MPI" and
+  @ref Rodin::Geometry::MPIMesh "Mesh<Context::MPI>". A distributed mesh stores
+  a rank-local @ref Rodin::Geometry::Shard "Shard" with owned, shared, and
+  ghost entities.
+
+  Distributed algorithms must respect ownership and reconciliation:
+
+  @code{.cpp}
+  mesh.getConnectivity().compute(2, 3);
+  mesh.reconcile(2);
+  @endcode
+
+  See @ref guides-mpi "MPI" for the full mesh distribution workflow.
+
+  @section guides-backends-petsc PETSc Storage and Solvers
+
+  PETSc support is activated by using PETSc-backed trial and test functions:
+
+  @code{.cpp}
+  PETSc::Variational::TrialFunction u(Vh);
+  PETSc::Variational::TestFunction  v(Vh);
+  @endcode
+
+  This selects PETSc-backed grid functions, forms, assembly, and
+  @ref Rodin::PETSc::Math "PETSc linear algebra" where appropriate. PETSc can
+  be used with local meshes or MPI meshes. For large distributed problems,
+  PETSc is the standard solver backend.
+
+  @section guides-backends-support What Complete Support Means
+
+  A feature may support only part of the backend matrix. That is fine, but the
+  documentation and tests should say so explicitly.
+
+  | Feature | Minimum support to claim it |
+  |---------|-----------------------------|
+  | Form-language operator | Traits, expression class, and assembly/evaluation path for every advertised grade/range |
+  | Finite element space | DOF layout, point evaluation, GridFunction assignment, and required differential operators |
+  | Assembly feature | Sequential implementation plus OpenMP/MPI/PETSc mirrors when advertised |
+  | Solver | Specialization for each advertised linear-system type |
+  | IO format | Loader/printer specialization for each advertised mesh, FES, and data backend |
+
+  @section guides-backends-see-also See Also
+
+  - @ref guides-mpi "MPI"
+  - @ref guides-petsc "PETSc"
+  - @ref guides-solvers "Solvers"
+  - @ref guides-numerical-contracts "Numerical contracts"
+*/

--- a/doc/Guides/BoundaryConditions.dox
+++ b/doc/Guides/BoundaryConditions.dox
@@ -36,6 +36,11 @@
   is imposed on a boundary segment, homogeneous Neumann is automatically
   satisfied by the weak formulation.
 
+  @note Dirichlet and periodic conditions are structural constraints: Rodin
+  enforces them algebraically in the assembled system. Penalty terms are a
+  different modeling choice. See @ref guides-numerical-contracts "Numerical
+  contracts" for the shared constraint contract.
+
   @section guides-bc-dirichlet Dirichlet Boundary Conditions
 
   Dirichlet conditions specify the value of the solution on the boundary:
@@ -271,6 +276,7 @@
 
   - @ref guides-weak-formulations "Weak formulations"
   - @ref guides-getting-started-core-concepts "Core concepts"
+  - @ref guides-numerical-contracts "Numerical contracts"
   - @ref examples-pdes-poisson "Poisson example"
   - @ref examples-pdes-elasticity "Elasticity example"
   - @ref examples-pdes-periodic "Periodic Poisson example"

--- a/doc/Guides/CoreConcepts.dox
+++ b/doc/Guides/CoreConcepts.dox
@@ -9,6 +9,11 @@
   This section provides a deeper understanding of the core concepts in Rodin,
   building on what you learned in the previous sections.
 
+  @note Before relying on finite element coefficient values, solver reuse, or
+  constraint behavior, read @ref guides-numerical-contracts "Numerical
+  contracts". It explains where interpolation, `L2` projection, assembly signs,
+  and solver lifetimes differ.
+
   @section guides-getting-started-core-concepts-geometry Geometry and Meshes
 
   @subsection guides-getting-started-core-concepts-mesh The Mesh Object
@@ -364,7 +369,12 @@
 
   A `GridFunction` represents a discrete
   function in a finite element space — it stores the actual coefficient values
-  (degrees of freedom) and provides evaluation, projection, and I/O.
+  (degrees of freedom) and provides assignment, evaluation, and I/O.
+
+  Assignment from a function expression interpolates values into the finite
+  element space by applying the space's DOF functionals. This is different from
+  an `L2` projection, which is a variational problem solved through a mass
+  matrix; see @ref guides-numerical-contracts "Numerical contracts".
 
   @subsection guides-getting-started-core-concepts-gf-create Creating Grid Functions
 
@@ -374,10 +384,10 @@
   // Create a grid function in the space (coefficients initialized to zero)
   GridFunction u(Vh);
 
-  // Project a lambda expression onto the space
+  // Interpolate a lambda expression into the space
   u = [](const Geometry::Point& p) { return p.x() * p.y(); };
 
-  // Project a RealFunction
+  // Use the project() convenience API for the same DOF assignment
   RealFunction f = 1;
   GridFunction v(Vh);
   v.project(f);

--- a/doc/Guides/CoreConcepts.dox
+++ b/doc/Guides/CoreConcepts.dox
@@ -57,7 +57,7 @@
   Mesh tet_mesh = Mesh().UniformGrid(Polytope::Type::Tetrahedron, {4, 4, 4});
   @endcode
 
-  @subsection guides-getting-started-core-concepts-connectivity Connectivity
+  @section guides-getting-started-core-concepts-connectivity Connectivity
 
   Connectivity describes the relationships between polytopes of different
   dimensions. You need to compute connectivity before certain operations.

--- a/doc/Guides/CoreConcepts.dox
+++ b/doc/Guides/CoreConcepts.dox
@@ -678,7 +678,8 @@
   @note The kernel @f$ K(\mathbf{x}, \mathbf{y}) @f$ is singular when
   @f$ \mathbf{x} = \mathbf{y} @f$. The small regularization term
   @f$ \varepsilon \int \nabla u \cdot \nabla v @f$ stabilizes the formulation.
-  See the `examples/IntegralEquations/` directory for complete implementations.
+  See the [IntegralEquations examples](https://github.com/cbritopacheco/rodin/tree/develop/examples/IntegralEquations)
+  directory for complete implementations.
 
   @subsection guides-getting-started-core-concepts-trace TraceOperator
 

--- a/doc/Guides/FiniteElementSpaces.dox
+++ b/doc/Guides/FiniteElementSpaces.dox
@@ -66,7 +66,7 @@
   std::cout << "P0 DOFs: " << Wh.getSize() << std::endl;
   // For an 8×8 grid of triangles: 128 DOFs (= 128 cells)
 
-  // Project a function: each cell stores the function value at its centroid
+  // Assign a function: each cell stores the function value at its centroid
   GridFunction indicator(Wh);
   indicator = [](const Geometry::Point& p) {
     return (p.x() < 0.5) ? 1.0 : 0.0;
@@ -232,7 +232,7 @@
   function living in a finite element space. It stores the coefficients
   (DOF values) and can be evaluated, saved, and loaded.
 
-  @subsection fem-spaces-gf-creation Creating and Projecting
+  @subsection fem-spaces-gf-creation Creating and Assigning
 
   Grid functions are created by associating them with a finite element
   space. They can be initialized from lambda functions, constants, or
@@ -244,18 +244,19 @@
   // Create a grid function in the P1 space
   GridFunction gf(Vh);
 
-  // Project a smooth function onto the FE space
+  // Interpolate a smooth function into the FE space
   gf = [](const Geometry::Point& p) {
     return std::sin(M_PI * p.x()) * std::sin(M_PI * p.y());
   };
 
-  // Project from a constant
+  // Assign from a constant
   GridFunction constant(Vh);
   constant = 1.0;
   @endcode
 
-  For P0 (piecewise constant) spaces, the projection computes cell
-  averages:
+  Assignment applies the finite element space's DOF functionals; it is not an
+  `L2` projection. For P0 (piecewise constant) spaces, assignment computes the
+  cellwise P0 coefficients:
 
   @code{.cpp}
   P0 Wh(mesh);
@@ -267,8 +268,8 @@
 
   @subsection fem-spaces-gf-gradient Computing Gradients
 
-  The gradient of a scalar grid function can be projected into a
-  vector-valued space:
+  The gradient of a scalar grid function can be assigned into a vector-valued
+  space:
 
   @code{.cpp}
   P1 scalarVh(mesh);
@@ -278,7 +279,7 @@
              - (p.y() - 0.5) * (p.y() - 0.5);
   };
 
-  // Project the gradient into a vector P1 space
+  // Interpolate the gradient into a vector P1 space
   size_t d = mesh.getSpaceDimension();
   P1 vectorVh(mesh, d);
 

--- a/doc/Guides/InterfacesDG.dox
+++ b/doc/Guides/InterfacesDG.dox
@@ -98,8 +98,10 @@
   - assembled DG systems are not SPD in general — see
     @ref guides-solvers for appropriate solvers.
 
-  See `examples/DG` for a starting point, and the `Jump`/`Average` unit
-  tests (`tests/unit/Rodin/Variational/JumpTest.cpp`, `AverageTest.cpp`)
+  See [examples/DG](https://github.com/cbritopacheco/rodin/tree/develop/examples/DG)
+  for a starting point, and the `Jump`/`Average` unit tests
+  ([JumpTest.cpp](https://github.com/cbritopacheco/rodin/blob/develop/tests/unit/Rodin/Variational/JumpTest.cpp),
+  [AverageTest.cpp](https://github.com/cbritopacheco/rodin/blob/develop/tests/unit/Rodin/Variational/AverageTest.cpp))
   for the precise operational semantics.
 
   @section guides-ifdg-seealso See also

--- a/doc/Guides/MPI.dox
+++ b/doc/Guides/MPI.dox
@@ -28,6 +28,9 @@
   #include <Rodin/MPI.h>
   @endcode
 
+  For a comparison of local, OpenMP, MPI, and PETSc execution/storage paths,
+  see @ref guides-backends "Backends".
+
   @section guides-mpi-context Execution Context
 
   The @ref Rodin::Context::MPI "Context::MPI" class wraps a
@@ -328,6 +331,7 @@
   - @ref Rodin::MPI "MPI namespace reference"
   - @ref Rodin::Context::MPI "Context::MPI"
   - @ref Rodin::Geometry::Shard "Shard"
+  - @ref guides-backends "Backends"
   - @ref guides-petsc "PETSc module"
   - @ref guides-solvers "Solvers"
 

--- a/doc/Guides/Meshes/Connectivity.dox
+++ b/doc/Guides/Meshes/Connectivity.dox
@@ -213,6 +213,6 @@
   - @ref guides-meshes "Meshes overview"
   - @ref guides-connectivity "Connectivity guide (detailed)"
   - @ref Rodin::Geometry::Connectivity "Connectivity class reference"
-  - Example: `examples/Geometry/Connectivity.cpp`
+  - @ref examples-geometry-connectivity "Connectivity example"
 
   */

--- a/doc/Guides/Meshes/Creation.dox
+++ b/doc/Guides/Meshes/Creation.dox
@@ -256,6 +256,6 @@
   - @ref guides-meshes-io "Mesh I/O"
   - @ref guides-meshes "Meshes overview"
   - @ref Rodin::Geometry::Mesh "Mesh class reference"
-  - Example: `examples/Geometry/UniformGrid.cpp`
+  - @ref examples-geometry-uniformgrid "UniformGrid example"
 
   */

--- a/doc/Guides/Meshes/Queries.dox
+++ b/doc/Guides/Meshes/Queries.dox
@@ -230,6 +230,6 @@
 
   - @ref guides-meshes "Meshes overview"
   - @ref Rodin::Geometry::Mesh "Mesh class reference"
-  - Example: `examples/Geometry/Volume.cpp`
+  - [Volume.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Geometry/Volume.cpp)
 
   */

--- a/doc/Guides/Meshes/Utilities.dox
+++ b/doc/Guides/Meshes/Utilities.dox
@@ -281,9 +281,9 @@
   - @ref Rodin::Geometry::SubMesh "SubMesh reference"
   - @ref Rodin::Geometry::BalancedCompactPartitioner "Partitioner reference"
   - Examples:
-    - `examples/Geometry/Displace.cpp`
-    - `examples/Geometry/Skin.cpp`
-    - `examples/Geometry/CCL.cpp`
-    - `examples/Geometry/BalancedCompactPartitioner.cpp`
+    - [Displace.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Geometry/Displace.cpp)
+    - [Skin.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Geometry/Skin.cpp)
+    - [CCL.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Geometry/CCL.cpp)
+    - [BalancedCompactPartitioner.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Geometry/BalancedCompactPartitioner.cpp)
 
   */

--- a/doc/Guides/NumericalContracts.dox
+++ b/doc/Guides/NumericalContracts.dox
@@ -1,0 +1,140 @@
+/**
+  @page guides-numerical-contracts Numerical contracts
+  @brief Interpolation, projection, assembly signs, quadrature, and solver contracts
+
+  @tableofcontents
+
+  @m_footernavigation
+
+  Rodin tries to make code read like mathematics, but some operations have
+  precise numerical contracts. This page collects the rules that affect
+  accuracy and solver behavior across modules.
+
+  @section guides-numerical-contracts-interpolation Interpolation vs Projection
+
+  Assigning an expression to a `GridFunction` applies the finite element
+  space's degree-of-freedom functionals to that expression:
+
+  @code{.cpp}
+  GridFunction uh(Vh);
+  uh = f;        // interpolate f in the DOF sense of Vh
+  @endcode
+
+  This is interpolation, not an @f$ L^2 @f$-orthogonal projection. For nodal
+  @ref Rodin::Variational::P1 "P1" spaces, the DOF functionals are vertex
+  evaluations, so the assignment stores nodal values. For higher-order
+  `H1<K>` spaces, Rodin uses higher-order bases and DOF machinery; coefficients
+  should not be read as nodal values. Evaluate the
+  @ref Rodin::Variational::GridFunction "GridFunction" at a
+  @ref Rodin::Geometry::Point "Point" instead.
+
+  @subsection guides-numerical-contracts-l2 L2 Projection
+
+  When the mathematical operation is the @f$ L^2 @f$ projection, assemble the
+  mass problem:
+
+  @f[
+    \int_\Omega u_h v_h\,dx = \int_\Omega f v_h\,dx
+    \qquad \forall v_h \in V_h.
+  @f]
+
+  In Rodin this is written as:
+
+  @code{.cpp}
+  TrialFunction u(Vh);
+  TestFunction  v(Vh);
+
+  Problem l2(u, v);
+  l2 = Integral(u, v) - Integral(f, v);
+  Solver::CG(l2).solve();
+
+  const auto& uh = u.getSolution();
+  @endcode
+
+  Use this route for optimal-order transfer of rough data, conservative
+  projection workflows, or whenever the variational definition of the
+  projection matters.
+
+  @section guides-numerical-contracts-signs Problem Sign Convention
+
+  A `Problem` assignment writes the residual equation with all terms on the
+  left-hand side. The Poisson weak form
+
+  @f[
+    a(u,v) = \ell(v)
+  @f]
+
+  becomes:
+
+  @code{.cpp}
+  Problem poisson(u, v);
+  poisson = Integral(Grad(u), Grad(v))
+          - Integral(f, v)
+          + DirichletBC(u, Zero());
+  @endcode
+
+  Bilinear terms contribute to the operator @f$ A @f$. Linear terms contribute
+  to the right-hand side @f$ b @f$ with the sign implied by the residual
+  equation. For nonlinear Newton problems, assemble the tangent and residual
+  so the linearized system is
+
+  @f[
+    J(x^k)\,\delta x^k = -F(x^k).
+  @f]
+
+  Do not write a second manual negation around a residual term that the
+  `Problem` assembly already moves to the right-hand side.
+
+  @section guides-numerical-contracts-linearsystem LinearSystem Lifetime
+
+  A @ref Rodin::Math::LinearSystem "LinearSystem" is tied to the finite
+  element spaces and block layout that created it. If the mesh, finite element
+  space, number of fields, or global size changes, create a new problem or
+  linear system.
+
+  PETSc makes this rule explicit: once a `Mat` or `Vec` has been laid out and
+  assembled, it cannot be resized in place. Reassembly may reuse storage when
+  sizes and sparsity structure match, but changed structure is a new system.
+
+  @section guides-numerical-contracts-quadrature Quadrature Exactness
+
+  Quadrature order controls the mathematical form being assembled. For
+  polynomial integrands on affine elements, choose a rule exact for the
+  product degree. Curved transformations, material coefficients, nonlinear
+  constitutive laws, and flow-map evaluations can raise the effective degree
+  or make the integrand non-polynomial.
+
+  If a specialized integrator uses a shortcut, verify it against the generic
+  quadrature path or a manufactured solution. Agreement should include the
+  assembled values, convergence rates, and any invariants the form is expected
+  to satisfy.
+
+  @section guides-numerical-contracts-tangent Residual and Tangent Consistency
+
+  Nonlinear residual/tangent pairs must be consistent. For a residual
+  @f$ R(x) @f$ and tangent @f$ J(x) @f$, the check is:
+
+  @f[
+    J(x)w \approx
+    \frac{R(x+\varepsilon w)-R(x-\varepsilon w)}{2\varepsilon}.
+  @f]
+
+  Rodin provides finite-difference probe helpers under @ref Rodin::Test
+  "Rodin::Test". Run these checks when adding or changing nonlinear terms,
+  especially in solid mechanics and mesh optimization.
+
+  @section guides-numerical-contracts-constraints Constraints
+
+  Dirichlet and identification boundary conditions are structural constraints.
+  They are represented in the assembly constraint map and eliminated or
+  expanded algebraically. Use penalty terms only when the model is explicitly
+  a penalty method.
+
+  @section guides-numerical-contracts-see-also See Also
+
+  - @ref guides-getting-started-core-concepts "Core concepts"
+  - @ref guides-variational "Variational formulations"
+  - @ref guides-solvers "Solvers"
+  - @ref guides-petsc "PETSc"
+  - @ref guides-solid-mechanics "Solid mechanics"
+*/

--- a/doc/Guides/PETSc.dox
+++ b/doc/Guides/PETSc.dox
@@ -233,9 +233,9 @@
 
   | Strategy | Header | Context | Description |
   |----------|--------|---------|-------------|
-  | `Sequential` | `PETSc/Assembly/Sequential.h` | `Context::Local` | Single-thread assembly into PETSc objects |
-  | `OpenMP` | `PETSc/Assembly/OpenMP.h` | `Context::Local` | Shared-memory parallel assembly |
-  | `MPI` | `PETSc/Assembly/MPI.h` | `Context::MPI` | Distributed assembly (each rank contributes owned elements) |
+  | `Sequential` | <a href="_p_e_t_sc_2_assembly_2_sequential_8h.html">PETSc/Assembly/Sequential.h</a> | `Context::Local` | Single-thread assembly into PETSc objects |
+  | `OpenMP` | <a href="_p_e_t_sc_2_assembly_2_open_m_p_8h.html">PETSc/Assembly/OpenMP.h</a> | `Context::Local` | Shared-memory parallel assembly |
+  | `MPI` | <a href="_p_e_t_sc_2_assembly_2_m_p_i_8h.html">PETSc/Assembly/MPI.h</a> | `Context::MPI` | Distributed assembly (each rank contributes owned elements) |
 
   The assembly strategy is selected automatically via the
   `Assembly::Default<TrialContext, TestContext>` trait based on the mesh

--- a/doc/Guides/PETSc.dox
+++ b/doc/Guides/PETSc.dox
@@ -24,6 +24,12 @@
   #include <Rodin/PETSc.h>
   @endcode
 
+  The relationship between local Eigen storage, threaded assembly, MPI mesh
+  contexts, and PETSc objects is summarized in
+  @ref guides-backends "Backends". The numerical contracts PETSc mirrors from
+  core Rodin assembly are summarized in
+  @ref guides-numerical-contracts "Numerical contracts".
+
   @note PETSc must be initialized before use and finalized after:
   @code{.cpp}
   PetscInitialize(&argc, &argv, PETSC_NULLPTR, PETSC_NULLPTR);
@@ -61,7 +67,7 @@
 
   | Feature | Description |
   |---------|-------------|
-  | Projection | `gf = expr` assigns DOF values from a function expression |
+  | Assignment | `gf = expr` assigns DOF values from a function expression |
   | Arithmetic | `+=`, `-=`, `*=`, `/=` for scalars and grid functions |
   | Point evaluation | `gf(point)` evaluates @f$ u_h @f$ at a geometric point |
   | DOF access | `gf[i]` accesses individual DOF coefficients |
@@ -347,6 +353,8 @@
   - @ref Rodin::PETSc "PETSc namespace reference"
   - @ref Rodin::Solver::KSP "KSP solver"
   - @ref Rodin::Solver::SNES "SNES nonlinear solver"
+  - @ref guides-backends "Backends"
+  - @ref guides-numerical-contracts "Numerical contracts"
   - @ref guides-mpi "MPI module"
   - @ref guides-solvers "Solvers guide"
 

--- a/doc/Guides/Quadrature.dox
+++ b/doc/Guides/Quadrature.dox
@@ -19,6 +19,11 @@
   returns a rule exact on @f$ \mathbb P_p(\widehat K) @f$ with positive
   weights and points inside @f$ \widehat K @f$.
 
+  This exactness choice is part of the assembled mathematical problem, not
+  just a performance setting. See @ref guides-numerical-contracts "Numerical
+  contracts" for how quadrature interacts with interpolation, projection,
+  manufactured solutions, and specialized integrators.
+
   @section guides-quadrature-dispatch Default dispatch
 
   <table>
@@ -107,6 +112,11 @@
   suggested by the finite-element fields alone. A quadrature point must remain
   inside the reference polytope because a curved transformation is not
   required to extend beyond it.
+
+  @section guides-quadrature-see-also See Also
+
+  - @ref guides-numerical-contracts "Numerical contracts"
+  - @ref guides-variational "Variational formulations"
 
   @m_footernavigation
 */

--- a/doc/Guides/ShapeOptimization.dox
+++ b/doc/Guides/ShapeOptimization.dox
@@ -26,14 +26,14 @@
 
   | Example | What it shows |
   |---------|---------------|
-  | `examples/ShapeOptimization/SimpleCantilever2D.cpp` | Minimal compliance loop |
-  | `examples/ShapeOptimization/LevelSetCantilever2D.cpp` | Level-set representation with remeshing |
-  | `examples/ShapeOptimization/LevelSetCantilever3D.cpp` | The same in 3D |
-  | `examples/ShapeOptimization/LevelSetArch2D.cpp`, `LevelSetMast2D.cpp` | Other load cases |
-  | `examples/ShapeOptimization/LevelSetEigenvalue2D.cpp` | Eigenvalue objective |
-  | `examples/ShapeOptimization/LevelSetWNGIRCantilever2D.cpp` | Interface registration (WNGIR) instead of full remeshing |
-  | `examples/BoundaryOptimization` | Boundary-condition/support optimization |
-  | `examples/DensityOptimization` | Density (SIMP-type) approaches |
+  | @ref examples-shapeoptimization-simple_cantilever "SimpleCantilever2D.cpp" | Minimal compliance loop |
+  | @ref examples-shapeoptimization-levelset_cantilever "LevelSetCantilever2D.cpp" | Level-set representation with remeshing |
+  | [LevelSetCantilever3D.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/ShapeOptimization/LevelSetCantilever3D.cpp) | The same in 3D |
+  | [LevelSetArch2D.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/ShapeOptimization/LevelSetArch2D.cpp), [LevelSetMast2D.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/ShapeOptimization/LevelSetMast2D.cpp) | Other load cases |
+  | [LevelSetEigenvalue2D.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/ShapeOptimization/LevelSetEigenvalue2D.cpp) | Eigenvalue objective |
+  | [LevelSetWNGIRCantilever2D.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/ShapeOptimization/LevelSetWNGIRCantilever2D.cpp) | Interface registration (WNGIR) instead of full remeshing |
+  | [BoundaryOptimization](https://github.com/cbritopacheco/rodin/tree/develop/examples/BoundaryOptimization) | Boundary-condition/support optimization |
+  | @ref examples-density_optimization-index "DensityOptimization" | Density (SIMP-type) approaches |
 
   @section guides-shapeopt-derivative The shape derivative
 
@@ -155,8 +155,9 @@
     mesh topology and connectivity stable between iterations.
   - **Ersatz material / density.** Keep a fixed mesh and interpolate
     material properties (void as weak material) — the
-    `examples/DensityOptimization` family. No remeshing, at the price of
-    a modeling error controlled by the material contrast.
+    @ref examples-density_optimization-index "DensityOptimization" family. No
+    remeshing, at the price of a modeling error controlled by the material
+    contrast.
 
   @section guides-shapeopt-loop The optimization loop
 
@@ -186,6 +187,7 @@
   - @ref Rodin::Hilbert "Hilbert" — extension-regularization
   - @ref Rodin::Distance "Distance", @ref Rodin::Eikonal "Eikonal" —
     redistancing
-  - MMG — remeshing and implicit-domain
-    discretization
+  - @ref Rodin::MMG "MMG" — remeshing and implicit-domain discretization
+  - @ref examples-shapeoptimization-index "Shape optimization examples"
+  - @ref examples-density_optimization-index "Density optimization examples"
 */

--- a/doc/Guides/SolidMechanics.dox
+++ b/doc/Guides/SolidMechanics.dox
@@ -21,10 +21,12 @@
   | Postprocessing | `Solid/Fields/` | Stress and strain fields for output |
   | Linear theory | `Solid/Linear/` | Small-strain elasticity integrators |
 
-  Working examples: `examples/Solid/BlockGravity.cpp` (quasi-static
-  NeoHookean block under ramped gravity), `examples/Solid/CantileverBeam.cpp`,
-  and `examples/Solid/ActiveContractionPlaneWave.cpp` (active fiber
-  contraction driven by an activation wave).
+  Working examples:
+  [BlockGravity.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Solid/BlockGravity.cpp)
+  (quasi-static NeoHookean block under ramped gravity),
+  [CantileverBeam.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Solid/CantileverBeam.cpp),
+  and [ActiveContractionPlaneWave.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Solid/ActiveContractionPlaneWave.cpp)
+  (active fiber contraction driven by an activation wave).
 
   The residual/tangent sign convention and finite-difference consistency
   checks used by Solid are part of Rodin's shared
@@ -71,7 +73,7 @@
   | `ActiveContraction<Passive, Active>` | passive law + active fiber law | Composition wrapper |
 
   Constructing a law and the internal virtual work form
-  (from `examples/Solid/BlockGravity.cpp`):
+  (from [BlockGravity.cpp](https://github.com/cbritopacheco/rodin/blob/develop/examples/Solid/BlockGravity.cpp)):
 
   @code{.cpp}
   Solid::NeoHookean law(lambda, mu);
@@ -123,10 +125,11 @@
 
   Laws that need more than kinematics (time step, activation, previous
   internal state, fiber directions) receive them through the
-  *constitutive point* mechanism (`Solid/Local/ConstitutivePoint.h`): the
-  integrators stamp tags — cell index, quadrature-point index, and any
-  user-relevant quantities — onto the point, and a user-supplied input
-  callable maps tags to law inputs:
+  *constitutive point* mechanism
+  (<a href="_constitutive_point_8h.html">Solid/Local/ConstitutivePoint.h</a>):
+  the integrators stamp tags — cell index, quadrature-point index, and any
+  user-relevant quantities — onto the point, and a user-supplied input callable
+  maps tags to law inputs:
 
   @code{.cpp}
   auto ivw = Solid::InternalVirtualWork(law, u).setInput(activeInput);
@@ -134,8 +137,9 @@
 
   This keeps laws pure functions of local state (unit-testable against
   finite differences at a single point) and keeps integrators ignorant of
-  constitutive details. `Solid/Local/FiberKinematics.h` carries preferred
-  directions; fibers are *material* (reference-configuration) vectors —
+  constitutive details. <a href="_fiber_kinematics_8h.html">Solid/Local/FiberKinematics.h</a>
+  carries preferred directions; fibers are *material* (reference-configuration)
+  vectors —
   their pushforward @f$ F f_0 @f$ happens inside laws and fields, never in
   user setup.
 

--- a/doc/Guides/SolidMechanics.dox
+++ b/doc/Guides/SolidMechanics.dox
@@ -26,6 +26,10 @@
   and `examples/Solid/ActiveContractionPlaneWave.cpp` (active fiber
   contraction driven by an activation wave).
 
+  The residual/tangent sign convention and finite-difference consistency
+  checks used by Solid are part of Rodin's shared
+  @ref guides-numerical-contracts "Numerical contracts".
+
   @section guides-solid-kinematics Kinematics
 
   With displacement @f$ u @f$, the deformation gradient is
@@ -110,6 +114,10 @@
   once @f$ u @f$ satisfies the constraint; loads are ramped in steps
   (incremental loading) because a full load applied to the undeformed
   state may lie outside Newton's basin of attraction.
+
+  New solid terms should be documented and tested as residual/tangent pairs;
+  the tangent must be the derivative of the residual assembled into the Newton
+  problem.
 
   @section guides-solid-inputs Constitutive-point inputs
 

--- a/doc/Guides/Solvers.dox
+++ b/doc/Guides/Solvers.dox
@@ -19,6 +19,12 @@
   covers all available solvers, explains when to use each, and shows how to
   configure them for best performance.
 
+  Solver behavior depends on the numerical contracts established by assembly:
+  sign conventions, constraint elimination, system lifetime, and residual/
+  tangent consistency are summarized in
+  @ref guides-numerical-contracts "Numerical contracts". Backend-specific
+  solver/storage choices are summarized in @ref guides-backends "Backends".
+
   @section guides-solvers-available Available Solvers
 
   Rodin provides a wide range of solvers. They are organized into direct
@@ -456,6 +462,8 @@
   - @ref Rodin::PETSc "PETSc module"
   - @ref guides-weak-formulations "Weak formulations"
   - @ref guides-boundary-conditions "Boundary conditions"
+  - @ref guides-numerical-contracts "Numerical contracts"
+  - @ref guides-backends "Backends"
   - @ref examples-pdes-poisson "Poisson example"
 
   */

--- a/doc/Guides/ThreadSafety.dox
+++ b/doc/Guides/ThreadSafety.dox
@@ -53,11 +53,12 @@
   @section guides-threads-assembly Parallel assembly
 
   The @ref Rodin::Assembly "Assembly" module provides sequential and
-  OpenMP backends (selected by `Assembly/Default.h` according to the
-  build configuration). The OpenMP backend parallelizes the *evaluation*
+  OpenMP backends (selected by
+  <a href="_assembly_2_default_8h.html">Assembly/Default.h</a> according to
+  the build configuration). The OpenMP backend parallelizes the *evaluation*
   phase — each thread iterates a share of the polytopes, evaluating local
-  integrators into thread-local storage — followed by a merge into the
-  global matrix/vector. Two practical consequences:
+  integrators into thread-local storage — followed by a merge into the global
+  matrix/vector. Two practical consequences:
 
   - **Determinism.** Floating-point sums may be reordered between runs
     with different thread counts; bit-identical reproducibility across

--- a/doc/Guides/VariationalFormulations.dox
+++ b/doc/Guides/VariationalFormulations.dox
@@ -17,6 +17,11 @@
   lets you express these variational formulations in C++ code that closely
   mirrors the mathematical notation.
 
+  The cross-module rules behind these examples are summarized in
+  @ref guides-numerical-contracts "Numerical contracts", including the
+  `Problem` sign convention and the distinction between interpolation and
+  `L2` projection.
+
   @section guides-variational-weak From Strong to Weak Form
 
   Consider a generic second-order PDE in its strong form:
@@ -383,5 +388,7 @@
   - @ref Rodin::Solid "Solid module" — Hyperelastic constitutive laws and Newton solvers
   - @ref Rodin::Advection "Advection module" — Semi-Lagrangian transport
   - @ref guides-solvers "Solvers guide" — Direct, iterative, and nonlinear solvers
+  - @ref guides-numerical-contracts "Numerical contracts" — Projection,
+    assembly signs, quadrature, constraints, and tangent consistency
 
   */

--- a/doc/Guides/VariationalFormulations.dox
+++ b/doc/Guides/VariationalFormulations.dox
@@ -334,7 +334,8 @@
   @subsection guides-variational-dg-example DG Poisson Example
 
   The simplest DG approach uses `P0` (piecewise constant) functions. The
-  actual `examples/DG/Poisson.cpp` uses this pattern:
+  actual [DG Poisson example](https://github.com/cbritopacheco/rodin/blob/develop/examples/DG/Poisson.cpp)
+  uses this pattern:
 
   @code{.cpp}
   P0 Vh(mesh);           // Discontinuous piecewise-constant space
@@ -374,8 +375,8 @@
      + DirichletBC(u, Zero());
   @endcode
 
-  See the DG Poisson example for a complete
-  working implementation.
+  See the [DG Poisson example](https://github.com/cbritopacheco/rodin/blob/develop/examples/DG/Poisson.cpp)
+  for a complete working implementation.
 
   @section guides-variational-see-also See Also
 

--- a/doc/Guides/WeakFormulations.dox
+++ b/doc/Guides/WeakFormulations.dox
@@ -19,6 +19,11 @@
   - Naturally incorporates certain boundary conditions
   - Leads to a well-posed problem suitable for discretization
 
+  Rodin writes assembled `Problem` objects as residual equations with all terms
+  moved to the left-hand side. See
+  @ref guides-numerical-contracts "Numerical contracts" for the sign convention,
+  structural constraints, quadrature exactness, and nonlinear tangent checks.
+
   @section guides-weak-procedure Derivation Procedure
 
   Consider a general second-order PDE on a domain @f$ \Omega @f$:
@@ -261,7 +266,9 @@
   solver.solve(u);  // updates u in place
   @endcode
 
-  See @ref Rodin::Solid "Solid module" for the full API.
+  See @ref Rodin::Solid "Solid module" for the full API, and
+  @ref guides-numerical-contracts "Numerical contracts" for residual/tangent
+  consistency checks.
 
   @section guides-weak-general General Structure
 

--- a/doc/GuidesIndex.dox
+++ b/doc/GuidesIndex.dox
@@ -25,6 +25,9 @@
   - @subpage guides-getting-started-core-concepts — Deeper dive into meshes,
     finite element spaces, operators, and variational formulations
 
+  - @subpage guides-numerical-contracts — Interpolation vs projection,
+    `Problem` sign conventions, quadrature, constraints, and solver lifetimes
+
   @subsection guides-getting-started-prerequisites Prerequisites
 
   Before starting, you should have:
@@ -77,6 +80,9 @@
   - @subpage guides-solvers — Direct solvers (SparseLU, UMFPack, CHOLMOD),
     iterative solvers (CG, GMRES, BiCGSTAB), and the Newton solver
 
+  - @subpage guides-numerical-contracts — Cross-module numerical contracts
+    for forms, projections, constraints, quadrature, and nonlinear tangents
+
   - @subpage guides-interfaces-dg — Facet integrals, traces, jump and
     average operators, interface tagging, and discontinuous Galerkin
     formulations
@@ -103,6 +109,9 @@
   @section guides-parallel-index Parallel and Distributed Computing
 
   Using MPI and PETSc for large-scale problems:
+
+  - @subpage guides-backends — Local, OpenMP, MPI, and PETSc backend choices
+    and what complete support means for each path
 
   - @subpage guides-mpi — Distributed mesh partitioning, sharding, and
     reconciliation with @ref Rodin::Context::MPI "Context::MPI",

--- a/doc/Namespaces.dox
+++ b/doc/Namespaces.dox
@@ -66,12 +66,12 @@
 
   | Type | Color | Behavior |
   |------|-------|----------|
-  | `Alert::Info` | Blue | Informational message (non-fatal) |
-  | `Alert::Warning` | Yellow | Warning message (non-fatal) |
-  | `Alert::Success` | Green | Success notification (non-fatal) |
-  | `Alert::Exception` | Red | Throws an exception (fatal) |
-  | `Alert::MemberFunctionException` | Red | Exception with class/method context |
-  | `Alert::MemberFunctionWarning` | Yellow | Warning with class/method context |
+  | @ref Rodin::Alert::Info "Alert::Info" | Blue | Informational message (non-fatal) |
+  | @ref Rodin::Alert::Warning "Alert::Warning" | Yellow | Warning message (non-fatal) |
+  | @ref Rodin::Alert::Success "Alert::Success" | Green | Success notification (non-fatal) |
+  | @ref Rodin::Alert::Exception "Alert::Exception" | Red | Throws an exception (fatal) |
+  | @ref Rodin::Alert::MemberFunctionException "Alert::MemberFunctionException" | Red | Exception with class/method context |
+  | @ref Rodin::Alert::MemberFunctionWarning "Alert::MemberFunctionWarning" | Yellow | Warning with class/method context |
 
   ## Usage Pattern
 
@@ -121,40 +121,40 @@
 
   | Method | Description |
   |--------|-------------|
-  | `Mesh::UniformGrid(type, shape)` | Structured grid on the unit hypercube |
-  | `Mesh::Box(faceType, shape)` | Surface mesh (boundary of unit box) |
-  | `Mesh::Build()` | Programmatic construction via Builder pattern |
-  | `mesh.load(file, format)` | Load from MFEM, MEDIT, or HDF5 |
+  | @ref Rodin::Geometry::Mesh "Mesh::UniformGrid(type, shape)" | Structured grid on the unit hypercube |
+  | @ref Rodin::Geometry::Mesh "Mesh::Box(faceType, shape)" | Surface mesh (boundary of unit box) |
+  | @ref Rodin::Geometry::Mesh "Mesh::Build()" | Programmatic construction via Builder pattern |
+  | @ref Rodin::Geometry::Mesh "mesh.load(file, format)" | Load from MFEM, MEDIT, or HDF5 |
 
   ## Mesh Operations
 
   | Method | Description |
   |--------|-------------|
-  | `getConnectivity().compute(d1, d2)` | Compute incidence relation @f$ d_1 \to d_2 @f$ |
-  | `scale(factor)` | Scale all vertex coordinates by a scalar factor |
-  | `displace(vectorFunction)` | Apply a displacement field to all vertices |
-  | `skin()` | Extract the boundary surface mesh |
-  | `getDimension()` | Topological dimension (2 for triangles, 3 for tetrahedra) |
-  | `getSpaceDimension()` | Ambient space dimension (≥ topological dimension) |
-  | `getVertexCount()` | Number of vertices |
-  | `getCellCount()` | Number of cells |
-  | `getVolume()` | Total volume (or area) of the domain |
-  | `getPerimeter()` | Total perimeter (or surface area) of the domain boundary |
-  | `getVertex()` / `getCell()` / `getBoundary()` | Polytope iterators |
-  | `getVertexCoordinates(idx)` | Get coordinates of a vertex |
-  | `setAttribute({dim, idx}, attr)` | Set attribute of a polytope (for BC labeling) |
+  | @ref Rodin::Geometry::Connectivity "getConnectivity().compute(d1, d2)" | Compute incidence relation @f$ d_1 \to d_2 @f$ |
+  | @ref Rodin::Geometry::Mesh "scale(factor)" | Scale all vertex coordinates by a scalar factor |
+  | @ref Rodin::Geometry::Mesh "displace(vectorFunction)" | Apply a displacement field to all vertices |
+  | @ref Rodin::Geometry::Mesh "skin()" | Extract the boundary surface mesh |
+  | @ref Rodin::Geometry::Mesh "getDimension()" | Topological dimension (2 for triangles, 3 for tetrahedra) |
+  | @ref Rodin::Geometry::Mesh "getSpaceDimension()" | Ambient space dimension (>= topological dimension) |
+  | @ref Rodin::Geometry::Mesh "getVertexCount()" | Number of vertices |
+  | @ref Rodin::Geometry::Mesh "getCellCount()" | Number of cells |
+  | @ref Rodin::Geometry::Mesh "getVolume()" | Total volume (or area) of the domain |
+  | @ref Rodin::Geometry::Mesh "getPerimeter()" | Total perimeter (or surface area) of the domain boundary |
+  | @ref Rodin::Geometry::Mesh "getVertex() / getCell() / getBoundary()" | Polytope iterators |
+  | @ref Rodin::Geometry::Mesh "getVertexCoordinates(idx)" | Get coordinates of a vertex |
+  | @ref Rodin::Geometry::Mesh "setAttribute({dim, idx}, attr)" | Set attribute of a polytope (for BC labeling) |
 
   ## Polytope Types
 
   | Type | Dimension | Description |
   |------|-----------|-------------|
-  | `Point` | 0 | Vertex |
-  | `Segment` | 1 | Edge |
-  | `Triangle` | 2 | 3-vertex face/cell |
-  | `Quadrilateral` | 2 | 4-vertex face/cell |
-  | `Tetrahedron` | 3 | 4-vertex cell |
-  | `Hexahedron` | 3 | 8-vertex cell |
-  | `Wedge` | 3 | Triangular prism (6 vertices) |
+  | @ref Rodin::Geometry::Polytope "Point" | 0 | Vertex |
+  | @ref Rodin::Geometry::Polytope "Segment" | 1 | Edge |
+  | @ref Rodin::Geometry::Polytope "Triangle" | 2 | 3-vertex face/cell |
+  | @ref Rodin::Geometry::Polytope "Quadrilateral" | 2 | 4-vertex face/cell |
+  | @ref Rodin::Geometry::Polytope "Tetrahedron" | 3 | 4-vertex cell |
+  | @ref Rodin::Geometry::Polytope "Hexahedron" | 3 | 8-vertex cell |
+  | @ref Rodin::Geometry::Polytope "Wedge" | 3 | Triangular prism (6 vertices) |
 
   @code{.cpp}
   Mesh mesh;
@@ -186,9 +186,9 @@
 
   | Strategy | Class | Description |
   |----------|-------|-------------|
-  | **Sequential** | `Assembly::Sequential` | Single-threaded assembly. Iterates over mesh cells, evaluates local element matrices/vectors, and accumulates into the global system. Deterministic and reproducible. |
-  | **OpenMP** | `Assembly::OpenMP` | Shared-memory parallel assembly using OpenMP. Each thread processes a subset of cells and accumulates contributions using thread-safe operations. Requires compilation with `RODIN_USE_OPENMP=ON`. |
-  | **Default** | `Assembly::Default` | Compile-time policy selector. Maps to `OpenMP` when OpenMP is available, otherwise falls back to `Sequential`. Users rarely need to specify this directly. |
+  | **Sequential** | @ref Rodin::Assembly::Sequential "Assembly::Sequential" | Single-threaded assembly. Iterates over mesh cells, evaluates local element matrices/vectors, and accumulates into the global system. Deterministic and reproducible. |
+  | **OpenMP** | @ref Rodin::Assembly "Assembly::OpenMP" | Shared-memory parallel assembly using OpenMP. Each thread processes a subset of cells and accumulates contributions using thread-safe operations. Requires compilation with `RODIN_USE_OPENMP=ON`. |
+  | **Default** | @ref Rodin::Assembly::Default "Assembly::Default" | Compile-time policy selector. Maps to @ref Rodin::Assembly "OpenMP" when OpenMP is available, otherwise falls back to @ref Rodin::Assembly::Sequential "Sequential". Users rarely need to specify this directly. |
 
   ## What Gets Assembled
 
@@ -259,9 +259,9 @@
   The IO module provides facilities for reading and writing meshes and grid
   functions in several formats:
 
-  - **MFEM** (`IO::FileFormat::MFEM`) — Native MFEM mesh and grid function format
-  - **MEDIT** (`IO::FileFormat::MEDIT`) — MEDIT format used by MMG and INRIA tools
-  - **HDF5** (`IO::FileFormat::HDF5`) — High-performance binary format
+  - **MFEM** (@ref Rodin::IO::FileFormat "IO::FileFormat::MFEM") — Native MFEM mesh and grid function format
+  - **MEDIT** (@ref Rodin::IO::FileFormat "IO::FileFormat::MEDIT") — MEDIT format used by MMG and INRIA tools
+  - **HDF5** (@ref Rodin::IO::FileFormat "IO::FileFormat::HDF5") — High-performance binary format
 
   Additionally, the @ref Rodin::IO::XDMF "XDMF" class provides XDMF 3.0
   output for scientific visualization in [ParaView](https://www.paraview.org/),
@@ -271,9 +271,9 @@
 
   The XDMF writer uses a two-level design:
 
-  - **XDMF** — Top-level writer that manages the `.xdmf` XML file and `.h5`
+  - @ref Rodin::IO::XDMF "XDMF" — Top-level writer that manages the `.xdmf` XML file and `.h5`
     HDF5 data. Provides `write()`, `flush()`, `close()`, `setPadding()`.
-  - **XDMF::Grid** — A lightweight handle returned by `xdmf.grid()` (default)
+  - @ref Rodin::IO::XDMF::Grid "XDMF::Grid" — A lightweight handle returned by `xdmf.grid()` (default)
     or `xdmf.grid("name")` (named). Provides `setMesh()`, `add()`, `hasMesh()`,
     `reset()` — all returning `Grid&` for method chaining.
 
@@ -292,10 +292,10 @@
 
   | Format | Extensions | Key Classes | Notes |
   |--------|-----------|-------------|-------|
-  | MFEM | `.mesh`, `.gf` | `IO::FileFormat::MFEM` | Text-based, compatible with MFEM ecosystem |
-  | MEDIT | `.mesh` | `IO::FileFormat::MEDIT` | Used by MMG, supports attributes |
-  | HDF5 | `.h5` | `IO::FileFormat::HDF5` | Binary, parallel-capable |
-  | XDMF | `.xdmf` + `.h5` | `IO::XDMF`, `IO::XDMF::Grid` | ParaView visualization, time series |
+  | MFEM | `.mesh`, `.gf` | @ref Rodin::IO::FileFormat "IO::FileFormat::MFEM" | Text-based, compatible with MFEM ecosystem |
+  | MEDIT | `.mesh` | @ref Rodin::IO::FileFormat "IO::FileFormat::MEDIT" | Used by MMG, supports attributes |
+  | HDF5 | `.h5` | @ref Rodin::IO::FileFormat "IO::FileFormat::HDF5" | Binary, parallel-capable |
+  | XDMF | `.xdmf` + `.h5` | @ref Rodin::IO::XDMF "IO::XDMF", @ref Rodin::IO::XDMF::Grid "IO::XDMF::Grid" | ParaView visualization, time series |
 
   @see @ref guides-io "I/O in Rodin" for a comprehensive guide.
  */
@@ -537,19 +537,19 @@
 
   | Method | Class | Equation | Properties |
   |--------|-------|----------|------------|
-  | **Eikonal** | `Distance::Eikonal` | @f$ \lVert\nabla d\rVert = 1 @f$ | Exact distances via FMM; supports signed distance with interior/interface regions |
-  | **Poisson** | `Distance::Poisson` | @f$ -\Delta u = 1, \; u\vert_{\partial\Omega} = 0 @f$ | Smooth approximation; fast (one linear solve); does not give exact distances |
-  | **SignedPoisson** | `Distance::SignedPoisson` | @f$ -\Delta u = 2\chi_\Omega - 1, \; u\vert_\Gamma = 0 @f$ | Region-dependent forcing yields a signed smooth distance |
-  | **Rvachev** | `Distance::Rvachev` | @f$ d = \frac{u}{\sqrt{u^2 + \lVert\nabla u\rVert^2}} @f$ | Normalizes a level-set field to approximate distance; preserves zero set and sign |
-  | **SpaldingTucker** | `Distance::SpaldingTucker` | @f$ d = \frac{2u}{\lVert\nabla u\rVert + \sqrt{\lVert\nabla u\rVert^2 + 2\lvert u\rvert}} @f$ | Better gradient normalization than Rvachev; more accurate near the interface |
+  | **Eikonal** | @ref Rodin::Distance::Eikonal "Distance::Eikonal" | @f$ \lVert\nabla d\rVert = 1 @f$ | Exact distances via FMM; supports signed distance with interior/interface regions |
+  | **Poisson** | @ref Rodin::Distance::Poisson "Distance::Poisson" | @f$ -\Delta u = 1, \; u\vert_{\partial\Omega} = 0 @f$ | Smooth approximation; fast (one linear solve); does not give exact distances |
+  | **SignedPoisson** | @ref Rodin::Distance::SignedPoisson "Distance::SignedPoisson" | @f$ -\Delta u = 2\chi_\Omega - 1, \; u\vert_\Gamma = 0 @f$ | Region-dependent forcing yields a signed smooth distance |
+  | **Rvachev** | @ref Rodin::Distance::Rvachev "Distance::Rvachev" | @f$ d = \frac{u}{\sqrt{u^2 + \lVert\nabla u\rVert^2}} @f$ | Normalizes a level-set field to approximate distance; preserves zero set and sign |
+  | **SpaldingTucker** | @ref Rodin::Distance::SpaldingTucker "Distance::SpaldingTucker" | @f$ d = \frac{2u}{\lVert\nabla u\rVert + \sqrt{\lVert\nabla u\rVert^2 + 2\lvert u\rvert}} @f$ | Better gradient normalization than Rvachev; more accurate near the interface |
 
-  All methods except `Rvachev` and `SpaldingTucker` inherit from a common CRTP
+  All methods except @ref Rodin::Distance::Rvachev "Rvachev" and @ref Rodin::Distance::SpaldingTucker "SpaldingTucker" inherit from a common CRTP
   `Base<Derived>` that provides `setInterior()` and `setInterface()` methods for
   specifying the signed-distance regions (mesh boundary attributes).
 
   ## Eikonal Distance (FMM)
 
-  The `Eikonal` class wraps the FMM solver and provides the most accurate
+  The @ref Rodin::Distance::Eikonal "Eikonal" class wraps the FMM solver and provides the most accurate
   distance computation. Seeds are automatically identified from the interface
   attributes. Calling `sign()` after `solve()` negates interior values to produce
   a signed distance field.
@@ -567,11 +567,11 @@
 
   ## Poisson Distance Approximation
 
-  `Poisson` solves @f$ -\Delta u = 1 @f$ with @f$ u = 0 @f$ on
+  @ref Rodin::Distance::Poisson "Poisson" solves @f$ -\Delta u = 1 @f$ with @f$ u = 0 @f$ on
   @f$ \partial\Omega @f$ in a single linear solve. The result is smooth but
   only approximates the true distance.
 
-  `SignedPoisson` extends this with region-dependent forcing: @f$ -\Delta u = 2 @f$
+  @ref Rodin::Distance::SignedPoisson "SignedPoisson" extends this with region-dependent forcing: @f$ -\Delta u = 2 @f$
   inside a specified region and @f$ -\Delta u = -1 @f$ elsewhere, with
   @f$ u = 0 @f$ on the interface. It supports both single-attribute and
   attribute-set overloads:
@@ -588,7 +588,7 @@
 
   ## Level-Set Normalization
 
-  `Rvachev` and `SpaldingTucker` are post-processing operators that normalize
+  @ref Rodin::Distance::Rvachev "Rvachev" and @ref Rodin::Distance::SpaldingTucker "SpaldingTucker" are post-processing operators that normalize
   an existing level-set field into an approximate distance function without
   solving any PDE:
 
@@ -615,7 +615,7 @@
 
   The Hilbert module implements @f$ H^1 @f$-based extension-regularization
   operators used in shape and topology optimization. The primary class
-  `H1a` solves the regularized extension problem:
+  @ref Rodin::Hilbert::H1a "H1a" solves the regularized extension problem:
   @f[
     \alpha^2 \int_\Omega \nabla u : \nabla v \, dx + \int_\Omega u \cdot v \, dx = \ell(v)
   @f]
@@ -630,14 +630,14 @@
 
   | Method | Description |
   |--------|-------------|
-  | `H1a(fes)` | Constructor: creates the extension operator on a finite element space |
-  | `setAlpha(alpha)` | Sets @f$ \alpha @f$ (typically proportional to mesh size @f$ h @f$) |
-  | `operator()(lf)` | Applies extension to a linear form (differential) |
-  | `operator+=(DirichletBC)` | Adds boundary conditions to the extension problem |
-  | `getProblem()` | Access the underlying `Problem` object |
-  | `getTrialFunction()` / `getTestFunction()` | Access trial/test functions |
+  | @ref Rodin::Hilbert::H1a "H1a(fes)" | Constructor: creates the extension operator on a finite element space |
+  | @ref Rodin::Hilbert::H1a "setAlpha(alpha)" | Sets @f$ \alpha @f$ (typically proportional to mesh size @f$ h @f$) |
+  | @ref Rodin::Hilbert::H1a "operator()(lf)" | Applies extension to a linear form (differential) |
+  | @ref Rodin::Hilbert::H1a "operator+=(DirichletBC)" | Adds boundary conditions to the extension problem |
+  | @ref Rodin::Hilbert::H1a "getProblem()" | Access the underlying @ref Rodin::Variational::Problem "Problem" object |
+  | @ref Rodin::Hilbert::H1a "getTrialFunction() / getTestFunction()" | Access trial/test functions |
 
-  For vector-valued problems, `H1a` uses `Jacobian()` instead of `Grad()`.
+  For vector-valued problems, @ref Rodin::Hilbert::H1a "H1a" uses `Jacobian()` instead of `Grad()`.
   The internal solver is `Solver::CG`.
  */
 
@@ -686,8 +686,8 @@
 
   | Policy | Behavior |
   |--------|----------|
-  | `StopInsideBoundaryPolicy` | Clamps the departure point to an interior point with a small inward offset (`eps_in_phys`, default @f$ 10^{-12} @f$). Used automatically for the **first time step** (from initial condition). |
-  | `TaylorBoundaryShiftPolicy<Field>` | Applies a first-order Taylor correction at the boundary hit: shifts the point inward and accumulates the gradient correction @f$ \nabla\phi \cdot \delta\mathbf{x} @f$. Used automatically for **subsequent steps** (from the current solution). |
+  | @ref Rodin::Advection::StopInsideBoundaryPolicy "StopInsideBoundaryPolicy" | Clamps the departure point to an interior point with a small inward offset (`eps_in_phys`, default @f$ 10^{-12} @f$). Used automatically for the **first time step** (from initial condition). |
+  | @ref Rodin::Advection::TaylorBoundaryShiftPolicy "TaylorBoundaryShiftPolicy<Field>" | Applies a first-order Taylor correction at the boundary hit: shifts the point inward and accumulates the gradient correction @f$ \nabla\phi \cdot \delta\mathbf{x} @f$. Used automatically for **subsequent steps** (from the current solution). |
 
   The `Lagrangian` class tracks time internally (`m_t`) and switches between
   the initial condition (first step) and the current solution (later steps).
@@ -822,33 +822,33 @@
 
   ## Kinematics
 
-  `KinematicState` encapsulates all finite-strain kinematic quantities at a
+  @ref Rodin::Solid::KinematicState "KinematicState" encapsulates all finite-strain kinematic quantities at a
   quadrature point. Set the displacement gradient with
   `setDisplacementGradient(H)` and query derived tensors:
 
   | Getter | Returns | Definition |
   |--------|---------|------------|
-  | `getDisplacementGradient()` | @f$ \nabla\mathbf{u} @f$ | Input gradient |
-  | `getDeformationGradient()` | @f$ \mathbf{F} @f$ | @f$ \mathbf{I} + \nabla\mathbf{u} @f$ |
-  | `getDeformationGradientInverse()` | @f$ \mathbf{F}^{-1} @f$ | Inverse |
-  | `getDeformationGradientInverseTranspose()` | @f$ \mathbf{F}^{-T} @f$ | Inverse transpose |
-  | `getRightCauchyGreenTensor()` | @f$ \mathbf{C} @f$ | @f$ \mathbf{F}^T\mathbf{F} @f$ |
-  | `getLeftCauchyGreenTensor()` | @f$ \mathbf{b} @f$ | @f$ \mathbf{F}\mathbf{F}^T @f$ |
-  | `getJacobian()` | @f$ J @f$ | @f$ \det\mathbf{F} @f$ |
-  | `getLogJacobian()` | @f$ \ln J @f$ | Natural log of Jacobian |
+  | @ref Rodin::Solid::KinematicState "getDisplacementGradient()" | @f$ \nabla\mathbf{u} @f$ | Input gradient |
+  | @ref Rodin::Solid::KinematicState "getDeformationGradient()" | @f$ \mathbf{F} @f$ | @f$ \mathbf{I} + \nabla\mathbf{u} @f$ |
+  | @ref Rodin::Solid::KinematicState "getDeformationGradientInverse()" | @f$ \mathbf{F}^{-1} @f$ | Inverse |
+  | @ref Rodin::Solid::KinematicState "getDeformationGradientInverseTranspose()" | @f$ \mathbf{F}^{-T} @f$ | Inverse transpose |
+  | @ref Rodin::Solid::KinematicState "getRightCauchyGreenTensor()" | @f$ \mathbf{C} @f$ | @f$ \mathbf{F}^T\mathbf{F} @f$ |
+  | @ref Rodin::Solid::KinematicState "getLeftCauchyGreenTensor()" | @f$ \mathbf{b} @f$ | @f$ \mathbf{F}\mathbf{F}^T @f$ |
+  | @ref Rodin::Solid::KinematicState "getJacobian()" | @f$ J @f$ | @f$ \det\mathbf{F} @f$ |
+  | @ref Rodin::Solid::KinematicState "getLogJacobian()" | @f$ \ln J @f$ | Natural log of Jacobian |
 
   Invariant classes compute derived quantities from the kinematic state:
-  - `IsotropicInvariants` — @f$ I_1 = \operatorname{tr}\mathbf{C} @f$,
+  - @ref Rodin::Solid::IsotropicInvariants "IsotropicInvariants" — @f$ I_1 = \operatorname{tr}\mathbf{C} @f$,
     @f$ I_2 = \tfrac{1}{2}[\operatorname{tr}(\mathbf{C})^2 - \operatorname{tr}(\mathbf{C}^2)] @f$,
     @f$ I_3 = \det\mathbf{C} = J^2 @f$
-  - `FiberInvariants` — @f$ I_4 = \mathbf{a}_0 \cdot \mathbf{C}\mathbf{a}_0 @f$,
+  - @ref Rodin::Solid::FiberInvariants "FiberInvariants" — @f$ I_4 = \mathbf{a}_0 \cdot \mathbf{C}\mathbf{a}_0 @f$,
     @f$ I_5 = \mathbf{a}_0 \cdot \mathbf{C}^2\mathbf{a}_0 @f$
     (for anisotropic materials; constructed with a fiber direction vector)
 
   ## Constitutive Point and Input Injection
 
-  `ConstitutivePoint` bundles a `KinematicState` with an optional
-  `Geometry::Point` (for spatial location) and a tag-based auxiliary data store.
+  @ref Rodin::Solid::ConstitutivePoint "ConstitutivePoint" bundles a @ref Rodin::Solid::KinematicState "KinematicState" with an optional
+  @ref Rodin::Geometry::Point "Geometry::Point" (for spatial location) and a tag-based auxiliary data store.
   Auxiliary data (fiber directions, activation values, etc.) is injected via
   typed tags:
 
@@ -858,13 +858,13 @@
   bool has = cp.has<Solid::Tags::Activation>();
   @endcode
 
-  The `Input<Derived>` CRTP base and `InputFunction` callable allow the user to
+  The @ref Rodin::Solid::Input "Input<Derived>" CRTP base and @ref Rodin::Solid::InputFunction "InputFunction" callable allow the user to
   inject auxiliary data at each quadrature point during assembly. Integrators
   accept input via `setInput()`.
 
   ## Constitutive Laws
 
-  Each law derives from `HyperElasticLaw<Derived>` (CRTP base) and provides:
+  Each law derives from @ref Rodin::Solid::HyperElasticLaw "HyperElasticLaw<Derived>" (CRTP base) and provides:
   - A `Cache` struct for precomputed invariant data
   - `setCache(cache, cp)` — populate the cache from a `ConstitutivePoint`
   - `getFirstPiolaKirchhoffStress(P, cache, cp)` — @f$ \mathbf{P} = \partial W / \partial \mathbf{F} @f$
@@ -873,10 +873,10 @@
 
   | Law | Constructor | Energy density @f$ W @f$ |
   |-----|-------------|--------------------------|
-  | `Hooke` | `Hooke(lambda, mu)` | @f$ \boldsymbol{\sigma} = \lambda(\operatorname{tr}\boldsymbol{\varepsilon})\mathbf{I} + 2\mu\boldsymbol{\varepsilon} @f$ (linear stress-strain; not hyperelastic) |
-  | `NeoHookean` | `NeoHookean(lambda, mu)` | @f$ \frac{\mu}{2}(I_1 - d) - \mu\ln J + \frac{\lambda}{2}(\ln J)^2 @f$ |
-  | `SaintVenantKirchhoff` | `SaintVenantKirchhoff(lambda, mu)` | @f$ \frac{\lambda}{2}(\operatorname{tr}\mathbf{E})^2 + \mu\,\mathbf{E}:\mathbf{E} @f$ |
-  | `MooneyRivlin` | `MooneyRivlin(c1, c2, kappa)` | @f$ c_1(\bar{I}_1 - d) + c_2(\bar{I}_2 - d) + \frac{\kappa}{2}(J-1)^2 @f$ |
+  | @ref Rodin::Solid::Hooke "Hooke" | `Hooke(lambda, mu)` | @f$ \boldsymbol{\sigma} = \lambda(\operatorname{tr}\boldsymbol{\varepsilon})\mathbf{I} + 2\mu\boldsymbol{\varepsilon} @f$ (linear stress-strain; not hyperelastic) |
+  | @ref Rodin::Solid::NeoHookean "NeoHookean" | `NeoHookean(lambda, mu)` | @f$ \frac{\mu}{2}(I_1 - d) - \mu\ln J + \frac{\lambda}{2}(\ln J)^2 @f$ |
+  | @ref Rodin::Solid::SaintVenantKirchhoff "SaintVenantKirchhoff" | `SaintVenantKirchhoff(lambda, mu)` | @f$ \frac{\lambda}{2}(\operatorname{tr}\mathbf{E})^2 + \mu\,\mathbf{E}:\mathbf{E} @f$ |
+  | @ref Rodin::Solid::MooneyRivlin "MooneyRivlin" | `MooneyRivlin(c1, c2, kappa)` | @f$ c_1(\bar{I}_1 - d) + c_2(\bar{I}_2 - d) + \frac{\kappa}{2}(J-1)^2 @f$ |
 
   where @f$ \mathbf{E} = \tfrac{1}{2}(\mathbf{C} - \mathbf{I}) @f$ is the
   Green-Lagrange strain, @f$ \bar{I}_k = J^{-2k/d} I_k @f$ are modified
@@ -897,8 +897,8 @@
 
   | Integrator | Form type | Assembles | Mathematical expression |
   |------------|-----------|-----------|-------------------------|
-  | `InternalForce<Law, FES>` | Linear (residual) | Internal force vector | @f$ R_i = \int_\Omega \mathbf{P} : \nabla\phi_i \, dX @f$ |
-  | `MaterialTangent<Law, Solution, FES>` | Bilinear (tangent) | Tangent stiffness matrix | @f$ K_{ij} = \int_\Omega D\mathbf{P}[\nabla\phi_j] : \nabla\phi_i \, dX @f$ |
+  | @ref Rodin::Solid::InternalVirtualWorkResidual "InternalForce<Law, FES>" | Linear (residual) | Internal force vector | @f$ R_i = \int_\Omega \mathbf{P} : \nabla\phi_i \, dX @f$ |
+  | @ref Rodin::Solid::InternalVirtualWorkTangent "MaterialTangent<Law, Solution, FES>" | Bilinear (tangent) | Tangent stiffness matrix | @f$ K_{ij} = \int_\Omega D\mathbf{P}[\nabla\phi_j] : \nabla\phi_i \, dX @f$ |
 
   Constructor signatures (CTAD-deduced):
 
@@ -912,9 +912,9 @@
 
   ## Derived Fields
 
-  - `FirstPiolaKirchhoffStress<Law>` — Post-process @f$ \mathbf{P} @f$ field
-  - `CauchyStress<Law>` — Post-process @f$ \boldsymbol{\sigma} = J^{-1}\mathbf{P}\mathbf{F}^T @f$
-  - `GreenLagrangeStrain` — Post-process @f$ \mathbf{E} = \frac{1}{2}(\mathbf{C} - \mathbf{I}) @f$
+  - @ref Rodin::Solid::FirstPiolaKirchhoffStress "FirstPiolaKirchhoffStress<Law>" — Post-process @f$ \mathbf{P} @f$ field
+  - @ref Rodin::Solid::CauchyStress "CauchyStress<Law>" — Post-process @f$ \boldsymbol{\sigma} = J^{-1}\mathbf{P}\mathbf{F}^T @f$
+  - @ref Rodin::Solid::GreenLagrangeStrain "GreenLagrangeStrain" — Post-process @f$ \mathbf{E} = \frac{1}{2}(\mathbf{C} - \mathbf{I}) @f$
 
   ## Typical Usage
 
@@ -987,10 +987,10 @@
   *
   * | Rule | Class | Polytopes | Exactness |
   * |------|-------|-----------|-----------|
-  * | **Centroid** | `QF::Centroid` | All types | Degree 1 (linear). Single point at barycenter. |
-  * | **Gauss-Legendre** | `QF::GaussLegendre` | All types | Degree @f$ 2n-1 @f$ for @f$ n @f$ points (1D). Tensor-product or Duffy transform for higher dimensions. |
-  * | **Gauss-Lobatto** | `QF::GaussLobatto` | Segments | Degree @f$ 2n-3 @f$ for @f$ n @f$ points. Includes endpoints (useful for spectral methods). |
-  * | **Grundmann-Möller** | `QF::GrundmannMoller` | Simplices only | Degree @f$ 2s+1 @f$ for parameter @f$ s \geq 0 @f$. Designed specifically for simplicial elements. |
+  * | **Centroid** | @ref Rodin::QF::Centroid "QF::Centroid" | All types | Degree 1 (linear). Single point at barycenter. |
+  * | **Gauss-Legendre** | @ref Rodin::QF::GaussLegendre "QF::GaussLegendre" | All types | Degree @f$ 2n-1 @f$ for @f$ n @f$ points (1D). Tensor-product or Duffy transform for higher dimensions. |
+  * | **Gauss-Lobatto** | @ref Rodin::QF::GaussLobatto "QF::GaussLobatto" | Segments | Degree @f$ 2n-3 @f$ for @f$ n @f$ points. Includes endpoints (useful for spectral methods). |
+  * | **Grundmann-Möller** | @ref Rodin::QF::GrundmannMoller "QF::GrundmannMoller" | Simplices only | Degree @f$ 2s+1 @f$ for parameter @f$ s \geq 0 @f$. Designed specifically for simplicial elements. |
   *
   * ## Automatic Selection
   *
@@ -1083,12 +1083,12 @@
 
   | Type | Description |
   |------|-------------|
-  | `Math::Vector<T>` | Dense column vector (Eigen-based) |
-  | `Math::Matrix<T>` | Dense matrix (Eigen-based) |
-  | `Math::SparseMatrix<T>` | Compressed sparse column matrix |
-  | `Math::SpatialVector<T>` | Small fixed-size vector for physical coordinates |
-  | `Math::SpatialMatrix<T>` | Small fixed-size matrix (e.g.\ Jacobians, stress tensors) |
-  | `Math::LinearSystem` | Couples operator matrix @f$ A @f$, RHS vector @f$ b @f$, and solution @f$ x @f$ |
+  | @ref Rodin::Math::Vector "Math::Vector<T>" | Dense column vector (Eigen-based) |
+  | @ref Rodin::Math::Matrix "Math::Matrix<T>" | Dense matrix (Eigen-based) |
+  | @ref Rodin::Math::SparseMatrix "Math::SparseMatrix<T>" | Compressed sparse column matrix |
+  | @ref Rodin::Math::SpatialVector "Math::SpatialVector<T>" | Small fixed-size vector for physical coordinates |
+  | @ref Rodin::Math::SpatialMatrix "Math::SpatialMatrix<T>" | Small fixed-size matrix (e.g.\ Jacobians, stress tensors) |
+  | @ref Rodin::Math::LinearSystem "Math::LinearSystem" | Couples operator matrix @f$ A @f$, RHS vector @f$ b @f$, and solution @f$ x @f$ |
 
   ## Constants
 
@@ -1098,20 +1098,20 @@
 
   | Function | Signature | Domain |
   |----------|-----------|--------|
-  | `abs` | `abs(x)` | Scalar or matrix |
-  | `exp` | `exp(x)` | Scalar or matrix |
-  | `sqrt` | `sqrt(x)` | Scalar or matrix |
-  | `pow` | `pow(base, exp)` | Scalar or matrix |
-  | `pow2` | `pow2(x)` | Scalar or matrix |
-  | `log` | `log(x)` | Scalar |
-  | `log2` | `log2(x)` | Scalar |
-  | `log10` | `log10(x)` | Scalar |
-  | `sin`, `cos`, `tan` | Trigonometric | Scalar or matrix |
-  | `asin`, `acos`, `atan` | Inverse trig | Scalar |
-  | `atan2` | `atan2(y, x)` | Two-argument arctangent |
-  | `sinh`, `cosh`, `tanh` | Hyperbolic | Scalar or matrix |
-  | `min`, `max` | Element-wise | Scalar |
-  | `clamp` | `clamp(x, lo, hi)` | Scalar |
+  | @ref Rodin::Math "abs" | `abs(x)` | Scalar or matrix |
+  | @ref Rodin::Math "exp" | `exp(x)` | Scalar or matrix |
+  | @ref Rodin::Math "sqrt" | `sqrt(x)` | Scalar or matrix |
+  | @ref Rodin::Math "pow" | `pow(base, exp)` | Scalar or matrix |
+  | @ref Rodin::Math "pow2" | `pow2(x)` | Scalar or matrix |
+  | @ref Rodin::Math "log" | `log(x)` | Scalar |
+  | @ref Rodin::Math "log2" | `log2(x)` | Scalar |
+  | @ref Rodin::Math "log10" | `log10(x)` | Scalar |
+  | @ref Rodin::Math "sin, cos, tan" | Trigonometric | Scalar or matrix |
+  | @ref Rodin::Math "asin, acos, atan" | Inverse trig | Scalar |
+  | @ref Rodin::Math "atan2" | `atan2(y, x)` | Two-argument arctangent |
+  | @ref Rodin::Math "sinh, cosh, tanh" | Hyperbolic | Scalar or matrix |
+  | @ref Rodin::Math "min, max" | Element-wise | Scalar |
+  | @ref Rodin::Math "clamp" | `clamp(x, lo, hi)` | Scalar |
 
   ## Unit Types
 
@@ -1245,11 +1245,11 @@
 
   | Class | Purpose |
   |-------|---------|
-  | `MMG::Mesh` | Local mesh type extending `Geometry::Mesh<Local>` with corner, ridge, and required-entity metadata. |
-  | `MMG::Adapt` | Metric-based adaptation from a nodal size map. |
-  | `MMG::Optimizer` | Mesh-quality optimization without an external metric field. |
-  | `MMG::LevelSetDiscretizer` | Level-set meshing: cuts a background mesh along an isovalue or extracts the isosurface. |
-  | `MMG::MMG5` | Base class providing shared MMG configuration and native conversion helpers. |
+  | @ref Rodin::MMG::Mesh "MMG::Mesh" | Local mesh type extending @ref Rodin::Geometry::Mesh "Geometry::Mesh<Context::Local>" with corner, ridge, and required-entity metadata. |
+  | @ref Rodin::MMG::Adapt "MMG::Adapt" | Metric-based adaptation from a nodal size map. |
+  | @ref Rodin::MMG::Optimizer "MMG::Optimizer" | Mesh-quality optimization without an external metric field. |
+  | @ref Rodin::MMG::LevelSetDiscretizer "MMG::LevelSetDiscretizer" | Level-set meshing: cuts a background mesh along an isovalue or extracts the isosurface. |
+  | @ref Rodin::MMG::MMG5 "MMG::MMG5" | Base class providing shared MMG configuration and native conversion helpers. |
 
   ## Workflow Semantics
 
@@ -1258,14 +1258,14 @@
 
   | Workflow | Expected behavior |
   |----------|-------------------|
-  | `Optimizer` | Improves element quality while keeping the mesh close to the existing local size distribution. |
-  | `Adapt` | Refines, coarsens, moves, and reconnects elements according to a size field. |
-  | `LevelSetDiscretizer` | Alters topology as needed to conform the output mesh to the selected level-set isovalue. |
+  | @ref Rodin::MMG::Optimizer "Optimizer" | Improves element quality while keeping the mesh close to the existing local size distribution. |
+  | @ref Rodin::MMG::Adapt "Adapt" | Refines, coarsens, moves, and reconnects elements according to a size field. |
+  | @ref Rodin::MMG::LevelSetDiscretizer "LevelSetDiscretizer" | Alters topology as needed to conform the output mesh to the selected level-set isovalue. |
 
-  All workflows convert an `MMG::Mesh` to native MMG structures, run MMG, and
-  convert the result back. The output is a remeshed object; input element
-  indices should be treated as stable only where the wrapper or tests
-  explicitly document preservation.
+  All workflows convert an @ref Rodin::MMG::Mesh "MMG::Mesh" to native MMG
+  structures, run MMG, and convert the result back. The output is a remeshed
+  object; input element indices should be treated as stable only where the
+  wrapper or tests explicitly document preservation.
 
   ## Auto-Dispatch
 
@@ -1280,29 +1280,29 @@
 
   ## Shared Configuration (MMG5 base)
 
-  The MMG wrappers inherit common configuration methods from `MMG5`; each
-  returns `*this` for chaining:
+  The MMG wrappers inherit common configuration methods from
+  @ref Rodin::MMG::MMG5 "MMG5"; each returns `*this` for chaining:
 
   | Method | Description |
   |--------|-------------|
-  | `setHMin(hmin)` | Minimal allowed edge size |
-  | `setHMax(hmax)` | Maximal allowed edge size |
-  | `setHausdorff(hausd)` | Hausdorff distance tolerance for boundary approximation |
-  | `setGradation(hgrad)` | Edge-size gradation ratio between adjacent elements |
-  | `setAngleDetection(bool)` | Enable ridge angle detection for feature preservation |
+  | @ref Rodin::MMG::MMG5 "setHMin(hmin)" | Minimal allowed edge size |
+  | @ref Rodin::MMG::MMG5 "setHMax(hmax)" | Maximal allowed edge size |
+  | @ref Rodin::MMG::MMG5 "setHausdorff(hausd)" | Hausdorff distance tolerance for boundary approximation |
+  | @ref Rodin::MMG::MMG5 "setGradation(hgrad)" | Edge-size gradation ratio between adjacent elements |
+  | @ref Rodin::MMG::MMG5 "setAngleDetection(bool)" | Enable ridge angle detection for feature preservation |
 
   ## Required Entities
 
-  `MMG::Mesh` stores MMG-specific metadata:
+  @ref Rodin::MMG::Mesh "MMG::Mesh" stores MMG-specific metadata:
 
   | Method | Description |
   |--------|-------------|
-  | `setCorner(vertexIdx)` | Mark a vertex as a geometric corner |
-  | `setRidge(edgeIdx)` | Mark an edge as a geometric ridge |
-  | `setRequiredVertex(idx)` | Mark a vertex as required (`MG_REQ`) |
-  | `setRequiredEdge(idx)` | Mark an edge as required (`MG_REQ`) |
-  | `setRequiredTriangle(idx)` | Mark a triangle as required (`MG_REQ`) |
-  | `setRequiredTetrahedron(idx)` | Mark a tetrahedron as required (`MG_REQ`) |
+  | @ref Rodin::MMG::Mesh "setCorner(vertexIdx)" | Mark a vertex as a geometric corner |
+  | @ref Rodin::MMG::Mesh "setRidge(edgeIdx)" | Mark an edge as a geometric ridge |
+  | @ref Rodin::MMG::Mesh "setRequiredVertex(idx)" | Mark a vertex as required (`MG_REQ`) |
+  | @ref Rodin::MMG::Mesh "setRequiredEdge(idx)" | Mark an edge as required (`MG_REQ`) |
+  | @ref Rodin::MMG::Mesh "setRequiredTriangle(idx)" | Mark a triangle as required (`MG_REQ`) |
+  | @ref Rodin::MMG::Mesh "setRequiredTetrahedron(idx)" | Mark a tetrahedron as required (`MG_REQ`) |
 
   Required vertices, edges, triangles, and tetrahedra are serialized through
   MEDIT, converted to native MMG `MG_REQ` tags, and restored from native MMG
@@ -1327,17 +1327,18 @@
 
   ## LevelSetDiscretizer API
 
-  In addition to `MMG5` parameters, `LevelSetDiscretizer` provides:
+  In addition to @ref Rodin::MMG::MMG5 "MMG5" parameters,
+  @ref Rodin::MMG::LevelSetDiscretizer "LevelSetDiscretizer" provides:
 
   | Method | Description |
   |--------|-------------|
-  | `setLevelSet(ls)` | Isovalue to extract (default: 0.0) |
-  | `surface(bool)` | When true, discretize the isosurface; when false, discretize the subdomain volume |
-  | `setRMC(rmc)` | Removal threshold for small parasitic components |
-  | `setBoundaryReference(ref)` | Material reference for the discretized boundary |
-  | `setBaseReferences(refs)` | Restrict level-set splitting to specified base materials |
-  | `split(ref, split)` | Split one material reference into inside/outside references |
-  | `noSplit(ref)` | Keep one material reference from being split by the material policy |
+  | @ref Rodin::MMG::LevelSetDiscretizer "setLevelSet(ls)" | Isovalue to extract (default: 0.0) |
+  | @ref Rodin::MMG::LevelSetDiscretizer "surface(bool)" | When true, discretize the isosurface; when false, discretize the subdomain volume |
+  | @ref Rodin::MMG::LevelSetDiscretizer "setRMC(rmc)" | Removal threshold for small parasitic components |
+  | @ref Rodin::MMG::LevelSetDiscretizer "setBoundaryReference(ref)" | Material reference for the discretized boundary |
+  | @ref Rodin::MMG::LevelSetDiscretizer "setBaseReferences(refs)" | Restrict level-set splitting to specified base materials |
+  | @ref Rodin::MMG::LevelSetDiscretizer "split(ref, split)" | Split one material reference into inside/outside references |
+  | @ref Rodin::MMG::LevelSetDiscretizer "noSplit(ref)" | Keep one material reference from being split by the material policy |
 
   `noSplit(ref)` is a material-reference splitting policy. It is not an
   element-integrity guarantee for an individual edge, triangle, or tetrahedron
@@ -1351,8 +1352,8 @@
     .discretize(phi);
   @endcode
 
-  Use `MMG::Mesh::Build()` to construct meshes programmatically via the
-  builder pattern.
+  Use @ref Rodin::MMG::Mesh "MMG::Mesh::Build()" to construct meshes
+  programmatically via the builder pattern.
 
   @note Requires the MMG library and Rodin configured with `RODIN_USE_MMG=ON`.
 

--- a/doc/Namespaces.dox
+++ b/doc/Namespaces.dox
@@ -1570,7 +1570,8 @@
   @note Requires PETSc to be available and Rodin configured with
   `RODIN_USE_PETSC=ON`.
 
-  @see Rodin::Solver::KSP, Rodin::Solver::SNES
+  @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+  @see <a href="class_rodin_1_1_solver_1_1_s_n_e_s.html">Rodin::Solver::SNES</a>
  */
 
 /**

--- a/doc/README.md
+++ b/doc/README.md
@@ -117,6 +117,15 @@ Useful conventions:
 - Use `@f$ ... @f$` for inline mathematics and `@f[ ... @f]` for displayed
   formulas.
 - Use links only when the target is documented and resolvable.
+- When a class or class template page describes a family with more than one
+  supported specialization, include a table in the class description with the
+  exact columns `Specialization` and `Description`. The specialization entry
+  must link to that specialization, and the table must list the complete
+  supported set for the family.
+- In `@see` blocks and prose lists that name public classes, templates,
+  specialization groups, or generated file pages, write explicit `@ref`
+  references or HTML links. Do not rely on m.css to autolink bare comma-
+  separated names such as `MeshBase, Mesh.h`.
 - Prefer plain code text over `@ref` for names that are intentionally not part
   of the generated public reference.
 - Keep generated files and local build output out of `doc/`.

--- a/doc/SourceHeaders.dox
+++ b/doc/SourceHeaders.dox
@@ -1,0 +1,64 @@
+/**
+  @page source-headers Source headers
+  @brief Curated links to the main Rodin source header pages.
+
+  The generated <a href="files.html">Files</a> index lists only a small subset
+  of file pages in the m.css output. This page collects the public module
+  headers and commonly referenced submodule headers so users can still navigate
+  to the generated file documentation directly.
+
+  @section source-headers-top Top-Level Headers
+
+  | Header | Description |
+  |--------|-------------|
+  | <a href="_rodin_8h.html">Rodin.h</a> | Top-level umbrella include |
+  | <a href="_geometry_8h.html">Rodin/Geometry.h</a> | Geometry and mesh API |
+  | <a href="_variational_8h.html">Rodin/Variational.h</a> | Finite element spaces and form language |
+  | <a href="_solver_8h.html">Rodin/Solver.h</a> | Linear and nonlinear solvers |
+  | <a href="_assembly_8h.html">Rodin/Assembly.h</a> | Assembly backend entry points |
+  | <a href="_i_o_8h.html">Rodin/IO.h</a> | Mesh and field I/O |
+  | <a href="_q_f_8h.html">Rodin/QF.h</a> | Quadrature formulae |
+  | <a href="_m_p_i_8h.html">Rodin/MPI.h</a> | MPI integration |
+  | <a href="_p_e_t_sc_8h.html">Rodin/PETSc.h</a> | PETSc integration |
+  | <a href="_m_m_g_8h.html">Rodin/MMG.h</a> | MMG integration |
+  | <a href="_solid_8h.html">Rodin/Solid.h</a> | Solid mechanics |
+  | <a href="_adaptation_8h.html">Rodin/Adaptation.h</a> | Moving-interface mesh adaptation |
+  | <a href="_heart_8h.html">Rodin/Heart.h</a> | Reduced heart models |
+
+  @section source-headers-geometry Geometry
+
+  | Header | Description |
+  |--------|-------------|
+  | <a href="_geometry_2_mesh_8h.html">Rodin/Geometry/Mesh.h</a> | Primary mesh template |
+  | <a href="_polytope_8h.html">Rodin/Geometry/Polytope.h</a> | Polytope types and entities |
+  | <a href="_connectivity_8h.html">Rodin/Geometry/Connectivity.h</a> | Incidence relations |
+  | <a href="_point_8h.html">Rodin/Geometry/Point.h</a> | Physical/reference evaluation point |
+  | <a href="_geometry_2_sub_mesh_8h.html">Rodin/Geometry/SubMesh.h</a> | Local submesh view |
+  | <a href="_shard_8h.html">Rodin/Geometry/Shard.h</a> | Distributed shard metadata |
+  | <a href="_geometry_2_sharder_8h.html">Rodin/Geometry/Sharder.h</a> | Mesh sharding utilities |
+  | <a href="_balanced_compact_partitioner_8h.html">Rodin/Geometry/BalancedCompactPartitioner.h</a> | Partitioning utility |
+
+  @section source-headers-mmg MMG
+
+  | Header | Description |
+  |--------|-------------|
+  | <a href="_m_m_g_2_mesh_8h.html">Rodin/MMG/Mesh.h</a> | MMG mesh wrapper |
+  | <a href="_adapt_8h.html">Rodin/MMG/Adapt.h</a> | Metric-based adaptation |
+  | <a href="_mesh_optimizer_8h.html">Rodin/MMG/MeshOptimizer.h</a> | Mesh-quality optimizer |
+  | <a href="_level_set_discretizer_8h.html">Rodin/MMG/LevelSetDiscretizer.h</a> | Level-set discretizer |
+  | <a href="_m_m_g5_8h.html">Rodin/MMG/MMG5.h</a> | Shared MMG wrapper base |
+  | <a href="_m_m_g_2_grid_function_8h.html">Rodin/MMG/GridFunction.h</a> | MMG grid-function aliases |
+  | <a href="_m_m_g_2_mesh_loader_8h.html">Rodin/MMG/MeshLoader.h</a> | MMG mesh loader |
+  | <a href="_m_m_g_2_mesh_printer_8h.html">Rodin/MMG/MeshPrinter.h</a> | MMG mesh printer |
+
+  @section source-headers-parallel Parallel and Backend Headers
+
+  | Header | Description |
+  |--------|-------------|
+  | <a href="_m_p_i_2_geometry_2_mesh_8h.html">Rodin/MPI/Geometry/Mesh.h</a> | MPI mesh specialization |
+  | <a href="_m_p_i_2_geometry_2_sub_mesh_8h.html">Rodin/MPI/Geometry/SubMesh.h</a> | MPI submesh specialization |
+  | <a href="_m_p_i_2_geometry_2_sharder_8h.html">Rodin/MPI/Geometry/Sharder.h</a> | MPI sharder |
+  | <a href="_p_e_t_sc_2_math_8h.html">Rodin/PETSc/Math.h</a> | PETSc linear algebra |
+  | <a href="_p_e_t_sc_2_solver_8h.html">Rodin/PETSc/Solver.h</a> | PETSc solver wrappers |
+  | <a href="_p_e_t_sc_2_variational_8h.html">Rodin/PETSc/Variational.h</a> | PETSc-backed variational wrappers |
+*/

--- a/doc/agents/README.md
+++ b/doc/agents/README.md
@@ -14,6 +14,13 @@ Hierarchical: read top-down, stop at the depth your task needs.
 
 - [architecture.md](architecture.md) — the module map: every directory under
   `src/Rodin/`, what it is, how the layers stack.
+- [workflows.md](workflows.md) — operational checklists for extending nodes,
+  finite element spaces, assembly, solvers, IO, and Solid terms.
+- [backend-support.md](backend-support.md) — what "supported" means across
+  local Eigen, OpenMP, MPI, and PETSc code paths.
+- [numerical-contracts.md](numerical-contracts.md) — interpolation vs `L2`
+  projection, problem signs, linear-system lifetimes, quadrature, and
+  residual/tangent consistency.
 
 ## Level 3 — per-domain detail (open the one your task touches)
 

--- a/doc/agents/backend-support.md
+++ b/doc/agents/backend-support.md
@@ -1,0 +1,45 @@
+# Backend and support matrix
+
+Use this page to decide which mirror implementations and tests a change needs.
+Rodin keeps one mathematical surface while varying storage, assembly, and
+parallel execution through template specializations.
+
+## Backend vocabulary
+
+| Dimension | Local Eigen path | OpenMP path | MPI path | PETSc path |
+| --- | --- | --- | --- | --- |
+| Context | `Context::Local` | `Context::Local` plus OpenMP assembly | `Context::MPI` | Local or MPI PETSc objects |
+| Mesh | `Geometry::Mesh<Context::Local>` | same mesh | `Geometry::Mesh<Context::MPI>` | same mesh contexts |
+| Assembly | `Assembly::Sequential` | `Assembly::OpenMP` | `Assembly::MPI` | `PETSc::Assembly::*` mirrors |
+| Linear algebra | `Math::Matrix`, `Math::SparseMatrix`, `Math::Vector` | same objects | usually PETSc for distributed solves | `PETSc::Math::Matrix`, `Vector`, `LinearSystem` |
+| Solvers | Eigen/SuiteSparse wrappers | same solvers after assembly | usually PETSc KSP/SNES | `Solver::KSP`, PETSc `CG`/`GMRES`, `SNES` |
+| IO | MFEM, MEDIT, HDF5, XDMF | same | HDF5/XDMF shard-aware paths | PETSc vector/grid-function paths |
+
+## What "complete support" means
+
+| Feature family | Local | OpenMP | MPI | PETSc |
+| --- | --- | --- | --- | --- |
+| Mesh topology/geometry | required | same as Local | mirror specialization and reconciliation | consumed by PETSc forms |
+| Finite element space | required | same as Local | mirror specialization when distributed use is claimed | must work with PETSc trial/test if claimed |
+| Form-language node | required | same expression node | works if the FES/backend traits support it | works if PETSc form assembly supports it |
+| Linear/bilinear assembly | `Sequential` | `OpenMP` if enabled | `MPI` if distributed | PETSc Sequential/OpenMP/MPI if PETSc support is claimed |
+| Solver | sparse/dense specialization as appropriate | same solver | usually not standalone | PETSc `LinearSystem` specialization if claimed |
+| IO format | local loader/printer | same | shard-aware loader/printer if distributed | PETSc data specialization if PETSc fields are claimed |
+
+A feature can deliberately support only one column. Say that explicitly in the
+class docs, guides, tests, and PR notes. Do not imply backend parity merely
+because the primary template compiles.
+
+## Common extension decisions
+
+- If the math is backend-independent, implement the core expression or
+  integrator once and let assembly backends consume it.
+- If the storage changes, specialize at the linear algebra or grid-function
+  layer, not in the mathematical API.
+- If the mesh is distributed, reason about ownership, shared entities, ghosts,
+  and reconciliation before writing assembly code.
+- If PETSc is involved, reason against PETSc 3.19 behavior even if the local
+  PETSc is newer.
+- If OpenMP is involved, test determinism and accumulation semantics. Most
+  speedups should come from per-cell caching, not a duplicate fast path.
+

--- a/doc/agents/numerical-contracts.md
+++ b/doc/agents/numerical-contracts.md
@@ -1,0 +1,88 @@
+# Numerical contracts
+
+This page collects cross-cutting numerical rules that otherwise hide in
+module docs. Read it before changing interpolation, projection, assembly,
+solvers, quadrature, or residual/tangent code.
+
+## Interpolation, projection, and coefficients
+
+`GridFunction::operator=(FunctionBase)` applies the finite element space's
+degree-of-freedom functionals to the expression. This is interpolation in the
+space's DOF sense, not an `L2`-orthogonal projection.
+
+For an `L2` projection, assemble and solve the mass problem:
+
+```cpp
+TrialFunction u(Vh);
+TestFunction  v(Vh);
+Problem l2(u, v);
+l2 = Integral(u, v) - Integral(f, v);
+Solver::CG(l2).solve();
+```
+
+Do not read coefficients as values except where the space guarantees that
+contract. P1 nodal spaces store vertex values. High-order H1 uses
+Fekete/Dubiner machinery, so coefficients are not plain nodal values.
+
+## Problem sign convention
+
+Rodin problem assignment states a residual equation with everything moved to
+the left:
+
+```cpp
+problem = Integral(Grad(u), Grad(v)) - Integral(f, v);
+```
+
+The assembler routes bilinear terms to the operator and linear terms to the
+right-hand side with the appropriate sign. For nonlinear Newton forms, build
+the tangent and residual so the assembled system is
+
+```text
+J(x) dx = -F(x)
+```
+
+Do not negate the residual twice.
+
+## LinearSystem lifetime
+
+A `Math::LinearSystem` is bound to the spaces that created it. A changed mesh,
+space, block layout, or global size means a new system object. PETSc makes
+this especially strict: matrices and vectors cannot be resized in place after
+layout/assembly.
+
+Warm starts are intentional. Reassembly zeroes the operator and right-hand
+side as needed but preserves the solution vector where the backend contract
+does so.
+
+## Quadrature and exactness
+
+Quadrature order is a numerical contract, not only a performance knob. A form
+that claims exactness or a convergence rate must state the polynomial degree
+being integrated and choose a rule that supports it. Curved mappings and
+non-polynomial coefficients change that accounting.
+
+When changing a fast path, compare against the generic quadrature path or a
+manufactured solution. Identical-looking formulas can differ through mapping,
+weights, or shape-function derivatives.
+
+## Residual/tangent consistency
+
+Every residual/tangent pair must satisfy a finite-difference consistency
+check:
+
+```text
+J(x) w ~= (R(x + eps w) - R(x - eps w)) / (2 eps)
+```
+
+Run the check at P1 and at higher order if the implementation claims
+order-genericity. A pair can be self-consistent and still physically wrong, so
+also keep energy identities, manufactured solutions, or known-limit tests
+when those are available.
+
+## Constraints
+
+Dirichlet conditions and identification conditions are structural constraints.
+Assembly eliminates or expands them through the constraint map. Do not replace
+them with penalty terms unless the mathematical model explicitly asks for a
+penalty method.
+

--- a/doc/agents/petsc.md
+++ b/doc/agents/petsc.md
@@ -1,5 +1,10 @@
 # PETSc backend notes
 
+Read [backend-support.md](backend-support.md) and
+[numerical-contracts.md](numerical-contracts.md) before changing PETSc-backed
+assembly, storage, or solver behavior. PETSc is a mirror of Rodin's finite
+element contracts, not a separate semantic path.
+
 ## Version skew: CI is the real gate
 
 CI (Ubuntu gcc-14 "Unit"/"Manufactured" jobs) builds against **PETSc 3.19.6**;

--- a/doc/agents/philosophy.md
+++ b/doc/agents/philosophy.md
@@ -169,7 +169,14 @@ rather than extended:
   deleted or omitted.
 - Doxygen with real mathematics: `@f$ ... @f$` formulas, a "Mathematical
   Foundation"/usage section, `@defgroup <Name>Specializations` per
-  specialization family. Documentation states the formula the code computes.
+  specialization family. When a class page documents a family with multiple
+  supported specializations, its description includes a table with exactly
+  `Specialization` and `Description` columns; every specialization entry links
+  to that specialization, and the table lists the complete supported set.
+  `@see` blocks and prose lists link public classes, templates, specialization
+  groups, and generated file pages explicitly with `@ref` or HTML links instead
+  of bare comma-separated names. Documentation states the formula the code
+  computes.
 - Errors: `Rodin::Alert` exceptions (streamable, composable) at API
   boundaries for user mistakes; `assert` for internal invariants (remember
   it vanishes under `-DNDEBUG`); `assert(ierr == PETSC_SUCCESS)` after PETSc

--- a/doc/agents/physics.md
+++ b/doc/agents/physics.md
@@ -4,6 +4,10 @@ The physics/application layers built on the form language. Structural
 facts only — parameter tuning and experiment history do not belong in the
 repo.
 
+For Solid or level-set terms that assemble residuals, tangents, constraints,
+or projection-like transfers, keep [workflows.md](workflows.md) and
+[numerical-contracts.md](numerical-contracts.md) open with this file.
+
 ## Solid (src/Rodin/Solid/) — finite-strain solid mechanics
 
 Layered like the mathematics:

--- a/doc/agents/quadrature.md
+++ b/doc/agents/quadrature.md
@@ -6,6 +6,10 @@ cover the degrees for which compact rules are available, and positive
 Gaussian product rules provide deterministic arbitrary-order fallbacks. The
 runtime library contains no nonlinear rule generator.
 
+Read [numerical-contracts.md](numerical-contracts.md) before changing default
+orders, fast paths, or mapped-integrand assumptions; quadrature exactness is a
+cross-module numerical contract, not only a `QF` implementation detail.
+
 ## Contract
 
 For a requested order $p$, `PolytopeQuadratureFormula` returns a rule that is

--- a/doc/agents/solvers-assembly.md
+++ b/doc/agents/solvers-assembly.md
@@ -1,5 +1,11 @@
 # Assembly and solvers
 
+For new assembly behavior, solver support, or backend claims, read
+[workflows.md](workflows.md), [backend-support.md](backend-support.md), and
+[numerical-contracts.md](numerical-contracts.md) with this file. They define
+the extension checklist, supported-configuration matrix, and numerical
+contracts that assembly/solver changes are expected to preserve.
+
 ## Assembly (src/Rodin/Assembly/)
 
 - Backends are mesh-iteration strategies: `Sequential` and `OpenMP`
@@ -67,3 +73,7 @@ are immutable for its lifetime; DOF elimination implements essential
 constraints; a new mesh/space means a new system object (this is a hard
 rule on the PETSc side — petsc.md). Warm starts: solution vectors are
 reused, not zeroed, across assemblies.
+
+When a feature claims backend support, update the expectation in
+[backend-support.md](backend-support.md) and cover every listed assembly path
+that can exercise it.

--- a/doc/agents/testing.md
+++ b/doc/agents/testing.md
@@ -111,3 +111,11 @@ CI facts that bite:
   look like an unrelated downstream failure.
 - Doxygen documentation is published per-branch; malformed doc comments
   can fail Documentation.yml.
+- Documentation.yml is also the review gate for specialization-family class
+  pages: if a class has multiple supported specializations, its Doxygen
+  description must include a complete `Specialization` / `Description` table
+  with each specialization linked.
+- Documentation review also treats unlinked public references as failures:
+  `@see` blocks and prose lists should use explicit `@ref` references or HTML
+  links for public classes, templates, specialization groups, and generated
+  file pages instead of bare comma-separated names.

--- a/doc/agents/testing.md
+++ b/doc/agents/testing.md
@@ -64,6 +64,10 @@ PETSc handle ownership is resource/lifecycle, the OpenMP and MPI assembly
 backends are concurrency, and CI building against PETSc 3.19 while local
 builds are newer is compatibility.
 
+Use [backend-support.md](backend-support.md) to decide which configurations a
+feature must test, and [numerical-contracts.md](numerical-contracts.md) to
+choose the invariant or manufactured check that proves the numerical behavior.
+
 Two rules that make the difference between coverage and theatre:
 
 - **A regression test must be shown to catch the bug.** Revert the fix,

--- a/doc/agents/theory/finite-elements.md
+++ b/doc/agents/theory/finite-elements.md
@@ -89,6 +89,9 @@ at $K\ge1$ for non-polynomial data; if you need the $L^2$-orthogonal
 projection, write the mass-matrix problem
 `Integral(u, v) - Integral(f, v)` and solve it.
 
+The operational checklist for this distinction lives in
+[../numerical-contracts.md](../numerical-contracts.md).
+
 ## Quadrature
 
 Element integrals are approximated by rules on $K$:

--- a/doc/agents/variational.md
+++ b/doc/agents/variational.md
@@ -2,7 +2,10 @@
 
 The largest module (~127 headers). Read philosophy.md first for the
 underlying algebra (typed expression trees, grading); this doc is the
-concrete inventory and the contracts.
+concrete inventory and the contracts. For extension work, keep
+[workflows.md](workflows.md) and [numerical-contracts.md](numerical-contracts.md)
+open beside this file: the first gives the checklist, the second states the
+cross-module numerical rules this module must preserve.
 
 ## FormLanguage substrate
 
@@ -95,8 +98,11 @@ Families:
 - Data access: `getData()`/`setData()` (Math::Vector), `getValue(Point)` /
   `getValue(IntegrationPoint)` for FES-agnostic evaluation (this is the
   sanctioned way — works at any order/basis).
-- `operator=` from any FunctionBase expression **projects** onto the space
-  (interpolation at DOF functionals); `projectOnBoundary` variants exist.
+- `operator=` from any FunctionBase expression interpolates into the space by
+  applying DOF functionals; `projectOnBoundary` variants exist. This is not an
+  `L2` projection; when the distinction matters, assemble a mass-matrix
+  `Problem` as described in
+  [numerical-contracts.md](numerical-contracts.md).
 - Components `.x()/.y()/.z()` return component views.
 - I/O: `load`/`save` in MFEM/MEDIT formats; XDMF/HDF5 via IO module.
 - `GridFunctionBaseReference` / LazyEvaluator wraps a GridFunction for use

--- a/doc/agents/workflows.md
+++ b/doc/agents/workflows.md
@@ -1,0 +1,91 @@
+# Extension workflows
+
+Use this page when the task is "add a new X" or "extend X to a new case".
+The philosophy page explains the shape of the library; this page is the
+operational checklist.
+
+## New form-language node
+
+1. Add one header for the algebraic concept, named for the mathematical
+   operation (`Trace`, `Jump`, `Potential`, etc.).
+2. Add `FormLanguage::Traits` specializations in the same header, above the
+   class definitions.
+3. Specialize the existing concept name for each grading/range case instead
+   of creating sibling class names.
+4. Deep-copy operands on construction and keep evaluation on the CRTP/static
+   path. Do not add virtual calls to quadrature-point evaluation.
+5. Add CTAD/deduction helpers so user code reads like the formula.
+6. Add Doxygen math for the formula and a specialization table when the node
+   has multiple supported specializations.
+7. Test the expression in the smallest form that exercises its grading:
+   function, linear-form integrand, bilinear-form integrand, or DG/facet term.
+
+## New finite element space
+
+1. Define the element first: basis, nodes/functionals, order, and range.
+2. Define how DOFs distribute over the incidence complex by dimension. Never
+   assume a `node * vdim + component` layout in users of the space.
+3. Implement pullback/pushforward and point evaluation through
+   `Geometry::Point` and the element basis.
+4. Add `FormLanguage::Traits` for the space and its element.
+5. Add FES-specific operator specializations (`Grad`, `Div`, `Jacobian`,
+   `QuadratureRule`) only where the space can support them mathematically.
+6. Add `GridFunction` coverage: assignment/interpolation, evaluation at a
+   point, vector-valued behavior if applicable, and I/O if the space is meant
+   to be saved.
+7. Verify with manufactured convergence when the space claims approximation
+   order, not just with compile tests.
+
+## New solver
+
+1. Start from `Solver::LinearSolverBase<LinearSystem>` unless the solver is
+   truly nonlinear.
+2. Add `FormLanguage::Traits<SolverType>` exposing `LinearSystemType`.
+3. Keep the user surface `Solver(problem).setX(...).solve()` and preserve
+   chainable setters.
+4. Specialize on the linear-system type: sparse, dense, or PETSc-backed.
+5. Document the matrix assumptions explicitly: SPD, symmetric indefinite,
+   nonsymmetric, rectangular, direct factorization, or Krylov iteration.
+6. Add a specialization table on the primary class page.
+7. Test both the raw linear-system path and the `Problem`/CTAD path when both
+   are supported.
+
+## New assembly behavior
+
+1. Identify the operand: bilinear form, linear form, Dirichlet value,
+   identification constraint, or complete problem.
+2. Add or extend the typed input object, preserving both local integrator
+   lists and global integrator lists.
+3. Implement `AssemblyBase` first, then concrete iteration backends:
+   `Sequential`, `OpenMP`, MPI, and PETSc mirrors as applicable.
+4. Preserve constraint semantics: Dirichlet and identification constraints
+   are structural eliminations, not penalties.
+5. Preserve `Math::LinearSystem` lifetime rules: a changed mesh or space means
+   a new system object.
+6. Add tests that cover the backend matrix the feature claims to support.
+
+## New IO support
+
+1. Extend the existing loader/printer family:
+   `MeshLoader`, `MeshPrinter`, `GridFunctionLoader`, or
+   `GridFunctionPrinter`.
+2. Specialize by `IO::FileFormat`, context, finite element space, and data
+   backend. Do not add a parallel naming hierarchy.
+3. Decide whether the format is mesh-only, field-only, local, MPI, PETSc, or
+   time-series output.
+4. Round-trip the smallest representative mesh/field and verify attributes,
+   geometry, connectivity requirements, and coefficient data.
+5. Add the specialization table rows to the family page.
+
+## New Solid term
+
+1. Write the residual and the consistent tangent together.
+2. State the sign convention in the docs. `Problem` moves linear forms to the
+   right-hand side, so Newton systems should assemble `K du = -R`.
+3. Keep internal variables as finite element unknowns when they participate
+   in the coupled solve.
+4. Add finite-difference consistency tests for the residual/tangent pair.
+5. Run the test at P1 and at higher order if the term claims order-genericity.
+6. For hyperelasticity, state the kinematics, stress measure, energy, and
+   tangent being implemented.
+

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -19,6 +19,7 @@ LINKS_NAVBAR1 = [
         ('Examples and tutorials', 'examples-index'),
         ('Gallery', 'gallery'),
         ('I/O in Rodin', 'guides-io'),
+        ('Source headers', 'source-headers'),
         ('Notation', 'notation-index'),
         ('Credits', 'credits-index')]),
     ("Modules", 'modules', [

--- a/src/Rodin/Advection/Lagrangian.h
+++ b/src/Rodin/Advection/Lagrangian.h
@@ -425,6 +425,11 @@ namespace Rodin::Advection
    * - Mass-conservative in variational form
    *
    * @tparam Params Parameter pack for class specialization
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Lagrangian "Lagrangian<TrialFunction<GridFunction<FES, Data>, FES>, TestFunction<FES>, Initial, VectorField, Step>" | Semi-Lagrangian projection update for a trial/test scalar transport formulation. |
+   * | @ref Lagrangian "Lagrangian<...>" | Primary template documenting the supported specialization family for advection schemes. |
    */
   template <class ... Params>
   class Lagrangian;

--- a/src/Rodin/Advection/Lagrangian.h
+++ b/src/Rodin/Advection/Lagrangian.h
@@ -32,7 +32,8 @@ namespace Rodin::Advection
   /**
    * @brief Boundary policy for characteristic tracing: stop-at-boundary with inward offset.
    *
-   * This policy is intended to be used with semi-Lagrangian / characteristic-based
+   * This policy is intended to be used with @ref Lagrangian
+   * "semi-Lagrangian" / characteristic-based
    * transport where the footpoint of a characteristic must remain inside the computational
    * domain (no sampling outside).
    *
@@ -62,7 +63,7 @@ namespace Rodin::Advection
    *   you want a stable, non-invasive handling of boundary hits without introducing
    *   tangential sliding artifacts or inflow modeling. Truncation + inward nudge is a good default.
    *
-   * - **Semi-Lagrangian advection of a scalar** when you deliberately choose:
+   * - **@ref Lagrangian "Semi-Lagrangian" advection of a scalar** when you deliberately choose:
    *   “if the departure point would be outside, sample the closest interior point”
    *   (often used as a robust fallback in graphics/engineering codes).
    *
@@ -77,7 +78,8 @@ namespace Rodin::Advection
    *
    * @par Assumptions
    * - The geometric mapping is sufficiently regular for using @f$ J^{-T} n_{\mathrm{ref}} @f$
-   *   as a physical normal direction on the face. (Best behavior for affine/P1 geometry.)
+   *   as a physical normal direction on the face. (Best behavior for
+   *   affine/<a href="class_rodin_1_1_variational_1_1_p1.html">P1</a> geometry.)
    *
    * @par Robustness notes
    * - The inward nudge is done in *physical space* so that the offset represents a true
@@ -99,7 +101,7 @@ namespace Rodin::Advection
        * @brief Constructs the boundary policy.
        *
        * @param[in] dt          Signed time step used by the tracer (kept for API symmetry).
-       * @param[in] mesh        Mesh on which tracing occurs.
+       * @param[in] mesh        @ref Geometry::Mesh "Mesh" on which tracing occurs.
        * @param[in] epsInPhys Inward physical offset used to place the footpoint strictly inside.
        */
       StopInsideBoundaryPolicy(
@@ -213,8 +215,10 @@ namespace Rodin::Advection
   /**
    * @brief First-order boundary-hit handler for semi-Lagrangian tracing with an inward shift.
    *
-   * This boundary policy is meant to be used with `Variational::Flow` (and therefore with
-   * semi-Lagrangian / characteristic-based schemes) when a traced characteristic hits a
+   * This boundary policy is meant to be used with
+   * <a href="_flow_8h.html">Variational::Flow</a>
+   * (and therefore with @ref Lagrangian "semi-Lagrangian" /
+   * characteristic-based schemes) when a traced characteristic hits a
    * boundary face before the remaining time `hit.tau` is consumed.
    *
    * The policy enforces an "always-sample-inside" rule:
@@ -265,7 +269,7 @@ namespace Rodin::Advection
    *
    * @par Parameters
    * - `dt`: Signed step size of the tracer (kept for API symmetry; not used directly here).
-   * - `mesh`: Mesh on which tracing occurs.
+   * - `mesh`: @ref Geometry::Mesh "Mesh" on which tracing occurs.
    * - `phi`: Scalar field/function to correct (typically the advected field itself in level-set use).
    * - `epsInPhys`: Desired inward physical offset. The effective shift is
    *   `max(epsInPhys, 50*sqrt(machine_epsilon))`.
@@ -277,7 +281,7 @@ namespace Rodin::Advection
       /**
        * @brief Constructs the boundary policy.
        * @param dt Signed time step used by the tracer.
-       * @param mesh Mesh on which tracing occurs.
+       * @param mesh @ref Geometry::Mesh "Mesh" on which tracing occurs.
        * @param phi Scalar field used for the Taylor correction.
        * @param epsInPhys Inward physical offset used after a boundary hit.
        */

--- a/src/Rodin/Assembly.h
+++ b/src/Rodin/Assembly.h
@@ -19,7 +19,7 @@
  * - **Sequential**: Single-threaded assembly (always available)
  * - **OpenMP**: Multi-threaded parallel assembly (requires RODIN_USE_OPENMP)
  *
- * @see Rodin::Assembly
+ * @see <a href="namespace_rodin_1_1_assembly.html">Rodin::Assembly</a>
  */
 
 #include "Assembly/Sequential.h"

--- a/src/Rodin/Assembly/ForwardDecls.h
+++ b/src/Rodin/Assembly/ForwardDecls.h
@@ -27,6 +27,17 @@ namespace Rodin::Assembly
    *
    * @tparam LinearAlgebraType Target linear algebra type (e.g., sparse matrix, vector)
    * @tparam Operand Variational form type (e.g., BilinearForm, LinearForm)
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref AssemblyBase "AssemblyBase<OperatorType, BilinearForm<...>>" | Base interface for assembling one bilinear form into one operator. |
+   * | @ref AssemblyBase "AssemblyBase<OperatorType, Tuple<BilinearForm<...>...>>" | Base interface for assembling block/tuple bilinear forms. |
+   * | @ref AssemblyBase "AssemblyBase<VectorType, LinearForm<...>>" | Base interface for assembling one linear form into one vector. |
+   * | @ref AssemblyBase "AssemblyBase<VectorType, Tuple<LinearForm<...>...>>" | Base interface for assembling block/tuple linear forms. |
+   * | @ref AssemblyBase "AssemblyBase<IndexMap<Scalar>, DirichletBC<TrialFunction, FunctionBase>>" | Base interface for scalar Dirichlet elimination maps. |
+   * | @ref AssemblyBase "AssemblyBase<IndexMap<pair<IndexArray, Vector>>, DirichletBC<TrialFunction, ShapeFunctionBase>>" | Base interface for identification-style Dirichlet constraints. |
+   * | @ref AssemblyBase "AssemblyBase<LinearSystem, Problem<LinearSystem, TrialFunction, TestFunction>>" | Base interface for single-field problem assembly. |
+   * | @ref AssemblyBase "AssemblyBase<LinearSystem, Problem<LinearSystem, U1, U2, U3, Us...>>" | Base interface for mixed multi-field problem assembly. |
    */
   template <class LinearAlgebraType, class Operand>
   class AssemblyBase;
@@ -40,6 +51,21 @@ namespace Rodin::Assembly
    *
    * @tparam LinearAlgebraType Target linear algebra type
    * @tparam Operand Variational form type to assemble
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Sequential "Sequential<VectorType, LinearForm<FES, VectorType>>" | Sequential assembly of one linear form. |
+   * | @ref Sequential "Sequential<VectorType, Tuple<LinearForm<...>...>>" | Sequential assembly of block/tuple linear forms. |
+   * | @ref Sequential "Sequential<OperatorType, BilinearForm<...>>" | Sequential assembly of one bilinear form. |
+   * | @ref Sequential "Sequential<OperatorType, Tuple<BilinearForm<...>...>>" | Sequential assembly of block/tuple bilinear forms. |
+   * | @ref Sequential "Sequential<Math::Vector<Real>, LinearForm<FES, Math::Vector<Real>>>" | Sequential real-vector linear form assembly helper. |
+   * | @ref Sequential "Sequential<LinearSystem, Problem<LinearSystem, TrialFunction, TestFunction>>" | Sequential single-field problem assembly. |
+   * | @ref Sequential "Sequential<LinearSystem, Problem<LinearSystem, U1, U2, U3, Us...>>" | Sequential mixed multi-field problem assembly. |
+   * | @ref Sequential "Sequential<IndexMap<Scalar>, DirichletBC<TrialFunction, FunctionBase>>" | Sequential scalar Dirichlet elimination-map assembly. |
+   * | @ref Sequential "Sequential<IndexMap<pair<IndexArray, Vector>>, DirichletBC<TrialFunction, ShapeFunctionBase>>" | Sequential identification-style Dirichlet constraint assembly. |
+   * | @ref Sequential "Sequential<Vec, LinearForm<FES, Vec>>" | PETSc sequential linear-form assembly. |
+   * | @ref Sequential "Sequential<Mat, BilinearForm<..., Mat>>" | PETSc sequential bilinear-form assembly. |
+   * | @ref Sequential "Sequential<PETSc::Math::LinearSystem, Problem<...>>" | PETSc sequential problem assembly. |
    */
   template <class LinearAlgebraType, class Operand>
   class Sequential;
@@ -51,6 +77,10 @@ namespace Rodin::Assembly
    * Used internally by Sequential assembly implementations.
    *
    * @tparam Mesh Mesh type to iterate over
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SequentialIteration "SequentialIteration<Mesh<Context::Local>>" | Sequential iteration over local mesh polytopes. |
    */
   template <class Mesh>
   class SequentialIteration;
@@ -123,6 +153,13 @@ namespace Rodin::Assembly
    * otherwise, defaults to sequential assembly.
    *
    * @tparam Ts Context type parameters (e.g., Context::Local)
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Default "Default<Context::Local>" | Default local assembly strategy. |
+   * | @ref Default "Default<Context::Local, Context::Local>" | Default local/local bilinear assembly strategy. |
+   * | @ref Default "Default<Context::MPI>" | Default distributed assembly strategy. |
+   * | @ref Default "Default<Context::MPI, Context::MPI>" | Default distributed/distributed bilinear assembly strategy. |
    */
   template <class ... Ts>
   class Default;
@@ -140,6 +177,20 @@ namespace Rodin::Assembly
    *
    * @tparam LinearAlgebraType Target linear algebra type
    * @tparam Operand Variational form type to assemble
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref OpenMP "OpenMP<VectorType, LinearForm<FES, VectorType>>" | OpenMP assembly of one linear form. |
+   * | @ref OpenMP "OpenMP<VectorType, Tuple<LinearForm<...>...>>" | OpenMP assembly of block/tuple linear forms. |
+   * | @ref OpenMP "OpenMP<OperatorType, BilinearForm<...>>" | OpenMP assembly of one bilinear form. |
+   * | @ref OpenMP "OpenMP<OperatorType, Tuple<BilinearForm<...>...>>" | OpenMP assembly of block/tuple bilinear forms. |
+   * | @ref OpenMP "OpenMP<LinearSystem, Problem<LinearSystem, TrialFunction, TestFunction>>" | OpenMP single-field problem assembly. |
+   * | @ref OpenMP "OpenMP<LinearSystem, Problem<LinearSystem, U1, U2, U3, Us...>>" | OpenMP mixed multi-field problem assembly. |
+   * | @ref OpenMP "OpenMP<IndexMap<Scalar>, DirichletBC<TrialFunction, FunctionBase>>" | OpenMP scalar Dirichlet elimination-map assembly. |
+   * | @ref OpenMP "OpenMP<IndexMap<pair<IndexArray, Vector>>, DirichletBC<TrialFunction, ShapeFunctionBase>>" | OpenMP identification-style Dirichlet constraint assembly. |
+   * | @ref OpenMP "OpenMP<Vec, LinearForm<FES, Vec>>" | PETSc/OpenMP linear-form assembly. |
+   * | @ref OpenMP "OpenMP<Mat, BilinearForm<..., Mat>>" | PETSc/OpenMP bilinear-form assembly. |
+   * | @ref OpenMP "OpenMP<PETSc::Math::LinearSystem, Problem<...>>" | PETSc/OpenMP problem assembly. |
    */
   template <class LinearAlgebraType, class Operand>
   class OpenMP;
@@ -151,6 +202,10 @@ namespace Rodin::Assembly
    * Used internally by OpenMP assembly implementations.
    *
    * @tparam Mesh Mesh type to iterate over
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref OpenMPIteration "OpenMPIteration<Mesh<Context::Local>>" | OpenMP iteration over local mesh polytopes. |
    */
   template <class Mesh>
   class OpenMPIteration;

--- a/src/Rodin/Assembly/Input.h
+++ b/src/Rodin/Assembly/Input.h
@@ -538,6 +538,17 @@ namespace Rodin::Assembly
       std::reference_wrapper<const FlatSet<Geometry::Attribute>> m_essBdr;
   };
 
+  /**
+   * @brief Input data for complete problem assembly.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref ProblemAssemblyInput "ProblemAssemblyInput<ProblemBody, TrialFunction, TestFunction>" | Assembly input for a single trial/test field problem. |
+   * | @ref ProblemAssemblyInput "ProblemAssemblyInput<ProblemBody, U1, U2, U3, Us...>" | Assembly input for mixed multi-field problems with multiple trial and test functions. |
+   *
+   * @tparam Ts Problem body and trial/test function types selected by the
+   *         concrete specialization.
+   */
   template <class ... Ts>
   class ProblemAssemblyInput;
 

--- a/src/Rodin/Context.h
+++ b/src/Rodin/Context.h
@@ -15,7 +15,7 @@
  * It handles thread-local and process-local state that may be needed during
  * finite element computations.
  *
- * @see Rodin::Context
+ * @see <a href="namespace_rodin_1_1_context.html">Rodin::Context</a>
  */
 
 #include "Context/Local.h"

--- a/src/Rodin/Eikonal/FMM.h
+++ b/src/Rodin/Eikonal/FMM.h
@@ -39,6 +39,11 @@ namespace Rodin::Eikonal
    *
    * @tparam Solution Solution type (typically a GridFunction)
    * @tparam SpeedFunction Type of the speed function @f$ F(x) @f$
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref FMM "FMM<GridFunction<P1<Real, Mesh<Context::Local>>, Data>, SpeedFunction>" | Fast marching method for scalar P1 grid functions on local simplicial meshes. |
+   * | @ref FMM "FMM<Solution, SpeedFunction>" | Primary template for supported fast marching method implementations. |
    */
   template <class Solution, class SpeedFunction>
   class FMM;

--- a/src/Rodin/FormLanguage.h
+++ b/src/Rodin/FormLanguage.h
@@ -15,7 +15,7 @@
  * the domain-specific language (DSL) used to express variational formulations
  * in Rodin. This includes expression templates and lazy evaluation mechanisms.
  *
- * @see Rodin::FormLanguage
+ * @see <a href="namespace_rodin_1_1_form_language.html">Rodin::FormLanguage</a>
  */
 
 #include "FormLanguage/Base.h"

--- a/src/Rodin/FormLanguage/ForwardDecls.h
+++ b/src/Rodin/FormLanguage/ForwardDecls.h
@@ -26,7 +26,7 @@ namespace Rodin::FormLanguage
   /**
    * @brief Container for polymorphic form language objects.
    * @tparam T Type of elements stored in the list
-   * @see List
+   * @see <a href="class_rodin_1_1_form_language_1_1_list.html">List</a>
    */
   template <class T>
   class List;
@@ -34,7 +34,7 @@ namespace Rodin::FormLanguage
   /**
    * @brief Type traits for form language objects.
    * @tparam Args Template parameters for trait specializations
-   * @see Traits
+   * @see <a href="struct_rodin_1_1_form_language_1_1_traits.html">Traits</a>
    */
   template <class ... Args>
   struct Traits;

--- a/src/Rodin/ForwardDecls.h
+++ b/src/Rodin/ForwardDecls.h
@@ -22,15 +22,21 @@ namespace Rodin
    * @brief Forward declaration of the Pair template class.
    * @tparam L Type of the first element.
    * @tparam R Type of the second element.
-   * @see Pair
+   * @see <a href="class_rodin_1_1_pair.html">Pair</a>
    */
   template <class L, class R>
   class Pair;
 
   /**
    * @brief Forward declaration of the Tuple template class.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Tuple "Tuple<>" | Empty compile-time tuple, used as the terminal case for recursive tuple algorithms. |
+   * | @ref Tuple "Tuple<T, Ts...>" | Non-empty compile-time tuple storing a head element and the remaining tail. |
+   *
    * @tparam Ts Types of the tuple elements.
-   * @see Tuple
+   * @see <a href="class_rodin_1_1_tuple.html">Tuple</a>
    */
   template <class ... Ts>
   class Tuple;

--- a/src/Rodin/Geometry/BalancedCompactPartitioner.h
+++ b/src/Rodin/Geometry/BalancedCompactPartitioner.h
@@ -26,7 +26,8 @@ namespace Rodin::Geometry
    * @note This is particularly useful for parallel computing where
    * minimizing communication between processors is important.
    *
-   * @see Partitioner, GreedyPartitioner
+   * @see <a href="class_rodin_1_1_geometry_1_1_partitioner.html">Partitioner</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_greedy_partitioner.html">GreedyPartitioner</a>
    */
   class BalancedCompactPartitioner : public Partitioner
   {

--- a/src/Rodin/Geometry/Connectivity.h
+++ b/src/Rodin/Geometry/Connectivity.h
@@ -195,7 +195,9 @@ namespace Rodin::Geometry
    * Connectivity objects are not thread-safe during construction. Once
    * finalized, read-only access is thread-safe.
    *
-   * @see ConnectivityBase, Mesh, Mode
+   * @see <a href="class_rodin_1_1_geometry_1_1_connectivity_base.html">ConnectivityBase</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh.html">Mesh</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_connectivity.html">Connectivity</a>
    */
   template <>
   class Connectivity<Context::Local> final : public ConnectivityBase

--- a/src/Rodin/Geometry/Euclidean/Base.h
+++ b/src/Rodin/Geometry/Euclidean/Base.h
@@ -34,7 +34,11 @@ namespace Rodin::Geometry::Euclidean
    * @note This is an abstract base class with no functionality, serving
    * only to establish the type hierarchy for Euclidean geometric objects.
    *
-   * @see Point2D, Circle, Line2D, LineSegment2D, Rectangle
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_rectangle.html">Rectangle</a>
    */
   template <class Derived, class T>
   class Base

--- a/src/Rodin/Geometry/Euclidean/Circle.h
+++ b/src/Rodin/Geometry/Euclidean/Circle.h
@@ -47,7 +47,9 @@ namespace Rodin::Geometry::Euclidean
    * - Intersection with other geometric objects
    * - Distance computations
    *
-   * @see Point2D, Line2D, LineSegment2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
    */
   template <class T>
   class Circle : public Base<Circle<T>, T>

--- a/src/Rodin/Geometry/Euclidean/ForwardDecls.h
+++ b/src/Rodin/Geometry/Euclidean/ForwardDecls.h
@@ -18,7 +18,11 @@ namespace Rodin::Geometry::Euclidean
    * @brief Base class for Euclidean geometric objects using CRTP.
    * @tparam T Scalar type (e.g., float, double)
    * @tparam Derived Derived class type
-   * @see Point2D, Circle, Line2D, LineSegment2D, Rectangle
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_rectangle.html">Rectangle</a>
    */
   template <class T, class Derived>
   class Base;
@@ -26,7 +30,8 @@ namespace Rodin::Geometry::Euclidean
   /**
    * @brief Circle in 2D Euclidean space.
    * @tparam T Scalar type
-   * @see Line2D, Point2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
    */
   template <class T>
   class Circle;
@@ -34,7 +39,9 @@ namespace Rodin::Geometry::Euclidean
   /**
    * @brief Infinite line in 2D Euclidean space.
    * @tparam T Scalar type
-   * @see LineSegment2D, Point2D, Circle
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
    */
   template <class T>
   class Line2D;
@@ -42,7 +49,9 @@ namespace Rodin::Geometry::Euclidean
   /**
    * @brief Point in 2D Euclidean space.
    * @tparam T Scalar type
-   * @see Line2D, Circle, LineSegment2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
    */
   template <class T>
   class Point2D;
@@ -50,7 +59,8 @@ namespace Rodin::Geometry::Euclidean
   /**
    * @brief Line segment in 2D Euclidean space.
    * @tparam T Scalar type
-   * @see Line2D, Point2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
    */
   template <class T>
   class LineSegment2D;
@@ -58,11 +68,10 @@ namespace Rodin::Geometry::Euclidean
   /**
    * @brief Axis-aligned rectangle in 2D Euclidean space.
    * @tparam T Scalar type
-   * @see Point2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
    */
   template <class T>
   class Rectangle;
 }
 
 #endif
-

--- a/src/Rodin/Geometry/Euclidean/Line2D.h
+++ b/src/Rodin/Geometry/Euclidean/Line2D.h
@@ -40,7 +40,9 @@ namespace Rodin::Geometry::Euclidean
    *
    * @warning The behavior is undefined if @f$ a = 0 @f$ and @f$ b = 0 @f$.
    *
-   * @see Point2D, Circle, LineSegment2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
    */
   template <class T>
   class Line2D : public Base<Line2D<T>, T>
@@ -239,7 +241,7 @@ namespace Rodin::Geometry::Euclidean
      * the two.
      * @note This is equivalent to the result of `point.connect(line).reverse();`
      *
-     * @see Point2D<T>::connect()
+     * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D<T>::connect()</a>
      */
     inline
     constexpr

--- a/src/Rodin/Geometry/Euclidean/LineSegment2D.h
+++ b/src/Rodin/Geometry/Euclidean/LineSegment2D.h
@@ -36,7 +36,8 @@ namespace Rodin::Geometry::Euclidean
    * where @f$ t \in [0, 1] @f$ maps to points on the segment, though the
    * parameterization accepts any real @f$ t @f$.
    *
-   * @see Point2D, Line2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
    */
   template <class T>
   class LineSegment2D : public Base<LineSegment2D<T>, T>
@@ -159,4 +160,3 @@ namespace Rodin::Geometry::Euclidean
 #include "LineSegment2D.hpp"
 
 #endif
-

--- a/src/Rodin/Geometry/Euclidean/Point2D.h
+++ b/src/Rodin/Geometry/Euclidean/Point2D.h
@@ -39,7 +39,9 @@ namespace Rodin::Geometry::Euclidean
    * @note This class uses multiple inheritance from Eigen::Vector2 and Base,
    * providing both vector operations and CRTP-based geometry interface.
    *
-   * @see Line2D, Circle, LineSegment2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
    */
   template <class T>
   class Point2D : public Eigen::Vector2<T>, public Base<Point2D<T>, T>
@@ -79,7 +81,7 @@ namespace Rodin::Geometry::Euclidean
        * @retval std::nullopt If the points are equal (no segment can be formed)
        * @retval LineSegment2D If the points are distinct
        *
-       * @see LineSegment2D
+       * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
        */
       inline
       constexpr
@@ -96,7 +98,8 @@ namespace Rodin::Geometry::Euclidean
        * @retval std::nullopt If the point lies on the line
        * @retval LineSegment2D Perpendicular segment from point to line
        *
-       * @see Line2D, LineSegment2D
+       * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line2_d.html">Line2D</a>
+       * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
        */
       inline
       constexpr
@@ -113,7 +116,8 @@ namespace Rodin::Geometry::Euclidean
        * @retval std::nullopt If the point lies on the circle
        * @retval LineSegment2D Segment from point to nearest point on circle
        *
-       * @see Circle, LineSegment2D
+       * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_circle.html">Circle</a>
+       * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_line_segment2_d.html">LineSegment2D</a>
        */
       inline
       constexpr

--- a/src/Rodin/Geometry/Euclidean/Rectangle.h
+++ b/src/Rodin/Geometry/Euclidean/Rectangle.h
@@ -37,7 +37,7 @@ namespace Rodin::Geometry::Euclidean
    * @f]
    * are contained in the rectangle.
    *
-   * @see Point2D
+   * @see <a href="class_rodin_1_1_geometry_1_1_euclidean_1_1_point2_d.html">Point2D</a>
    */
   template <class T>
   class Rectangle

--- a/src/Rodin/Geometry/ForwardDecls.h
+++ b/src/Rodin/Geometry/ForwardDecls.h
@@ -29,7 +29,7 @@ namespace Rodin::Geometry
   /**
    * @brief Template container indexed by polytope geometry types.
    * @tparam T Type of values to store
-   * @see GeometryIndexed.h
+   * @see <a href="_geometry_indexed_8h.html">GeometryIndexed.h</a>
    */
   template <class T>
   class GeometryIndexed;
@@ -37,34 +37,34 @@ namespace Rodin::Geometry
   /**
    * @brief Index generator that wraps a container's iterators.
    * @tparam T Container type
-   * @see IndexGenerator.h
+   * @see <a href="_index_generator_8h.html">IndexGenerator.h</a>
    */
   template <class T>
   class ContainerIndexGenerator;
 
   /**
    * @brief Enumeration of polytope geometries (forward declaration).
-   * @see Polytope::Type
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html#a1d1cfd8ffb84e947f82999c682b666a7">Polytope::Type</a>
    */
   enum class Type;
 
   /**
    * @brief Base class for polytope transformations.
-   * @see PolytopeTransformation.h
+   * @see <a href="_polytope_transformation_8h.html">PolytopeTransformation.h</a>
    */
   class PolytopeTransformation;
 
   /**
    * @brief Template for finite-element parametric transformations.
    * @tparam FE Finite element type
-   * @see ParametricTransformation.h
+   * @see <a href="_parametric_transformation_8h.html">ParametricTransformation.h</a>
    */
   template <class FE>
   class ParametricTransformation;
 
   /**
    * @brief Represents a geometric polytope in a mesh.
-   * @see Polytope.h
+   * @see <a href="_polytope_8h.html">Polytope.h</a>
    */
   class Polytope;
 
@@ -72,55 +72,55 @@ namespace Rodin::Geometry
 
   /**
    * @brief Represents a mesh cell (polytope of maximal dimension).
-   * @see Polytope.h
+   * @see <a href="_polytope_8h.html">Polytope.h</a>
    */
   class Cell;
 
   /**
    * @brief Represents a mesh face (polytope of dimension d-1).
-   * @see Polytope.h
+   * @see <a href="_polytope_8h.html">Polytope.h</a>
    */
   class Face;
 
   /**
    * @brief Represents a mesh vertex (0-dimensional polytope).
-   * @see Polytope.h
+   * @see <a href="_polytope_8h.html">Polytope.h</a>
    */
   class Vertex;
 
   /**
    * @brief Represents a point on a mesh polytope.
-   * @see Point.h
+   * @see <a href="_point_8h.html">Point.h</a>
    */
   class Point;
 
   /**
    * @brief Iterator over polytopes.
-   * @see PolytopeIterator.h
+   * @see <a href="_polytope_iterator_8h.html">PolytopeIterator.h</a>
    */
   class PolytopeIterator;
 
   /**
    * @brief Iterator over mesh cells.
-   * @see PolytopeIterator.h
+   * @see <a href="_polytope_iterator_8h.html">PolytopeIterator.h</a>
    */
   class CellIterator;
 
   /**
    * @brief Iterator over mesh faces.
-   * @see PolytopeIterator.h
+   * @see <a href="_polytope_iterator_8h.html">PolytopeIterator.h</a>
    */
   class FaceIterator;
 
   /**
    * @brief Iterator over mesh vertices.
-   * @see PolytopeIterator.h
+   * @see <a href="_polytope_iterator_8h.html">PolytopeIterator.h</a>
    */
   class VertexIterator;
 
   /**
    * @brief Base class for mesh representations.
-   * @see Mesh.h
+   * @see <a href="_geometry_2_mesh_8h.html">Mesh.h</a>
    */
   class MeshBase;
 
@@ -128,8 +128,14 @@ namespace Rodin::Geometry
 
   /**
    * @brief Template for connectivity information.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Connectivity "Connectivity<Context::Local>" | Sequential connectivity table storing all requested incidence relations for a local mesh. |
+   * | @ref Connectivity "Connectivity<Context::MPI>" | Distributed connectivity facade for rank-local shard topology and MPI mesh operations. |
+   *
    * @tparam ContextType Context type (Local, MPI, etc.)
-   * @see Connectivity.h
+   * @see <a href="_connectivity_8h.html">Connectivity.h</a>
    */
   template <class ContextType>
   class Connectivity;
@@ -148,19 +154,23 @@ namespace Rodin::Geometry
    * - Thread-safe operations (context-dependent)
    *
    * # Context Types
-   * The template parameter @p ContextType determines the execution model:
-   * - Context::Local for sequential execution
-   * - Context::MPI for distributed parallel execution
+   * The template parameter @p ContextType determines the execution model.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [Mesh<Context::Local>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_local_01_4.html) | Sequential mesh storing the full incidence complex and geometry in a single process. |
+   * | [Mesh<Context::MPI>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed mesh storing a rank-local shard, global/local index maps, and MPI context for parallel assembly. |
    *
    * @tparam ContextType Execution context (default: Context::Local)
-   * @see MeshBase, Mesh.h
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_base.html">MeshBase</a>
+   * @see <a href="_geometry_2_mesh_8h.html">Mesh.h</a>
    */
   template <class ContextType = Context::Local>
   class Mesh;
 
   /**
    * @brief Base class for SubMesh functionality.
-   * @see SubMesh.h
+   * @see <a href="_geometry_2_sub_mesh_8h.html">SubMesh.h</a>
    */
   class SubMeshBase;
 
@@ -196,22 +206,28 @@ namespace Rodin::Geometry
    * - Interface problem formulation
    * - Region-specific operations
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [SubMesh<Context::Local>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_local_01_4.html) | Sequential submesh view extracted from a local parent mesh. |
+   * | [SubMesh<Context::MPI>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed submesh view extracted from an MPI parent mesh and its rank-local shards. |
+   *
    * @tparam Context Execution context type
-   * @see SubMeshBase, SubMesh.h
+   * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh_base.html">SubMeshBase</a>
+   * @see <a href="_geometry_2_sub_mesh_8h.html">SubMesh.h</a>
    */
   template <class Context>
   class SubMesh;
 
   /**
    * @brief Sequential SubMesh specialization.
-   * @see SubMesh.h
+   * @see <a href="_geometry_2_sub_mesh_8h.html">SubMesh.h</a>
    */
   template <>
   class SubMesh<Context::Local>;
 
   /**
    * @brief Distributed MPI SubMesh specialization.
-   * @see Rodin/MPI/Geometry/SubMesh.h
+   * @see <a href="_m_p_i_2_geometry_2_sub_mesh_8h.html">Rodin/MPI/Geometry/SubMesh.h</a>
    */
 #ifdef RODIN_USE_MPI
   template <>
@@ -221,7 +237,7 @@ namespace Rodin::Geometry
   /**
    * @brief Builder for constructing SubMesh objects.
    * @tparam Context Execution context type
-   * @see SubMesh.h
+   * @see <a href="_geometry_2_sub_mesh_8h.html">SubMesh.h</a>
    */
   template <class Context>
   class SubMeshBuilder;

--- a/src/Rodin/Geometry/ForwardDecls.h
+++ b/src/Rodin/Geometry/ForwardDecls.h
@@ -132,7 +132,7 @@ namespace Rodin::Geometry
    * | Specialization | Description |
    * |----------------|-------------|
    * | @ref Connectivity "Connectivity<Context::Local>" | Sequential connectivity table storing all requested incidence relations for a local mesh. |
-   * | @ref Connectivity "Connectivity<Context::MPI>" | Distributed connectivity facade for rank-local shard topology and MPI mesh operations. |
+   * | @ref Connectivity "Connectivity<Context::MPI>" | Distributed connectivity facade for rank-local @ref Rodin::Geometry::Shard "shard" topology and MPI mesh operations. |
    *
    * @tparam ContextType Context type (Local, MPI, etc.)
    * @see <a href="_connectivity_8h.html">Connectivity.h</a>
@@ -159,7 +159,7 @@ namespace Rodin::Geometry
    * | Specialization | Description |
    * |----------------|-------------|
    * | [Mesh<Context::Local>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_local_01_4.html) | Sequential mesh storing the full incidence complex and geometry in a single process. |
-   * | [Mesh<Context::MPI>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed mesh storing a rank-local shard, global/local index maps, and MPI context for parallel assembly. |
+   * | [Mesh<Context::MPI>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed mesh storing a rank-local @ref Rodin::Geometry::Shard "shard", global/local index maps, and MPI context for parallel assembly. |
    *
    * @tparam ContextType Execution context (default: Context::Local)
    * @see <a href="class_rodin_1_1_geometry_1_1_mesh_base.html">MeshBase</a>
@@ -209,7 +209,7 @@ namespace Rodin::Geometry
    * | Specialization | Description |
    * |----------------|-------------|
    * | [SubMesh<Context::Local>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_local_01_4.html) | Sequential submesh view extracted from a local parent mesh. |
-   * | [SubMesh<Context::MPI>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed submesh view extracted from an MPI parent mesh and its rank-local shards. |
+   * | [SubMesh<Context::MPI>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed submesh view extracted from an MPI parent mesh and its rank-local @ref Rodin::Geometry::Shard "shards". |
    *
    * @tparam Context Execution context type
    * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh_base.html">SubMeshBase</a>

--- a/src/Rodin/Geometry/GeometryIndexed.h
+++ b/src/Rodin/Geometry/GeometryIndexed.h
@@ -47,7 +47,7 @@ namespace Rodin::Geometry
    *
    * @tparam T Type of data to associate with each polytope type
    *
-   * @see Polytope::Type
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html#a1d1cfd8ffb84e947f82999c682b666a7">Polytope::Type</a>
    */
   template <class T>
   class GeometryIndexed

--- a/src/Rodin/Geometry/GreedyPartitioner.h
+++ b/src/Rodin/Geometry/GreedyPartitioner.h
@@ -26,7 +26,8 @@ namespace Rodin::Geometry
    * @note This is a simpler and faster alternative to BalancedCompactPartitioner,
    * but may produce less spatially compact partitions.
    *
-   * @see Partitioner, BalancedCompactPartitioner
+   * @see <a href="class_rodin_1_1_geometry_1_1_partitioner.html">Partitioner</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_balanced_compact_partitioner.html">BalancedCompactPartitioner</a>
    */
   class GreedyPartitioner : public Partitioner
   {

--- a/src/Rodin/Geometry/IdentityTransformation.h
+++ b/src/Rodin/Geometry/IdentityTransformation.h
@@ -28,7 +28,8 @@ namespace Rodin::Geometry
    * This is typically used when the reference element and physical element
    * coincide, or when no geometric transformation is needed.
    *
-   * @see PolytopeTransformation, ParametricTransformation
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_transformation.html">PolytopeTransformation</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_parametric_transformation.html">ParametricTransformation</a>
    */
   class IdentityTransformation final : public PolytopeTransformation
   {

--- a/src/Rodin/Geometry/IndexGenerator.h
+++ b/src/Rodin/Geometry/IndexGenerator.h
@@ -45,7 +45,9 @@ namespace Rodin::Geometry
    * They support standard iterator operations (increment, dereference, end
    * check) and can be copied or moved.
    *
-   * @see EmptyIndexGenerator, BoundedIndexGenerator, IteratorIndexGenerator
+   * @see <a href="class_rodin_1_1_geometry_1_1_empty_index_generator.html">EmptyIndexGenerator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_bounded_index_generator.html">BoundedIndexGenerator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_iterator_index_generator.html">IteratorIndexGenerator</a>
    */
   class IndexGeneratorBase : public Copyable, public Moveable
   {

--- a/src/Rodin/Geometry/Mesh.h
+++ b/src/Rodin/Geometry/Mesh.h
@@ -177,7 +177,9 @@ namespace Rodin::Geometry
    * @f]
    * where each element @f$ K @f$ is a polytope (simplex or hypercube).
    *
-   * @see Mesh, Polytope, Connectivity
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh.html">Mesh</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_connectivity.html">Connectivity</a>
    */
 
   /**
@@ -278,7 +280,13 @@ namespace Rodin::Geometry
    * @defgroup MeshTypes Mesh Types and Template Specializations
    * @brief Different types of mesh and template specializations of the Mesh
    * class.
-   * @see Mesh
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [Mesh<Context::Local>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_local_01_4.html) | Sequential mesh storing the full incidence complex and geometry in a single process. |
+   * | [Mesh<Context::MPI>](class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed mesh storing a rank-local shard, global/local index maps, and MPI context for parallel assembly. |
+   *
+   * @see @ref Mesh
    */
 
   /**
@@ -296,15 +304,17 @@ namespace Rodin::Geometry
    * # Inheritance Hierarchy
    *
    * All concrete mesh implementations derive from this base class:
-   * - Mesh<Context::Local>: Sequential (non-distributed) meshes
-   * - SubMesh<Context::Local>: Submeshes representing subregions
-   * - Shard: Distributed mesh shards for parallel computing
+   * - <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_local_01_4.html">Mesh<Context::Local></a>: Sequential (non-distributed) meshes
+   * - <a href="class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_local_01_4.html">SubMesh<Context::Local></a>: Submeshes representing subregions
+   * - <a href="class_rodin_1_1_geometry_1_1_shard.html">Shard</a>: Distributed mesh shards for parallel computing
    *
    * # Thread Safety
    * MeshBase and derived classes are not thread-safe during construction.
    * Once finalized, read-only operations are thread-safe.
    *
-   * @see Mesh, SubMesh, Shard
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh.html">Mesh</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh.html">SubMesh</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_shard.html">Shard</a>
    */
   class MeshBase
   {
@@ -837,6 +847,9 @@ namespace Rodin::Geometry
    * @ingroup MeshTypes
    * @brief Represents the subdivision of some domain into faces of (possibly)
    * different geometries.
+   *
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_base.html">MeshBase</a>
+   * @see <a href="_geometry_2_mesh_8h.html">Mesh.h</a>
    */
   template <>
   class Mesh<Context::Local> : public MeshBase

--- a/src/Rodin/Geometry/Mesh.h
+++ b/src/Rodin/Geometry/Mesh.h
@@ -145,9 +145,9 @@ namespace Rodin::Geometry
    * # Key Components
    *
    * ## Mesh Data Structures
-   * - **Mesh**: Core unstructured mesh class with support for mixed element types
-   * - **SubMesh**: Mesh representing a subregion of a parent mesh
-   * - **Shard**: Mesh shard for distributed parallel computing
+   * - @ref Rodin::Geometry::Mesh "Mesh": Core unstructured mesh class with support for mixed element types
+   * - @ref Rodin::Geometry::SubMesh "SubMesh": Mesh representing a subregion of a parent mesh
+   * - @ref Rodin::Geometry::Shard "Shard": Mesh shard for distributed parallel computing
    *
    * ## Connectivity Management
    * - Automatic computation of incidence relations @f$ d \rightarrow d' @f$

--- a/src/Rodin/Geometry/MeshPartitioner.h
+++ b/src/Rodin/Geometry/MeshPartitioner.h
@@ -23,7 +23,8 @@ namespace Rodin::Geometry
    * useful for load balancing, parallel processing, and domain decomposition
    * methods. Each polytope is assigned to exactly one partition.
    *
-   * @see BalancedCompactPartitioner, GreedyPartitioner
+   * @see <a href="class_rodin_1_1_geometry_1_1_balanced_compact_partitioner.html">BalancedCompactPartitioner</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_greedy_partitioner.html">GreedyPartitioner</a>
    */
   class Partitioner
   {

--- a/src/Rodin/Geometry/Point.h
+++ b/src/Rodin/Geometry/Point.h
@@ -66,7 +66,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * This class is **not** thread-safe. Each thread should use its own Point instances.
    *
-   * @see PolytopeTransformation, Polytope, Point
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_transformation.html">PolytopeTransformation</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_point.html">Point</a>
    */
   class PointBase
   {
@@ -314,7 +316,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * Not thread-safe. Each thread should use separate Point instances.
    *
-   * @see PointBase, Polytope, PolytopeTransformation
+   * @see <a href="class_rodin_1_1_geometry_1_1_point_base.html">PointBase</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_transformation.html">PolytopeTransformation</a>
    */
   class Point final : public PointBase
   {

--- a/src/Rodin/Geometry/Polytope.h
+++ b/src/Rodin/Geometry/Polytope.h
@@ -65,7 +65,10 @@ namespace Rodin::Geometry
    * }
    * @endcode
    *S 
-   * @see Cell, Face, Vertex, PolytopeIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell.html">Cell</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face.html">Face</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex.html">Vertex</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_iterator.html">PolytopeIterator</a>
    */
   class Polytope
   {
@@ -473,7 +476,7 @@ namespace Rodin::Geometry
        * @brief Gets the geometric transformation for this polytope.
        * @returns Reference to the transformation @f$ x: K \rightarrow \tau @f$
        *
-       * @see PolytopeTransformation
+       * @see <a href="class_rodin_1_1_geometry_1_1_polytope_transformation.html">PolytopeTransformation</a>
        */
       const PolytopeTransformation& getTransformation() const;
 
@@ -568,7 +571,9 @@ namespace Rodin::Geometry
    * Cells form the basis for finite element computations and define the
    * computational domain.
    *
-   * @see Polytope, Face, Vertex
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face.html">Face</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex.html">Vertex</a>
    */
   class Cell : public Polytope
   {
@@ -613,7 +618,9 @@ namespace Rodin::Geometry
    * - Interface problems
    * - Flux computations
    *
-   * @see Polytope, Cell, Vertex
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell.html">Cell</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex.html">Vertex</a>
    */
   class Face : public Polytope
   {
@@ -670,7 +677,9 @@ namespace Rodin::Geometry
    * - Endpoints for edges and corners for higher-dimensional elements
    * - Spatial anchors for the mesh geometry
    *
-   * @see Polytope, Cell, Face
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope.html">Polytope</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell.html">Cell</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face.html">Face</a>
    */
   class Vertex : public Polytope
   {

--- a/src/Rodin/Geometry/PolytopeIterator.h
+++ b/src/Rodin/Geometry/PolytopeIterator.h
@@ -45,7 +45,10 @@ namespace Rodin::Geometry
    * Polytope iterators are **not** thread-safe. Each thread should use its
    * own iterator instance.
    *
-   * @see PolytopeIterator, CellIterator, FaceIterator, VertexIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_iterator.html">PolytopeIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell_iterator.html">CellIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face_iterator.html">FaceIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex_iterator.html">VertexIterator</a>
    */
   template <class T, class Derived>
   class PolytopeIteratorBase
@@ -236,7 +239,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * Not thread-safe. Each thread should use its own iterator instance.
    *
-   * @see CellIterator, FaceIterator, VertexIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell_iterator.html">CellIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face_iterator.html">FaceIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex_iterator.html">VertexIterator</a>
    */
   class PolytopeIterator : public PolytopeIteratorBase<Polytope, PolytopeIterator>
   {
@@ -327,7 +332,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * Not thread-safe. Each thread should use its own iterator instance.
    *
-   * @see PolytopeIterator, FaceIterator, VertexIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_iterator.html">PolytopeIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face_iterator.html">FaceIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex_iterator.html">VertexIterator</a>
    */
   class CellIterator : public PolytopeIteratorBase<Cell, CellIterator>
   {
@@ -396,7 +403,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * Not thread-safe. Each thread should use its own iterator instance.
    *
-   * @see PolytopeIterator, CellIterator, VertexIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_iterator.html">PolytopeIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell_iterator.html">CellIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_vertex_iterator.html">VertexIterator</a>
    */
   class FaceIterator : public PolytopeIteratorBase<Face, FaceIterator>
   {
@@ -465,7 +474,9 @@ namespace Rodin::Geometry
    * # Thread Safety
    * Not thread-safe. Each thread should use its own iterator instance.
    *
-   * @see PolytopeIterator, CellIterator, FaceIterator
+   * @see <a href="class_rodin_1_1_geometry_1_1_polytope_iterator.html">PolytopeIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_cell_iterator.html">CellIterator</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_face_iterator.html">FaceIterator</a>
    */
   class VertexIterator : public PolytopeIteratorBase<Vertex, VertexIterator>
   {

--- a/src/Rodin/Geometry/PolytopeTransformation.h
+++ b/src/Rodin/Geometry/PolytopeTransformation.h
@@ -62,7 +62,9 @@ namespace Rodin::Geometry
    * for concurrent read access. The transform(), jacobian(), and inverse()
    * methods can be called concurrently from multiple threads.
    *
-   * @see IdentityTransformation, ParametricTransformation, Point
+   * @see <a href="class_rodin_1_1_geometry_1_1_identity_transformation.html">IdentityTransformation</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_parametric_transformation.html">ParametricTransformation</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_point.html">Point</a>
    */
   class PolytopeTransformation : public Copyable
   {

--- a/src/Rodin/Geometry/Shard.h
+++ b/src/Rodin/Geometry/Shard.h
@@ -199,7 +199,9 @@ namespace Rodin::Geometry
    * Global distributed numbering is a higher-level concern handled for example
    * by MPI finite element spaces.
    *
-   * @see Mesh<Context::Local>, Sharder, MPIMesh
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_local_01_4.html">Mesh<Context::Local></a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_sharder.html">Sharder</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html">MPIMesh</a>
    */
   class Shard : public Mesh<Context::Local>
   {

--- a/src/Rodin/Geometry/Sharder.h
+++ b/src/Rodin/Geometry/Sharder.h
@@ -217,7 +217,13 @@ namespace Rodin::Geometry
    *
    * @tparam Context The context type (e.g., Context::Local, Context::MPI)
    *
-   * @see Shard, MeshShard
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Sharder "Sharder<Context::Local>" | Local mesh sharder that builds shard metadata without MPI communication. |
+   * | @ref Sharder "Sharder<Context::MPI>" | Distributed mesh sharder that prepares shards for MPI mesh ownership and halo exchange. |
+   *
+   * @see <a href="class_rodin_1_1_geometry_1_1_shard.html">Shard</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html">Mesh<Context::MPI></a>
    */
   template <class Context>
   class Sharder;

--- a/src/Rodin/Geometry/Sharder.h
+++ b/src/Rodin/Geometry/Sharder.h
@@ -21,7 +21,7 @@ namespace Rodin::Geometry
   /**
    * @brief Base implementation for decomposing a partitioned mesh into shards.
    *
-   * Given a mesh partitioner, this class constructs one local Shard per
+   * Given a mesh partitioner, this class constructs one local @ref Rodin::Geometry::Shard "Shard" per
    * partition, including owned entities, shared entities, ghosts, owners, and
    * halo metadata.
    *

--- a/src/Rodin/Geometry/SubMesh.h
+++ b/src/Rodin/Geometry/SubMesh.h
@@ -23,7 +23,12 @@ namespace Rodin::Geometry
   /**
    * @defgroup SubMeshSpecializations SubMesh Template Specializations
    * @brief Template specializations of the SubMesh class.
-   * @see SubMesh
+   * @see @ref SubMesh
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [SubMesh<Context::Local>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_local_01_4.html) | Sequential submesh with local parent/child index maps. |
+   * | [SubMesh<Context::MPI>](class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_m_p_i_01_4.html) | Distributed submesh with MPI-aware parent/child index maps. |
    */
 
   /**
@@ -151,7 +156,9 @@ namespace Rodin::Geometry
    * SubMesh objects are not thread-safe during construction. Once finalized,
    * read-only operations are thread-safe.
    *
-   * @see SubMeshBase, Mesh, Shard
+   * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh_base.html">SubMeshBase</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh.html">Mesh</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_shard.html">Shard</a>
    */
   template <>
   class SubMesh<Context::Local> final : public SubMeshBase, public Mesh<Context::Local>
@@ -315,4 +322,3 @@ namespace Rodin::Geometry
 }
 
 #endif
-

--- a/src/Rodin/Geometry/Types.h
+++ b/src/Rodin/Geometry/Types.h
@@ -37,7 +37,7 @@ namespace Rodin::Geometry
    * polytope of dimension @f$ d @f$ the indices of all incident polytopes
    * of dimension @f$ d' @f$.
    *
-   * @see Connectivity
+   * @see <a href="class_rodin_1_1_geometry_1_1_connectivity.html">Connectivity</a>
    */
   using Incidence = std::vector<std::vector<Index>>;
 }

--- a/src/Rodin/IO.h
+++ b/src/Rodin/IO.h
@@ -19,7 +19,7 @@
  * - MEDIT (.mesh)
  * - MFEM (.mfem)
  *
- * @see Rodin::IO
+ * @see <a href="namespace_rodin_1_1_i_o.html">Rodin::IO</a>
  */
 
 #include "IO/ForwardDecls.h"

--- a/src/Rodin/IO/ForwardDecls.h
+++ b/src/Rodin/IO/ForwardDecls.h
@@ -17,7 +17,7 @@ namespace Rodin::IO
   /**
    * @brief Base template for loading objects from files or streams.
    * @tparam T Type of object to load
-   * @see Loader
+   * @see <a href="class_rodin_1_1_i_o_1_1_loader.html">Loader</a>
    */
   template <class T>
   class Loader;
@@ -25,7 +25,7 @@ namespace Rodin::IO
   /**
    * @brief Base template for printing objects to streams.
    * @tparam T Type of object to print
-   * @see Printer
+   * @see <a href="class_rodin_1_1_i_o_1_1_printer.html">Printer</a>
    */
   template <class T>
   class Printer;
@@ -45,38 +45,74 @@ namespace Rodin::IO
 
   /**
    * @brief Loader template for meshes with specific file format and context.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [MeshLoader<IO::FileFormat::MFEM, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html) | Loads local meshes from MFEM mesh files. |
+   * | [MeshLoader<IO::FileFormat::MEDIT, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html) | Loads local meshes from MEDIT `.mesh` files. |
+   * | [MeshLoader<IO::FileFormat::HDF5, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html) | Loads complete local meshes from Rodin HDF5 datasets. |
+   * | [MeshLoader<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Loads distributed MPI meshes from rank-local Rodin HDF5 shards. |
+   *
    * @tparam Fmt File format to use for loading
    * @tparam Trait Context trait (e.g., sequential or parallel)
-   * @see MeshLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">MeshLoader</a>
    */
   template <FileFormat Fmt, class Trait>
   class MeshLoader;
 
   /**
    * @brief Printer template for meshes with specific file format and context.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | [MeshPrinter<IO::FileFormat::MFEM, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html) | Writes local meshes in MFEM mesh format. |
+   * | [MeshPrinter<IO::FileFormat::MEDIT, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html) | Writes local meshes in MEDIT `.mesh` format. |
+   * | [MeshPrinter<IO::FileFormat::HDF5, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html) | Writes complete local meshes to Rodin HDF5 datasets. |
+   * | [MeshPrinter<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Writes distributed MPI mesh shards to rank-local Rodin HDF5 datasets. |
+   *
    * @tparam Fmt File format to use for printing
    * @tparam Trait Context trait (e.g., sequential or parallel)
-   * @see MeshPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">MeshPrinter</a>
    */
   template <FileFormat Fmt, class Trait>
   class MeshPrinter;
 
   /**
    * @brief Loader template for grid functions with specific file format.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::MFEM, FES, Data>" | Loads MFEM grid functions into Rodin-owned vector storage. |
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::MFEM, FES, Math::Vector<Scalar>&>" | Loads MFEM grid functions into referenced vector storage. |
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::MEDIT, FES, Data>" | Loads MEDIT grid functions into Rodin-owned vector storage. |
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::MEDIT, FES, Math::Vector<Scalar>&>" | Loads MEDIT grid functions into referenced vector storage. |
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::HDF5, FES, Math::Vector<Scalar>>" | Loads HDF5 grid functions into Rodin vector storage. |
+   * | @ref GridFunctionLoader "GridFunctionLoader<IO::FileFormat::HDF5, FES, Vec>" | Loads HDF5 grid functions into PETSc vector storage. |
+   *
    * @tparam Fmt File format to use for loading
    * @tparam FES Finite element space type
    * @tparam Data Data storage type
-   * @see GridFunctionLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">GridFunctionLoader</a>
    */
   template <FileFormat Fmt, class FES, class Data>
   class GridFunctionLoader;
 
   /**
    * @brief Printer template for grid functions with specific file format.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::MFEM, FES, Math::Vector<Scalar>>" | Writes Rodin vector-backed grid functions in MFEM format. |
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::MFEM, FES, Vec>" | Writes PETSc vector-backed grid functions in MFEM format. |
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::MEDIT, FES, Math::Vector<Scalar>>" | Writes Rodin vector-backed grid functions in MEDIT format. |
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::MEDIT, FES, Vec>" | Writes PETSc vector-backed grid functions in MEDIT format. |
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::HDF5, FES, Math::Vector<Scalar>>" | Writes Rodin vector-backed grid functions to HDF5 datasets. |
+   * | @ref GridFunctionPrinter "GridFunctionPrinter<IO::FileFormat::HDF5, FES, Vec>" | Writes PETSc vector-backed grid functions to HDF5 datasets. |
+   *
    * @tparam Fmt File format to use for printing
    * @tparam FES Finite element space type
    * @tparam Data Data storage type
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <FileFormat Fmt, class FES, class Data>
   class GridFunctionPrinter;

--- a/src/Rodin/IO/ForwardDecls.h
+++ b/src/Rodin/IO/ForwardDecls.h
@@ -51,7 +51,7 @@ namespace Rodin::IO
    * | [MeshLoader<IO::FileFormat::MFEM, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html) | Loads local meshes from MFEM mesh files. |
    * | [MeshLoader<IO::FileFormat::MEDIT, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html) | Loads local meshes from MEDIT `.mesh` files. |
    * | [MeshLoader<IO::FileFormat::HDF5, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html) | Loads complete local meshes from Rodin HDF5 datasets. |
-   * | [MeshLoader<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Loads distributed MPI meshes from rank-local Rodin HDF5 shards. |
+   * | [MeshLoader<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Loads distributed MPI meshes from rank-local Rodin HDF5 @ref Rodin::Geometry::Shard "shards". |
    *
    * @tparam Fmt File format to use for loading
    * @tparam Trait Context trait (e.g., sequential or parallel)
@@ -68,7 +68,7 @@ namespace Rodin::IO
    * | [MeshPrinter<IO::FileFormat::MFEM, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html) | Writes local meshes in MFEM mesh format. |
    * | [MeshPrinter<IO::FileFormat::MEDIT, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html) | Writes local meshes in MEDIT `.mesh` format. |
    * | [MeshPrinter<IO::FileFormat::HDF5, Context::Local>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html) | Writes complete local meshes to Rodin HDF5 datasets. |
-   * | [MeshPrinter<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Writes distributed MPI mesh shards to rank-local Rodin HDF5 datasets. |
+   * | [MeshPrinter<IO::FileFormat::HDF5, Context::MPI>](class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html) | Writes distributed MPI @ref Rodin::Geometry::Shard "mesh shards" to rank-local Rodin HDF5 datasets. |
    *
    * @tparam Fmt File format to use for printing
    * @tparam Trait Context trait (e.g., sequential or parallel)

--- a/src/Rodin/IO/GridFunctionLoader.h
+++ b/src/Rodin/IO/GridFunctionLoader.h
@@ -32,7 +32,8 @@ namespace Rodin::IO
    *       GridFunctionBase::load() remain compilable while still producing a
    *       clear error at runtime.
    *
-   * @see Loader, GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_loader.html">Loader</a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <FileFormat Fmt, class FES, class Data>
   class GridFunctionLoader : public IO::Loader<Variational::GridFunction<FES, Data>>

--- a/src/Rodin/IO/GridFunctionPrinter.h
+++ b/src/Rodin/IO/GridFunctionPrinter.h
@@ -29,7 +29,7 @@ namespace Rodin::IO
    * @note An exception is raised at runtime if this primary template is
    *       actually invoked.
    *
-   * @see GridFunctionLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">GridFunctionLoader</a>
    */
   template <FileFormat Fmt, class FES, class Data>
   class GridFunctionPrinter : public IO::Printer<Variational::GridFunction<FES, Data>>
@@ -64,6 +64,15 @@ namespace Rodin::IO
    *
    * Stores the grid function by reference and exposes it to derived printers
    * through @ref getObject().
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::MFEM, FES, Math::Vector<Scalar>>" | Base for MFEM grid function printers backed by local vector coefficients. |
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::MFEM, FES, Vec>" | Base for MFEM grid function printers backed by PETSc vectors. |
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::MEDIT, FES, Math::Vector<Scalar>>" | Base for MEDIT grid function printers backed by local vector coefficients. |
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::MEDIT, FES, Vec>" | Base for MEDIT grid function printers backed by PETSc vectors. |
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::HDF5, FES, Math::Vector<Scalar>>" | Base for HDF5 grid function printers backed by local vector coefficients. |
+   * | @ref GridFunctionPrinterBase "GridFunctionPrinterBase<FileFormat::HDF5, FES, Vec>" | Base for HDF5 grid function printers backed by PETSc vectors. |
    */
   template <FileFormat Fmt, class FES, class Data>
   class GridFunctionPrinterBase : public IO::Printer<Variational::GridFunction<FES, Data>>

--- a/src/Rodin/IO/HDF5.h
+++ b/src/Rodin/IO/HDF5.h
@@ -81,8 +81,11 @@
  * GridFunctionLoader/GridFunctionPrinter API patterns established by the
  * MFEM and MEDIT format specializations.
  *
- * @see IO::MeshLoader, IO::MeshPrinter, IO::GridFunctionLoader,
- *      IO::GridFunctionPrinter, IO::XDMF
+ * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">IO::MeshLoader</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">IO::MeshPrinter</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">IO::GridFunctionLoader</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">IO::GridFunctionPrinter</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_x_d_m_f.html">IO::XDMF</a>
  */
 #ifndef RODIN_IO_HDF5_H
 #define RODIN_IO_HDF5_H
@@ -1621,8 +1624,10 @@ namespace Rodin::IO
      * @param[in] mesh      Local mesh to export for visualization.
      * @param[in] allowUniformCurvedTopology Whether uniform curved topology is allowed.
      *
-     * @see writeXDMFTopology, writeXDMFVertices, writeXDMFRegionAttribute,
-     *      MeshPrinter<FileFormat::HDF5, Context::Local>
+     * @see writeXDMFTopology
+     * @see writeXDMFVertices
+     * @see writeXDMFRegionAttribute
+     * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshPrinter<FileFormat::HDF5, Context::Local></a>
      */
     inline void writeXDMFMesh(const boost::filesystem::path& filename,
       const Geometry::MeshBase& mesh, bool allowUniformCurvedTopology = true)
@@ -2125,7 +2130,8 @@ namespace Rodin::IO
    * loader.load("output.h5");
    * ```
    *
-   * @see MeshPrinter<FileFormat::HDF5, Context::Local>
+   * @ingroup MeshLoaderSpecializations
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshPrinter<FileFormat::HDF5, Context::Local></a>
    */
   template <>
   class MeshLoader<FileFormat::HDF5, Context::Local>
@@ -2413,7 +2419,9 @@ namespace Rodin::IO
    *   .print("output.h5");
    * ```
    *
-   * @see MeshLoader<FileFormat::HDF5, Context::Local>, IO::XDMF
+   * @ingroup PrinterSpecializations
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshLoader<FileFormat::HDF5, Context::Local></a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_x_d_m_f.html">IO::XDMF</a>
    */
   template <>
   class MeshPrinter<FileFormat::HDF5, Context::Local>
@@ -2756,7 +2764,7 @@ namespace Rodin::IO
    * loader.load("field.h5");
    * ```
    *
-   * @see GridFunctionPrinter<FileFormat::HDF5, FES, Math::Vector<Scalar>>
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter<FileFormat::HDF5, FES, Math::Vector<Scalar>></a>
    */
   template <class FES, class Scalar>
   class GridFunctionLoader<FileFormat::HDF5, FES, Math::Vector<Scalar>>
@@ -2873,7 +2881,7 @@ namespace Rodin::IO
    *   .print("field.h5");
    * ```
    *
-   * @see GridFunctionLoader<FileFormat::HDF5, FES, Math::Vector<Scalar>>
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">GridFunctionLoader<FileFormat::HDF5, FES, Math::Vector<Scalar>></a>
    */
   template <class FES, class Scalar>
   class GridFunctionPrinter<FileFormat::HDF5, FES, Math::Vector<Scalar>> final

--- a/src/Rodin/IO/Loader.h
+++ b/src/Rodin/IO/Loader.h
@@ -51,7 +51,8 @@ namespace Rodin::IO
    * };
    * ```
    *
-   * @see MeshLoader, GridFunctionLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">MeshLoader</a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">GridFunctionLoader</a>
    */
   template <class T>
   class Loader

--- a/src/Rodin/IO/MEDIT.h
+++ b/src/Rodin/IO/MEDIT.h
@@ -682,6 +682,8 @@ namespace Rodin::IO
   };
 
   /**
+   * @ingroup PrinterSpecializations
+   *
    * @brief MEDIT mesh printer for local meshes.
    */
   template <>

--- a/src/Rodin/IO/MFEM.h
+++ b/src/Rodin/IO/MFEM.h
@@ -2998,7 +2998,6 @@ namespace Rodin::IO
       std::reference_wrapper<const ObjectType> m_gf;
   };
 
-
   /**
    * @brief Base class for printing P1 (continuous Lagrange) grid functions in MFEM format.
    *

--- a/src/Rodin/IO/MFEM.h
+++ b/src/Rodin/IO/MFEM.h
@@ -1665,7 +1665,7 @@ namespace Rodin::IO
    * loader.load("mesh.mfem");
    * ```
    *
-   * @see MeshPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">MeshPrinter</a>
    */
   template <>
   class MeshLoader<IO::FileFormat::MFEM, Context::Local>
@@ -1745,7 +1745,7 @@ namespace Rodin::IO
    * printer.print(file);
    * ```
    *
-   * @see MeshLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">MeshLoader</a>
    */
   template <>
   class MeshPrinter<FileFormat::MFEM, Context::Local>
@@ -1821,7 +1821,7 @@ namespace Rodin::IO
    * loader.load("solution.gf");
    * ```
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class Range>
   class GridFunctionLoader<
@@ -1978,7 +1978,7 @@ namespace Rodin::IO
    * loader.load("solution.gf");
    * ```
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <size_t K, class Range>
   class GridFunctionLoader<
@@ -2770,7 +2770,7 @@ namespace Rodin::IO
    * loader.load("solution.gf");
    * ```
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class Range>
   class GridFunctionLoader<
@@ -2924,7 +2924,7 @@ namespace Rodin::IO
    * @tparam Context Context type (e.g., Context::Local)
    * @tparam Data Data storage type
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class Range, class Context, class Data>
   class GridFunctionPrinterBase<FileFormat::MFEM, Variational::P0<Range, Geometry::Mesh<Context>>, Data>
@@ -3008,7 +3008,7 @@ namespace Rodin::IO
    * @tparam Context Context type (e.g., Context::Local)
    * @tparam Data Data storage type
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class Range, class Context, class Data>
   class GridFunctionPrinterBase<FileFormat::MFEM, Variational::P1<Range, Geometry::Mesh<Context>>, Data>
@@ -3092,7 +3092,7 @@ namespace Rodin::IO
    * @tparam Context Context type (e.g., Context::Local)
    * @tparam Data Data storage type
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <size_t K, class Range, class Context, class Data>
   class GridFunctionPrinterBase<FileFormat::MFEM, Variational::H1<K, Range, Geometry::Mesh<Context>>, Data>

--- a/src/Rodin/IO/MeshLoader.h
+++ b/src/Rodin/IO/MeshLoader.h
@@ -20,7 +20,14 @@ namespace Rodin::IO
   /**
    * @defgroup MeshLoaderSpecializations MeshLoader Template Specializations
    * @brief Template specializations of the MeshLoader class.
-   * @see MeshLoader
+   * @see @ref MeshLoader
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::MFEM, Context::Local></a> | Loads sequential meshes from MFEM mesh streams. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::MEDIT, Context::Local></a> | Loads sequential meshes from MEDIT mesh streams. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::HDF5, Context::Local></a> | Loads sequential meshes from HDF5 files. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshLoader<IO::FileFormat::HDF5, Context::MPI></a> | Loads distributed mesh shards and metadata from per-rank HDF5 files. |
    */
 
   /**
@@ -42,7 +49,8 @@ namespace Rodin::IO
    * loader.load("mesh.mfem");
    * ```
    *
-   * @see Loader, MeshPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_loader.html">Loader</a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">MeshPrinter</a>
    */
   template <class Context>
   class MeshLoaderBase : public IO::Loader<Rodin::Geometry::Mesh<Context>>

--- a/src/Rodin/IO/MeshLoader.h
+++ b/src/Rodin/IO/MeshLoader.h
@@ -27,7 +27,7 @@ namespace Rodin::IO
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::MFEM, Context::Local></a> | Loads sequential meshes from MFEM mesh streams. |
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_i_o_1_1_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::MEDIT, Context::Local></a> | Loads sequential meshes from MEDIT mesh streams. |
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshLoader<IO::FileFormat::HDF5, Context::Local></a> | Loads sequential meshes from HDF5 files. |
-   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshLoader<IO::FileFormat::HDF5, Context::MPI></a> | Loads distributed mesh shards and metadata from per-rank HDF5 files. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshLoader<IO::FileFormat::HDF5, Context::MPI></a> | Loads distributed @ref Rodin::Geometry::Shard "mesh shards" and metadata from per-rank HDF5 files. |
    */
 
   /**

--- a/src/Rodin/IO/MeshPrinter.h
+++ b/src/Rodin/IO/MeshPrinter.h
@@ -36,7 +36,8 @@ namespace Rodin::IO
    * printer.print(file);
    * ```
    *
-   * @see Printer, MeshLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_printer.html">Printer</a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">MeshLoader</a>
    */
   template <class Context>
   class MeshPrinterBase : public IO::Printer<Geometry::Mesh<Context>>
@@ -79,4 +80,3 @@ namespace Rodin::IO
 }
 
 #endif
-

--- a/src/Rodin/IO/Printer.h
+++ b/src/Rodin/IO/Printer.h
@@ -19,7 +19,14 @@ namespace Rodin::IO
   /**
    * @defgroup PrinterSpecializations Printer Template Specializations
    * @brief Template specializations of the Printer class.
-   * @see Printer
+   * @see <a href="class_rodin_1_1_i_o_1_1_printer.html">Printer</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::MFEM, Context::Local></a> | Writes sequential meshes in MFEM format. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::MEDIT, Context::Local></a> | Writes sequential meshes in MEDIT format. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::HDF5, Context::Local></a> | Writes sequential meshes in HDF5 format. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshPrinter<IO::FileFormat::HDF5, Context::MPI></a> | Writes distributed mesh shards and metadata to per-rank HDF5 files. |
    */
 
   /**
@@ -63,7 +70,8 @@ namespace Rodin::IO
    * printer.print(std::cout);
    * ```
    *
-   * @see MeshPrinter, GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">MeshPrinter</a>
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class T>
   class Printer

--- a/src/Rodin/IO/Printer.h
+++ b/src/Rodin/IO/Printer.h
@@ -26,7 +26,7 @@ namespace Rodin::IO
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_f_e_m_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::MFEM, Context::Local></a> | Writes sequential meshes in MFEM format. |
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_m_e_d_i_t_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::MEDIT, Context::Local></a> | Writes sequential meshes in MEDIT format. |
    * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshPrinter<IO::FileFormat::HDF5, Context::Local></a> | Writes sequential meshes in HDF5 format. |
-   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshPrinter<IO::FileFormat::HDF5, Context::MPI></a> | Writes distributed mesh shards and metadata to per-rank HDF5 files. |
+   * | <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_m_p_i_01_4.html">MeshPrinter<IO::FileFormat::HDF5, Context::MPI></a> | Writes distributed @ref Rodin::Geometry::Shard "mesh shards" and metadata to per-rank HDF5 files. |
    */
 
   /**

--- a/src/Rodin/IO/XDMF.h
+++ b/src/Rodin/IO/XDMF.h
@@ -42,8 +42,9 @@
  * xdmf.close();  // writes the XDMF XML; also called by destructor
  * ```
  *
- * @see IO::HDF5, IO::MeshPrinter<FileFormat::HDF5, Context::Local>,
- *      IO::GridFunctionPrinter<FileFormat::HDF5, FES, Data>
+ * @see <a href="_i_o_2_h_d_f5_8h.html">IO::HDF5</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">IO::MeshPrinter<FileFormat::HDF5, Context::Local></a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">IO::GridFunctionPrinter</a>
  * @see <a href="https://www.xdmf.org/index.php/XDMF_Model_and_Format">
  *      XDMF Model and Format Specification</a>
  */

--- a/src/Rodin/MPI.h
+++ b/src/Rodin/MPI.h
@@ -24,7 +24,7 @@
  *
  * @note This module requires MPI to be available and properly configured.
  *
- * @see Rodin::MPI
+ * @see <a href="namespace_rodin_1_1_m_p_i.html">Rodin::MPI</a>
  */
 
 #include "MPI/Context.h"

--- a/src/Rodin/MPI/Assembly/MPI.h
+++ b/src/Rodin/MPI/Assembly/MPI.h
@@ -69,6 +69,15 @@ namespace Rodin::Assembly
    *
    * Concrete behavior is provided by partial specializations for supported
    * operand types.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref MPI "MPI<IndexMap<Scalar>, DirichletBC<TrialFunction, FunctionBase>>" | Distributed scalar Dirichlet elimination-map assembly on MPI mesh shards. |
+   * | @ref MPI "MPI<IndexMap<pair<IndexArray, Vector>>, DirichletBC<TrialFunction, ShapeFunctionBase>>" | Distributed identification-style Dirichlet constraint assembly. |
+   * | @ref MPI "MPI<Vec, LinearForm<FES, Vec>>" | PETSc/MPI linear-form assembly. |
+   * | @ref MPI "MPI<Mat, BilinearForm<..., Mat>>" | PETSc/MPI bilinear-form assembly. |
+   * | @ref MPI "MPI<PETSc::Math::LinearSystem, Problem<PETSc::Math::LinearSystem, U, V>>" | PETSc/MPI single-field problem assembly. |
+   * | @ref MPI "MPI<PETSc::Math::LinearSystem, Problem<PETSc::Math::LinearSystem, U1, U2, U3, Us...>>" | PETSc/MPI mixed multi-field problem assembly. |
    */
   template <class LinearAlgebraType, class Operand>
   class MPI;

--- a/src/Rodin/MPI/Geometry/Mesh.h
+++ b/src/Rodin/MPI/Geometry/Mesh.h
@@ -40,10 +40,14 @@ namespace Rodin::Geometry
   using MPIMesh = Mesh<Context::MPI>;
 
   /**
+   * @ingroup MeshTypes
    * @brief Distributed mesh specialization for MPI contexts.
    *
    * Stores the rank-local shard of a partitioned mesh together with the MPI
    * context and global/local index mappings needed for distributed assembly.
+   *
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_base.html">MeshBase</a>
+   * @see <a href="_m_p_i_2_geometry_2_mesh_8h.html">Mesh.h</a>
    */
   template <>
   class Mesh<Context::MPI> : public MeshBase

--- a/src/Rodin/MPI/Geometry/SubMesh.h
+++ b/src/Rodin/MPI/Geometry/SubMesh.h
@@ -57,7 +57,9 @@ namespace Rodin::Geometry
    * SubMesh<Context::MPI> boundary = builder.finalize();
    * @endcode
    *
-   * @see SubMeshBase, Mesh<Context::MPI>, SubMesh<Context::Local>
+   * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh_base.html">SubMeshBase</a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html">Mesh<Context::MPI></a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_sub_mesh_3_01_context_1_1_local_01_4.html">SubMesh<Context::Local></a>
    */
   template <>
   class SubMesh<Context::MPI> final : public SubMeshBase, public Mesh<Context::MPI>

--- a/src/Rodin/MPI/IO/HDF5.h
+++ b/src/Rodin/MPI/IO/HDF5.h
@@ -14,14 +14,14 @@
  * Provides MeshPrinter and MeshLoader specializations for
  * `Mesh<Context::MPI>` using the HDF5 file format.
  *
- * Each MPI rank persists its own local shard independently: the printer
- * delegates to `MeshPrinter<FileFormat::HDF5, Context::Local>` to write the
- * base mesh topology and then appends shard-specific metadata (ownership
+ * Each MPI rank persists its own local @ref Rodin::Geometry::Shard "shard" independently: the printer
+ * delegates to @ref Rodin::IO::MeshPrinter "MeshPrinter<FileFormat::HDF5, Context::Local>" to write the
+ * base mesh topology and then appends @ref Rodin::Geometry::Shard "shard"-specific metadata (ownership
  * flags, polytope index maps, ghost-to-owner maps, and halo CSR) under the
  * `/Shard/...` HDF5 group.
  *
- * The loader delegates to `MeshLoader<FileFormat::HDF5, Context::Local>` to
- * restore the base mesh and then reconstructs the MPI shard metadata needed
+ * The loader delegates to @ref Rodin::IO::MeshLoader "MeshLoader<FileFormat::HDF5, Context::Local>" to
+ * restore the base mesh and then reconstructs the MPI @ref Rodin::Geometry::Shard "shard" metadata needed
  * for distributed assembly from the `/Shard/...` HDF5 datasets written by the
  * MPI printer.
  *
@@ -44,8 +44,8 @@ namespace Rodin::IO
   /**
    * @brief Loads a distributed MPI mesh from an HDF5 file.
    *
-   * Each MPI rank independently loads its local shard from the given HDF5 file
-   * path using the canonical local mesh HDF5 layout and the vertex/cell shard
+   * Each MPI rank independently loads its local @ref Rodin::Geometry::Shard "shard" from the given HDF5 file
+   * path using the canonical local mesh HDF5 layout and the vertex/cell @ref Rodin::Geometry::Shard "shard"
    * metadata stored under `/Shard/...`.  The file is expected to have been
    * produced by `MeshPrinter<FileFormat::HDF5, Context::MPI>`.
    *
@@ -287,11 +287,11 @@ namespace Rodin::IO
    * file path.  The process consists of two phases:
    *
    * 1. **Base mesh** — delegated to
-   *    `MeshPrinter<FileFormat::HDF5, Context::Local>`, which writes the
+   *    @ref Rodin::IO::MeshPrinter "MeshPrinter<FileFormat::HDF5, Context::Local>", which writes the
    *    canonical `/Mesh/...` datasets (vertices, connectivity, attributes,
    *    transformations).
    *
-   * 2. **Shard metadata** — the file is reopened in read-write mode and
+   * 2. @ref Rodin::Geometry::Shard "Shard" metadata — the file is reopened in read-write mode and
    *    the following datasets are appended under `/Shard/`:
    *
    *    | Dataset | Type | Description |

--- a/src/Rodin/MPI/IO/HDF5.h
+++ b/src/Rodin/MPI/IO/HDF5.h
@@ -25,10 +25,10 @@
  * for distributed assembly from the `/Shard/...` HDF5 datasets written by the
  * MPI printer.
  *
- * @see MeshPrinter
- * @see MeshLoader
- * @see Geometry::Mesh<Context::MPI>
- * @see Geometry::Shard
+ * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer.html">MeshPrinter</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader.html">MeshLoader</a>
+ * @see <a href="class_rodin_1_1_geometry_1_1_mesh_3_01_context_1_1_m_p_i_01_4.html">Geometry::Mesh<Context::MPI></a>
+ * @see <a href="class_rodin_1_1_geometry_1_1_shard.html">Geometry::Shard</a>
  */
 
 #include "Rodin/IO/HDF5.h"
@@ -52,7 +52,8 @@ namespace Rodin::IO
    * @note Each rank must be given a rank-specific file path (e.g. via
    *       the callable filename overload on Mesh<Context::MPI>::load).
    *
-   * @see MeshLoader<FileFormat::HDF5, Context::Local>
+   * @ingroup MeshLoaderSpecializations
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_loader_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshLoader<FileFormat::HDF5, Context::Local></a>
    */
   template <>
   class MeshLoader<FileFormat::HDF5, Context::MPI>
@@ -308,8 +309,9 @@ namespace Rodin::IO
    * @note Each rank must be given a rank-specific file path (e.g. via
    *       the callable filename overload on Mesh<Context::MPI>::save).
    *
-   * @see MeshPrinter<FileFormat::HDF5, Context::Local>
-   * @see Geometry::Shard
+   * @ingroup PrinterSpecializations
+   * @see <a href="class_rodin_1_1_i_o_1_1_mesh_printer_3_01_file_format_1_1_h_d_f5_00_01_context_1_1_local_01_4.html">MeshPrinter<FileFormat::HDF5, Context::Local></a>
+   * @see <a href="class_rodin_1_1_geometry_1_1_shard.html">Geometry::Shard</a>
    */
   template <>
   class MeshPrinter<FileFormat::HDF5, Context::MPI>

--- a/src/Rodin/Math.h
+++ b/src/Rodin/Math.h
@@ -16,7 +16,7 @@
  * These types are built on top of the Eigen library for high-performance
  * linear algebra operations.
  *
- * @see Rodin::Math
+ * @see <a href="namespace_rodin_1_1_math.html">Rodin::Math</a>
  */
 
 #include "Math/ForwardDecls.h"

--- a/src/Rodin/Math/Deg.h
+++ b/src/Rodin/Math/Deg.h
@@ -34,7 +34,8 @@ namespace Rodin::Math
    * Rad radians = angle.toRad();  // π radians
    * ```
    *
-   * @see Rad, Unit
+   * @see <a href="class_rodin_1_1_math_1_1_rad.html">Rad</a>
+   * @see <a href="class_rodin_1_1_math_1_1_unit.html">Unit</a>
    */
   class Deg : public Unit<Deg, Real>
   {

--- a/src/Rodin/Math/ForwardDecls.h
+++ b/src/Rodin/Math/ForwardDecls.h
@@ -33,7 +33,14 @@ namespace Rodin::Math
    * @tparam Operator Type of the linear operator (e.g., SparseMatrix, Matrix)
    * @tparam Vector Type of the vectors (solution and right-hand side)
    *
-   * @see LinearSystem
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref LinearSystem "LinearSystem<SparseMatrix, Vector>" | Local sparse linear system used by finite element assembly and iterative/direct sparse solvers. |
+   * | @ref LinearSystem "LinearSystem<Matrix, Vector>" | Local dense linear system used by dense solvers and small algebraic systems. |
+   * | @ref LinearSystem "LinearSystem<PETSc::Math::Matrix, PETSc::Math::Vector>" | PETSc-backed distributed linear system assembled and solved through PETSc objects. |
+   * | @ref LinearSystem "LinearSystem<Operator, Vector>" | Generic linear system interface for compatible operator/vector pairs. |
+   *
+   * @see <a href="class_rodin_1_1_math_1_1_linear_system.html">LinearSystem</a>
    */
   template <class Operator, class Vector>
   class LinearSystem;

--- a/src/Rodin/Math/Rad.h
+++ b/src/Rodin/Math/Rad.h
@@ -32,7 +32,7 @@ namespace Rodin::Math
    * Rad sum = angle1 + angle2;  // 3π/2 radians
    * ```
    *
-   * @see Unit
+   * @see <a href="class_rodin_1_1_math_1_1_unit.html">Unit</a>
    */
   class Rad : public Unit<Rad, Real>
   {

--- a/src/Rodin/Math/Unit.h
+++ b/src/Rodin/Math/Unit.h
@@ -56,7 +56,7 @@ namespace Rodin::Math
    * @tparam Derived The derived class type (CRTP pattern)
    * @tparam T The underlying value type (typically Real)
    *
-   * @see Rad
+   * @see <a href="class_rodin_1_1_math_1_1_rad.html">Rad</a>
    */
   template <class Derived, class T>
   class Unit
@@ -303,4 +303,3 @@ namespace Rodin::Math
 }
 
 #endif
-

--- a/src/Rodin/PETSc.h
+++ b/src/Rodin/PETSc.h
@@ -24,7 +24,7 @@
  *
  * @note This module requires PETSc to be available and properly configured.
  *
- * @see Rodin::PETSc
+ * @see <a href="namespace_rodin_1_1_p_e_t_sc.html">Rodin::PETSc</a>
  */
 
 #include "PETSc/ForwardDecls.h"

--- a/src/Rodin/PETSc/Assembly/ForwardDecls.h
+++ b/src/Rodin/PETSc/Assembly/ForwardDecls.h
@@ -22,9 +22,9 @@ namespace Rodin::PETSc::Assembly
    * PETSc vectors (@c Vec) and matrices (@c Mat) from Rodin variational
    * forms.
    *
-   * @see Rodin::Assembly::Sequential, Rodin::Assembly::MPI
+   * @see <a href="namespace_rodin_1_1_assembly.html">Rodin::Assembly::Sequential</a>
+   * @see <a href="namespace_rodin_1_1_assembly.html">Rodin::Assembly::MPI</a>
    */
 }
 
 #endif
-

--- a/src/Rodin/PETSc/ForwardDecls.h
+++ b/src/Rodin/PETSc/ForwardDecls.h
@@ -27,8 +27,8 @@ namespace Rodin::PETSc
    *
    * - @ref Rodin::PETSc::Math "Math" — PETSc vector, matrix, and linear
    *   system wrappers
-   * - @ref Rodin::PETSc::Solver "Solver" — KSP, SNES, CG, and GMRES
-   *   solver aliases
+   * - @ref Rodin::PETSc::Solver "Solver" — @ref Rodin::Solver::KSP "KSP",
+   *   @ref Rodin::Solver::SNES "SNES", CG, and GMRES solver aliases
    * - @ref Rodin::PETSc::Assembly "Assembly" — Assembly strategies for PETSc
    *   objects (sequential, MPI, OpenMP)
    * - @ref Rodin::PETSc::Variational "Variational" — Trial/test functions,
@@ -36,7 +36,8 @@ namespace Rodin::PETSc
    *
    * @note Available only when Rodin is configured with PETSc support.
    *
-   * @see Rodin::PETSc::Math, Rodin::PETSc::Solver
+   * @see <a href="namespace_rodin_1_1_p_e_t_sc_1_1_math.html">Rodin::PETSc::Math</a>
+   * @see <a href="namespace_rodin_1_1_p_e_t_sc_1_1_solver.html">Rodin::PETSc::Solver</a>
    */
 }
 

--- a/src/Rodin/PETSc/IO/GridFunctionPrinter.h
+++ b/src/Rodin/PETSc/IO/GridFunctionPrinter.h
@@ -14,7 +14,7 @@
  * The concrete specializations are provided in the format-specific headers
  * (HDF5.h, MFEM.h, MEDIT.h).
  *
- * @see Rodin::IO::GridFunctionPrinter
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">Rodin::IO::GridFunctionPrinter</a>
  */
 
 #include <petscvec.h>

--- a/src/Rodin/PETSc/IO/HDF5.h
+++ b/src/Rodin/PETSc/IO/HDF5.h
@@ -27,9 +27,9 @@
  *     └── Data       (1-D array of double — DOF coefficients)
  * ```
  *
- * @see Rodin::IO::GridFunctionPrinter,
- *      Rodin::IO::GridFunctionLoader,
- *      Rodin::PETSc::Variational::GridFunction
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">Rodin::IO::GridFunctionPrinter</a>
+ * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">Rodin::IO::GridFunctionLoader</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_grid_function.html">Rodin::PETSc::Variational::GridFunction</a>
  */
 
 #include <petscvec.h>
@@ -138,7 +138,7 @@ namespace Rodin::IO
    *
    * @note Stream-based loading is not supported; use the path-based overload.
    *
-   * @see GridFunctionPrinter
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_printer.html">GridFunctionPrinter</a>
    */
   template <class FES>
   class GridFunctionLoader<FileFormat::HDF5, FES, ::Vec>
@@ -235,7 +235,7 @@ namespace Rodin::IO
    *
    * @note Stream-based printing is not supported; use the path-based overload.
    *
-   * @see GridFunctionLoader
+   * @see <a href="class_rodin_1_1_i_o_1_1_grid_function_loader.html">GridFunctionLoader</a>
    */
   template <class FES>
   class GridFunctionPrinter<FileFormat::HDF5, FES, ::Vec> final

--- a/src/Rodin/PETSc/Math/LinearSystem.h
+++ b/src/Rodin/PETSc/Math/LinearSystem.h
@@ -24,9 +24,9 @@
  * such as @ref Rodin::Solver::KSP receive a reference to the linear
  * system through the `solve(LinearSystem&)` interface.
  *
- * @see Rodin::PETSc::Math::LinearSystem (convenience alias),
- *      Rodin::Solver::KSP,
- *      Rodin::PETSc::Variational::Problem
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a> convenience alias
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u_00_01_v_01_4.html">Rodin::PETSc::Variational::Problem</a>
  */
 
 #include <petsc.h>
@@ -63,8 +63,8 @@ namespace Rodin::Math
    * (`IS`) that can be passed to `PCFIELDSPLIT` for block
    * preconditioning of multi-field systems.
    *
-   * @see Rodin::PETSc::Math::LinearSystem (convenience alias),
-   *      Rodin::Solver::KSP
+   * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a> convenience alias
+   * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
    */
   template <>
   class LinearSystem<::Mat, ::Vec>
@@ -94,7 +94,7 @@ namespace Rodin::Math
        * The class takes ownership of the `IS` handles and destroys them
        * in its destructor.
        *
-       * @see Rodin::PETSc::Variational::Problem::setFieldSplits
+       * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u1_00_01_u2_00_01_u3_00_01_us_8_8_8_01_4.html">Rodin::PETSc::Variational::Problem::setFieldSplits</a>
        */
       class FieldSplits
       {
@@ -447,7 +447,7 @@ namespace Rodin::PETSc::Math
   /**
    * @brief Convenient alias for the PETSc linear system specialization.
    *
-   * @see Rodin::Math::LinearSystem
+   * @see <a href="class_rodin_1_1_math_1_1_linear_system.html">Rodin::Math::LinearSystem</a>
    */
   using LinearSystem = Rodin::Math::LinearSystem<Matrix, Vector>;
 }

--- a/src/Rodin/PETSc/Math/Matrix.h
+++ b/src/Rodin/PETSc/Math/Matrix.h
@@ -15,7 +15,8 @@
  * provides the @ref Rodin::FormLanguage::Traits specialization so that
  * Rodin's type-trait machinery recognises PETSc matrices.
  *
- * @see Rodin::PETSc::Math::Vector, Rodin::PETSc::Math::LinearSystem
+ * @see <a href="_p_e_t_sc_2_math_2_vector_8h.html">Rodin::PETSc::Math::Vector</a>
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
  */
 
 #include <boost/mpi/communicator.hpp>

--- a/src/Rodin/PETSc/Math/Vector.h
+++ b/src/Rodin/PETSc/Math/Vector.h
@@ -15,7 +15,8 @@
  * provides the @ref Rodin::FormLanguage::Traits specialization so that
  * Rodin's type-trait machinery recognises PETSc vectors.
  *
- * @see Rodin::PETSc::Math::Matrix, Rodin::PETSc::Math::LinearSystem
+ * @see <a href="_p_e_t_sc_2_math_2_matrix_8h.html">Rodin::PETSc::Math::Matrix</a>
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
  */
 
 #include <boost/mpi/communicator.hpp>

--- a/src/Rodin/PETSc/Object.h
+++ b/src/Rodin/PETSc/Object.h
@@ -14,7 +14,8 @@
  * Provides a common interface for accessing the underlying PETSc handle
  * and querying the associated MPI communicator.
  *
- * @see Rodin::Solver::KSP, Rodin::Solver::SNES
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_s_n_e_s.html">Rodin::Solver::SNES</a>
  */
 
 #include <cassert>

--- a/src/Rodin/PETSc/Solver/CG.h
+++ b/src/Rodin/PETSc/Solver/CG.h
@@ -16,7 +16,8 @@
  * applicable to symmetric positive definite systems
  * @f$ A\mathbf{x} = \mathbf{b} @f$.
  *
- * @see Rodin::Solver::KSP, Rodin::PETSc::Solver::GMRES
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_g_m_r_e_s_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::GMRES</a>
  */
 
 #include <petscksp.h>
@@ -37,7 +38,8 @@ namespace Rodin::Solver
    * algorithm to `KSPCG`.  Applicable only to symmetric positive definite
    * (SPD) systems.
    *
-   * @see Rodin::Solver::KSP, Rodin::PETSc::Solver::CG
+   * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+   * @see <a href="class_rodin_1_1_solver_1_1_c_g_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::CG</a>
    */
   template <>
   class CG<PETSc::Math::LinearSystem> final : public KSP

--- a/src/Rodin/PETSc/Solver/GMRES.h
+++ b/src/Rodin/PETSc/Solver/GMRES.h
@@ -16,7 +16,8 @@
  * general (non-symmetric) linear systems
  * @f$ A\mathbf{x} = \mathbf{b} @f$.
  *
- * @see Rodin::Solver::KSP, Rodin::PETSc::Solver::CG
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_c_g_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::CG</a>
  */
 
 #include <petscksp.h>
@@ -38,7 +39,8 @@ namespace Rodin::Solver
    * algorithm to `KSPGMRES`.  Suitable for non-symmetric and
    * indefinite systems.
    *
-   * @see Rodin::Solver::KSP, Rodin::PETSc::Solver::GMRES
+   * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+   * @see <a href="class_rodin_1_1_solver_1_1_g_m_r_e_s_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::GMRES</a>
    */
   template <>
   class GMRES<PETSc::Math::LinearSystem> final : public KSP

--- a/src/Rodin/PETSc/Solver/KSP.h
+++ b/src/Rodin/PETSc/Solver/KSP.h
@@ -23,9 +23,9 @@
  * - Command-line overrides via `KSPSetFromOptions` (called inside `solve`).
  * - Automatic solution vector allocation when `x == PETSC_NULL`.
  *
- * @see Rodin::PETSc::Solver::CG,
- *      Rodin::PETSc::Solver::GMRES,
- *      Rodin::PETSc::Solver::SNES
+ * @see <a href="class_rodin_1_1_solver_1_1_c_g_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::CG</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_g_m_r_e_s_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::PETSc::Solver::GMRES</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_s_n_e_s.html">Rodin::PETSc::Solver::SNES</a>
  */
 
 #include <petscksp.h>
@@ -48,9 +48,9 @@ namespace Rodin::Solver
    * Combines programmatic configuration (tolerances, type, preconditioner)
    * with PETSc command-line overrides (`-ksp_type`, `-ksp_rtol`, …).
    *
-   * @see Rodin::Solver::CG<PETSc::Math::LinearSystem>,
-   *      Rodin::Solver::GMRES<PETSc::Math::LinearSystem>,
-   *      Rodin::Solver::SNES
+   * @see <a href="class_rodin_1_1_solver_1_1_c_g_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::Solver::CG<PETSc::Math::LinearSystem></a>
+   * @see <a href="class_rodin_1_1_solver_1_1_g_m_r_e_s_3_01_p_e_t_sc_1_1_math_1_1_linear_system_01_4.html">Rodin::Solver::GMRES<PETSc::Math::LinearSystem></a>
+   * @see <a href="class_rodin_1_1_solver_1_1_s_n_e_s.html">Rodin::Solver::SNES</a>
    */
   class KSP
     : public LinearSolverBase<PETSc::Math::LinearSystem>, public PETSc::Object<::KSP>

--- a/src/Rodin/PETSc/Solver/SNES.h
+++ b/src/Rodin/PETSc/Solver/SNES.h
@@ -16,9 +16,9 @@
  * the Jacobian system is solved by the associated
  * @ref Rodin::Solver::KSP linear solver.
  *
- * @see Rodin::Solver::KSP,
- *      Rodin::Solver::NewtonSolverBase,
- *      Rodin::PETSc::Math::LinearSystem
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_newton_solver_base.html">Rodin::Solver::NewtonSolverBase</a>
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
  */
 
 #include <petscsnes.h>
@@ -64,9 +64,9 @@ namespace Rodin::Solver
    * Supports both programmatic configuration (`setType`, `setTolerances`)
    * and PETSc command-line overrides (`-snes_type`, `-snes_rtol`, …).
    *
-   * @see Rodin::Solver::KSP,
-   *      Rodin::Solver::NewtonSolverBase,
-   *      Rodin::PETSc::Math::LinearSystem
+   * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
+   * @see <a href="class_rodin_1_1_solver_1_1_newton_solver_base.html">Rodin::Solver::NewtonSolverBase</a>
+   * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
    */
   class SNES
     : public PETSc::Object<::SNES>, public NewtonSolverBase<KSP>

--- a/src/Rodin/PETSc/Variational/BilinearForm.h
+++ b/src/Rodin/PETSc/Variational/BilinearForm.h
@@ -29,10 +29,10 @@
  * where @f$ \psi_j @f$ and @f$ \phi_i @f$ are trial and test basis
  * functions, respectively.
  *
- * @see Rodin::PETSc::Variational::LinearForm,
- *      Rodin::PETSc::Variational::Problem,
- *      Rodin::PETSc::Variational::TrialFunction,
- *      Rodin::PETSc::Variational::TestFunction
+ * @see <a href="class_rodin_1_1_variational_1_1_linear_form_3_01_f_e_s_00_01_1_1_vec_01_4.html">Rodin::PETSc::Variational::LinearForm</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u_00_01_v_01_4.html">Rodin::PETSc::Variational::Problem</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_trial_function.html">Rodin::PETSc::Variational::TrialFunction</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_test_function.html">Rodin::PETSc::Variational::TestFunction</a>
  */
 
 #include <petscmacros.h>
@@ -58,8 +58,8 @@ namespace Rodin::Variational
    * @tparam TrialFES  Finite element space type of the trial function.
    * @tparam TestFES   Finite element space type of the test function.
    *
-   * @see Rodin::Variational::BilinearFormBase,
-   *      Rodin::PETSc::Variational::BilinearForm
+   * @see <a href="class_rodin_1_1_variational_1_1_bilinear_form_base.html">Rodin::Variational::BilinearFormBase</a>
+   * @see <a href="class_rodin_1_1_variational_1_1_bilinear_form_3_01_solution_00_01_trial_f_e_s_00_01_test_f_e_s_00_01_1_1_mat_01_4.html">Rodin::PETSc::Variational::BilinearForm</a>
    */
   template <class Solution, class TrialFES, class TestFES>
   class BilinearForm<Solution, TrialFES, TestFES, ::Mat> final

--- a/src/Rodin/PETSc/Variational/GridFunction.h
+++ b/src/Rodin/PETSc/Variational/GridFunction.h
@@ -101,10 +101,10 @@
  * PetscScalar val = u(pt);
  * ```
  *
- * @see Rodin::Variational::GridFunctionBase,
- *      Rodin::PETSc::Variational::TrialFunction,
- *      Rodin::PETSc::Variational::TestFunction,
- *      Rodin::PETSc::Math::LinearSystem
+ * @see <a href="class_rodin_1_1_variational_1_1_grid_function_base.html">Rodin::Variational::GridFunctionBase</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_trial_function.html">Rodin::PETSc::Variational::TrialFunction</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_test_function.html">Rodin::PETSc::Variational::TestFunction</a>
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
  */
 
 #include <petsc.h>
@@ -168,8 +168,8 @@ namespace Rodin::Variational
    * @tparam FES Finite element space type (e.g. `P1<Real, Mesh<Context::Local>>`
    *             or `P1<Real, Mesh<Context::MPI>>`).
    *
-   * @see Rodin::Variational::GridFunctionBase,
-   *      Rodin::PETSc::Variational::GridFunction (convenience wrapper)
+   * @see <a href="class_rodin_1_1_variational_1_1_grid_function_base.html">Rodin::Variational::GridFunctionBase</a>
+   * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_grid_function.html">Rodin::PETSc::Variational::GridFunction</a> convenience wrapper
    */
   template <class FES>
   class GridFunction<FES, ::Vec>
@@ -1541,7 +1541,7 @@ namespace Rodin::PETSc::Variational
    *
    * @tparam FES Finite element space type (deduced by CTAD).
    *
-   * @see Rodin::Variational::GridFunction<FES, ::Vec>
+   * @see <a href="class_rodin_1_1_variational_1_1_grid_function_3_01_f_e_s_00_01_1_1_vec_01_4.html">Rodin::Variational::GridFunction<FES, ::Vec></a>
    */
   template <class FES>
   class GridFunction

--- a/src/Rodin/PETSc/Variational/LinearForm.h
+++ b/src/Rodin/PETSc/Variational/LinearForm.h
@@ -30,9 +30,9 @@
  * This specialization stores @f$ \mathbf{b} @f$ in a PETSc @c Vec and
  * evaluates @f$ L(u_h) = \mathbf{b}^\top \mathbf{u} @f$ via `VecDot`.
  *
- * @see Rodin::PETSc::Variational::TestFunction,
- *      Rodin::PETSc::Variational::BilinearForm,
- *      Rodin::PETSc::Variational::Problem
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_test_function.html">Rodin::PETSc::Variational::TestFunction</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_bilinear_form_3_01_solution_00_01_trial_f_e_s_00_01_test_f_e_s_00_01_1_1_mat_01_4.html">Rodin::PETSc::Variational::BilinearForm</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u_00_01_v_01_4.html">Rodin::PETSc::Variational::Problem</a>
  */
 
 #include <petscsystypes.h>
@@ -53,8 +53,8 @@ namespace Rodin::Variational
    *
    * @tparam FES Finite element space type of the associated test function.
    *
-   * @see Rodin::Variational::LinearFormBase,
-   *      Rodin::PETSc::Variational::LinearForm
+   * @see <a href="_variational_2_linear_form_8h.html">Rodin::Variational::LinearFormBase</a>
+   * @see <a href="class_rodin_1_1_variational_1_1_linear_form_3_01_f_e_s_00_01_1_1_vec_01_4.html">Rodin::PETSc::Variational::LinearForm</a>
    */
   template <class FES>
   class LinearForm<FES, ::Vec> final

--- a/src/Rodin/PETSc/Variational/Problem.h
+++ b/src/Rodin/PETSc/Variational/Problem.h
@@ -24,10 +24,10 @@
  * Both specializations support `Context::Local` (sequential) and
  * `Context::MPI` (distributed) mesh contexts.
  *
- * @see Rodin::PETSc::Variational::TrialFunction,
- *      Rodin::PETSc::Variational::TestFunction,
- *      Rodin::PETSc::Math::LinearSystem,
- *      Rodin::Solver::KSP
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_trial_function.html">Rodin::PETSc::Variational::TrialFunction</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_test_function.html">Rodin::PETSc::Variational::TestFunction</a>
+ * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4.html">Rodin::PETSc::Math::LinearSystem</a>
+ * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
  */
 
 #include <mpi.h>
@@ -68,8 +68,8 @@ namespace Rodin::Variational
    *           `TrialFunction<GridFunction<P1<…>>, P1<…>>`).
    * @tparam V Test function type (e.g. `TestFunction<P1<…>>`).
    *
-   * @see Rodin::PETSc::Variational::Problem (convenience alias),
-   *      Rodin::Solver::KSP
+   * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u_00_01_v_01_4.html">Rodin::PETSc::Variational::Problem</a> convenience alias
+   * @see <a href="class_rodin_1_1_solver_1_1_k_s_p.html">Rodin::Solver::KSP</a>
    */
   template <class U, class V>
   class Problem<PETSc::Math::LinearSystem, U, V>
@@ -353,8 +353,8 @@ namespace Rodin::Variational
    * @tparam U3  Third function type.
    * @tparam Us  Additional function types.
    *
-   * @see Rodin::PETSc::Variational::Problem (convenience alias),
-   *      Rodin::PETSc::Math::LinearSystem::FieldSplits
+   * @see <a href="class_rodin_1_1_variational_1_1_problem_3_01_p_e_t_sc_1_1_math_1_1_linear_system_00_01_u1_00_01_u2_00_01_u3_00_01_us_8_8_8_01_4.html">Rodin::PETSc::Variational::Problem</a> convenience alias
+   * @see <a href="class_rodin_1_1_math_1_1_linear_system_3_1_1_mat_00_01_1_1_vec_01_4_1_1_field_splits.html">Rodin::PETSc::Math::LinearSystem::FieldSplits</a>
    */
   template <class U1, class U2, class U3, class... Us>
   class Problem<PETSc::Math::LinearSystem, U1, U2, U3, Us...>

--- a/src/Rodin/PETSc/Variational/TestFunction.h
+++ b/src/Rodin/PETSc/Variational/TestFunction.h
@@ -16,9 +16,9 @@
  * PETSc namespace and triggers PETSc-specific template argument deduction
  * for linear forms, bilinear forms, and problems.
  *
- * @see Rodin::PETSc::Variational::TrialFunction,
- *      Rodin::PETSc::Variational::LinearForm,
- *      Rodin::PETSc::Variational::BilinearForm
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_trial_function.html">Rodin::PETSc::Variational::TrialFunction</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_linear_form_3_01_f_e_s_00_01_1_1_vec_01_4.html">Rodin::PETSc::Variational::LinearForm</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_bilinear_form_3_01_solution_00_01_trial_f_e_s_00_01_test_f_e_s_00_01_1_1_mat_01_4.html">Rodin::PETSc::Variational::BilinearForm</a>
  */
 
 #include <petsc.h>
@@ -38,7 +38,7 @@ namespace Rodin::PETSc::Variational
    *
    * @tparam FES Finite element space type (e.g. `P1<Real, Mesh<Context::Local>>`).
    *
-   * @see Rodin::Variational::TestFunction
+   * @see <a href="_variational_2_test_function_8h.html">Rodin::Variational::TestFunction</a>
    */
   template <class FES>
   class TestFunction : public Rodin::Variational::TestFunction<FES>

--- a/src/Rodin/PETSc/Variational/TrialFunction.h
+++ b/src/Rodin/PETSc/Variational/TrialFunction.h
@@ -17,9 +17,9 @@
  * trial function with a PETSc-backed
  * PETSc-backed grid function as its solution type.
  *
- * @see Rodin::PETSc::Variational::TestFunction,
- *      Rodin::PETSc::Variational::GridFunction,
- *      Rodin::PETSc::Variational::BilinearForm
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_test_function.html">Rodin::PETSc::Variational::TestFunction</a>
+ * @see <a href="class_rodin_1_1_p_e_t_sc_1_1_variational_1_1_grid_function.html">Rodin::PETSc::Variational::GridFunction</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_bilinear_form_3_01_solution_00_01_trial_f_e_s_00_01_test_f_e_s_00_01_1_1_mat_01_4.html">Rodin::PETSc::Variational::BilinearForm</a>
  */
 
 #include <petsc.h>
@@ -43,7 +43,7 @@ namespace Rodin::PETSc::Variational
    *         `PETSc::Variational::GridFunction<FES>`).
    * @tparam FES      Finite element space type.
    *
-   * @see Rodin::Variational::TrialFunction
+   * @see <a href="_variational_2_trial_function_8h.html">Rodin::Variational::TrialFunction</a>
    */
   template <class Solution, class FES>
   class TrialFunction : public Rodin::Variational::TrialFunction<Solution, FES>

--- a/src/Rodin/QF.h
+++ b/src/Rodin/QF.h
@@ -20,15 +20,15 @@
  * where @f$ K @f$ is a reference polytope, @f$ x_i @f$ are quadrature points,
  * and @f$ w_i @f$ are associated weights.
  *
- * @see Rodin::QF::QuadratureFormulaBase
- * @see Rodin::QF::GaussLegendre
- * @see Rodin::QF::GrundmannMoller
- * @see Rodin::QF::Centroid
- * @see Rodin::QF::PolytopeQuadratureFormula
- * @see Rodin::QF::XiaoGimbutas
- * @see Rodin::QF::WitherdenVincent
- * @see Rodin::QF::TensorProduct
- * @see Rodin::QF::GaussLobatto (header-only, include QF/GaussLobato.h separately)
+ * @see <a href="class_rodin_1_1_q_f_1_1_quadrature_formula_base.html">Rodin::QF::QuadratureFormulaBase</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_gauss_legendre.html">Rodin::QF::GaussLegendre</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_grundmann_moller.html">Rodin::QF::GrundmannMoller</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_centroid.html">Rodin::QF::Centroid</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_polytope_quadrature_formula.html">Rodin::QF::PolytopeQuadratureFormula</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_xiao_gimbutas.html">Rodin::QF::XiaoGimbutas</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_witherden_vincent.html">Rodin::QF::WitherdenVincent</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_tensor_product.html">Rodin::QF::TensorProduct</a>
+ * @see <a href="class_rodin_1_1_q_f_1_1_gauss_lobatto.html">Rodin::QF::GaussLobatto</a> header-only, include QF/GaussLobato.h separately
  */
 
 #include "QF/QuadratureFormula.h"

--- a/src/Rodin/QF/Centroid.h
+++ b/src/Rodin/QF/Centroid.h
@@ -59,8 +59,8 @@ namespace Rodin::QF
    * This is the simplest possible quadrature rule for each geometry type
    * and is computationally efficient when low accuracy is acceptable.
    *
-   * @see QuadratureFormulaBase
-   * @see GaussLegendre
+   * @see <a href="class_rodin_1_1_q_f_1_1_quadrature_formula_base.html">QuadratureFormulaBase</a>
+   * @see <a href="class_rodin_1_1_q_f_1_1_gauss_legendre.html">GaussLegendre</a>
    */
   class Centroid final : public QuadratureFormulaBase
   {

--- a/src/Rodin/QF/GrundmannMoller.h
+++ b/src/Rodin/QF/GrundmannMoller.h
@@ -16,7 +16,7 @@
  * @ingroup RodinDirectives
  * @brief Maximum value permitted for the @f$ s \geq 0 @f$ parameter in
  * Grundmann-Moller quadrature.
- * @see Rodin::QF::GrundmannMoller
+ * @see <a href="class_rodin_1_1_q_f_1_1_grundmann_moller.html">Rodin::QF::GrundmannMoller</a>
  * @see RODIN_QF_GRUNDMANNMOLLER_MAX_ORDER
  */
 #define RODIN_QF_GRUNDMANNMOLLER_MAX_S 16
@@ -26,7 +26,7 @@
  * @brief Maximum degree permitted for Grundmann-Moller quadrature.
  *
  * The degree is given by @f$ d = 2s + 1 @f$ where @f$ s \geq 0 @f$.
- * @see Rodin::QF::GrundmannMoller
+ * @see <a href="class_rodin_1_1_q_f_1_1_grundmann_moller.html">Rodin::QF::GrundmannMoller</a>
  * @see RODIN_QF_GRUNDMANNMOLLER_MAX_S
  */
 #define RODIN_QF_GRUNDMANNMOLLER_MAX_ORDER 2 * RODIN_QF_GRUNDMANNMOLLER_MAX_S + 1

--- a/src/Rodin/QF/PolytopeQuadratureFormula.h
+++ b/src/Rodin/QF/PolytopeQuadratureFormula.h
@@ -59,10 +59,10 @@ namespace Rodin::QF
    * PolytopeQuadratureFormula qf_default(Geometry::Polytope::Type::Tetrahedron);
    * @endcode
    *
-   * @see QuadratureFormulaBase
-   * @see GaussLegendre
-   * @see XiaoGimbutas
-   * @see WitherdenVincent
+   * @see <a href="class_rodin_1_1_q_f_1_1_quadrature_formula_base.html">QuadratureFormulaBase</a>
+   * @see <a href="class_rodin_1_1_q_f_1_1_gauss_legendre.html">GaussLegendre</a>
+   * @see <a href="class_rodin_1_1_q_f_1_1_xiao_gimbutas.html">XiaoGimbutas</a>
+   * @see <a href="class_rodin_1_1_q_f_1_1_witherden_vincent.html">WitherdenVincent</a>
    */
   class PolytopeQuadratureFormula : public QuadratureFormulaBase
   {

--- a/src/Rodin/QF/QuadratureFormula.h
+++ b/src/Rodin/QF/QuadratureFormula.h
@@ -26,7 +26,7 @@ namespace Rodin::QF
   /**
    * @defgroup RodinQuadrature Quadrature formulae
    * @brief Quadrature formulae utilized by Rodin
-   * @see QuadratureFormulaBase
+   * @see <a href="class_rodin_1_1_q_f_1_1_quadrature_formula_base.html">QuadratureFormulaBase</a>
    */
 
   /**

--- a/src/Rodin/QF/WitherdenVincent.h
+++ b/src/Rodin/QF/WitherdenVincent.h
@@ -26,7 +26,7 @@ namespace Rodin::QF
    * Witherden--Vincent tables. Every entry is independently tested for
    * polynomial exactness, positive weights, and interior nodes.
    *
-   * @see XiaoGimbutas
+   * @see <a href="class_rodin_1_1_q_f_1_1_xiao_gimbutas.html">XiaoGimbutas</a>
    */
   class WitherdenVincent final : public QuadratureFormulaBase
   {

--- a/src/Rodin/Solid/Constitutive/MooneyRivlin.h
+++ b/src/Rodin/Solid/Constitutive/MooneyRivlin.h
@@ -42,7 +42,7 @@ namespace Rodin::Solid
    * Parameterized by material constants @f$ c_1, c_2 @f$ and bulk modulus
    * @f$ \kappa @f$.
    *
-   * @see HyperElasticLaw
+   * @see <a href="class_rodin_1_1_solid_1_1_hyper_elastic_law.html">HyperElasticLaw</a>
    */
   class MooneyRivlin final : public HyperElasticLaw<MooneyRivlin>
   {

--- a/src/Rodin/Solid/Constitutive/NeoHookean.h
+++ b/src/Rodin/Solid/Constitutive/NeoHookean.h
@@ -48,7 +48,7 @@ namespace Rodin::Solid
   /**
    * @brief Compressible Neo-Hookean hyperelastic law.
    *
-   * @see HyperElasticLaw
+   * @see <a href="class_rodin_1_1_solid_1_1_hyper_elastic_law.html">HyperElasticLaw</a>
    */
   class NeoHookean final : public HyperElasticLaw<NeoHookean>
   {

--- a/src/Rodin/Solid/Constitutive/SaintVenantKirchhoff.h
+++ b/src/Rodin/Solid/Constitutive/SaintVenantKirchhoff.h
@@ -45,7 +45,7 @@ namespace Rodin::Solid
    * This is the simplest hyperelastic law, extending linear elasticity
    * to large deformations through the Green-Lagrange strain tensor.
    *
-   * @see HyperElasticLaw
+   * @see <a href="class_rodin_1_1_solid_1_1_hyper_elastic_law.html">HyperElasticLaw</a>
    */
   class SaintVenantKirchhoff final : public HyperElasticLaw<SaintVenantKirchhoff>
   {

--- a/src/Rodin/Solid/Constitutive/Yeoh.h
+++ b/src/Rodin/Solid/Constitutive/Yeoh.h
@@ -48,7 +48,9 @@ namespace Rodin::Solid
    * modulus @f$ \kappa @f$. The small-strain shear modulus is
    * @f$ \mu = 2 c_1 @f$; @f$ c_2, c_3 @f$ control the strain-stiffening.
    *
-   * @see HyperElasticLaw, MooneyRivlin, NeoHookean
+   * @see <a href="class_rodin_1_1_solid_1_1_hyper_elastic_law.html">HyperElasticLaw</a>
+   * @see <a href="class_rodin_1_1_solid_1_1_mooney_rivlin.html">MooneyRivlin</a>
+   * @see <a href="class_rodin_1_1_solid_1_1_neo_hookean.html">NeoHookean</a>
    */
   class Yeoh final : public HyperElasticLaw<Yeoh>
   {

--- a/src/Rodin/Solid/Integrators/InternalVirtualWork.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWork.h
@@ -150,7 +150,7 @@ namespace Rodin::Solid
        * @c commit(), never during assembly, so a caller controls exactly when
        * derived quantities are taken.
        *
-       * @see Solid::Output
+       * @see <a href="class_rodin_1_1_solid_1_1_output.html">Solid::Output</a>
        */
       InternalVirtualWork& setOutput(OutputFunctionType output)
       {

--- a/src/Rodin/Solid/Integrators/InternalVirtualWorkResidual.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWorkResidual.h
@@ -51,6 +51,17 @@
 
 namespace Rodin::Solid
 {
+  /**
+   * @brief Internal virtual work residual integrator family.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref InternalVirtualWorkResidual "InternalVirtualWorkResidual<LawDerived, TestFunctionType, DisplacementType>" | Momentum residual for pure-displacement hyperelastic formulations. |
+   * | @ref InternalVirtualWorkResidual "InternalVirtualWorkResidual<LawDerived, TestFunctionType, DisplacementType, PressureType>" | Momentum residual for mixed displacement-pressure formulations with pressure contribution. |
+   *
+   * @tparam Args Constitutive law, test function, displacement state, and
+   *         optional pressure state types selected by the specialization.
+   */
   template <class... Args>
   class InternalVirtualWorkResidual;
 

--- a/src/Rodin/Solid/Integrators/InternalVirtualWorkTangent.h
+++ b/src/Rodin/Solid/Integrators/InternalVirtualWorkTangent.h
@@ -59,6 +59,17 @@
 namespace Rodin::Solid
 {
 
+  /**
+   * @brief Internal virtual work tangent integrator family.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref InternalVirtualWorkTangent "InternalVirtualWorkTangent<LawDerived, TrialFunctionType, TestFunctionType, DisplacementType>" | Displacement tangent for pure-displacement hyperelastic formulations. |
+   * | @ref InternalVirtualWorkTangent "InternalVirtualWorkTangent<LawDerived, TrialFunctionType, TestFunctionType, DisplacementType, PressureType>" | Displacement-displacement tangent for mixed displacement-pressure formulations. |
+   *
+   * @tparam Args Constitutive law, trial/test functions, displacement state,
+   *         and optional pressure state types selected by the specialization.
+   */
   template <class... Args>
   class InternalVirtualWorkTangent;
 

--- a/src/Rodin/Solid/Linear/LinearElasticityIntegral.h
+++ b/src/Rodin/Solid/Linear/LinearElasticityIntegral.h
@@ -48,6 +48,11 @@ namespace Rodin::Variational
    * @tparam FES Finite element space type
    * @tparam LambdaDerived Type of first Lamé parameter function
    * @tparam MuDerived Type of second Lamé parameter (shear modulus) function
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref LinearElasticityIntegrator "LinearElasticityIntegrator<Solution, FES, LambdaDerived, MuDerived>" | Generic vector-valued finite element integrator for the linear elasticity bilinear form. |
+   * | @ref LinearElasticityIntegrator "LinearElasticityIntegrator<Solution, P1<Range, Mesh>, MuDerived, LambdaDerived>" | P1 vector-space specialization using the constant-gradient structure of linear elements. |
    */
   template <class Solution, class FES, class LambdaDerived, class MuDerived>
   class LinearElasticityIntegrator final

--- a/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
+++ b/src/Rodin/Solid/Linear/P1/LinearElasticityIntegral.h
@@ -34,7 +34,8 @@
  * problem = Solid::Linear::LinearElasticityIntegral(u, v)(lambda, mu);
  * @endcode
  *
- * @see LinearElasticityIntegral, P1
+ * @see <a href="_linear_elasticity_integral_8h.html">LinearElasticityIntegral</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
  */
 
 #include "Rodin/Solid/Linear/LinearElasticityIntegral.h"

--- a/src/Rodin/Solver.h
+++ b/src/Rodin/Solver.h
@@ -21,7 +21,7 @@
  * - **Specialized solvers**: Least-squares and problem-specific algorithms
  * - **External library solvers**: High-performance solvers from SuiteSparse
  *
- * @see Rodin::Solver namespace for all solver classes
+ * @see <a href="namespace_rodin_1_1_solver.html">Rodin::Solver</a> namespace for all solver classes
  */
 
 #include "Solver/LinearSolver.h"

--- a/src/Rodin/Solver/BiCGSTAB.h
+++ b/src/Rodin/Solver/BiCGSTAB.h
@@ -35,7 +35,7 @@
  * solver.setTolerance(1e-10).setMaxIterations(1000).solve();
  * ```
  *
- * @see BiCGSTAB for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_bi_c_g_s_t_a_b.html">BiCGSTAB</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_BICGSTAB_H
 #define RODIN_SOLVER_BICGSTAB_H
@@ -64,7 +64,7 @@ namespace Rodin::Solver
   /**
    * @defgroup BiCGSTABSpecializations BiCGSTAB Template Specializations
    * @brief Template specializations of the BiCGSTAB class.
-   * @see BiCGSTAB
+   * @see @ref BiCGSTAB
    */
 
   /**

--- a/src/Rodin/Solver/CG.h
+++ b/src/Rodin/Solver/CG.h
@@ -45,7 +45,7 @@
  *   std::cout << "Converged!\n";
  * ```
  *
- * @see CG for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_c_g.html">CG</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_CG_H
 #define RODIN_SOLVER_CG_H
@@ -76,7 +76,13 @@ namespace Rodin::Solver
   /**
    * @defgroup CGSpecializations CG Template Specializations
    * @brief Template specializations of the CG class.
-   * @see CG
+   * @see @ref CG
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref CG "CG<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Iterative conjugate-gradient solver for sparse symmetric positive-definite systems. |
+   * | @ref CG "CG<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Iterative conjugate-gradient solver for dense symmetric positive-definite systems. |
+   * | @ref CG "CG<PETSc::LinearSystem>" | PETSc-backed conjugate-gradient solver for distributed systems. |
    */
 
   /**

--- a/src/Rodin/Solver/CHOLMOD.h
+++ b/src/Rodin/Solver/CHOLMOD.h
@@ -40,7 +40,7 @@
  * @note This solver requires CHOLMOD from SuiteSparse to be installed
  * and RODIN_USE_CHOLMOD to be defined at compile time.
  *
- * @see CHOLMOD::SupernodalLLT for the solver implementation
+ * @see <a href="_c_h_o_l_m_o_d_8h.html">CHOLMOD::SupernodalLLT</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_CHOLMOD_H
 #define RODIN_SOLVER_CHOLMOD_H

--- a/src/Rodin/Solver/DGMRES.h
+++ b/src/Rodin/Solver/DGMRES.h
@@ -58,7 +58,12 @@ namespace Rodin::Solver
   /**
    * @defgroup DGMRESSpecializations DGMRES Template Specializations
    * @brief Template specializations of the DGMRES class.
-   * @see DGMRES
+   * @see @ref DGMRES
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref DGMRES "DGMRES<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Iterative DGMRES solver for sparse systems. |
+   * | @ref DGMRES "DGMRES<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Iterative DGMRES solver for dense systems. |
    */
 
   /**

--- a/src/Rodin/Solver/ForwardDecls.h
+++ b/src/Rodin/Solver/ForwardDecls.h
@@ -118,7 +118,6 @@ namespace Rodin::Solver
   template <class LinearSystem>
   class LDLT;
 
-
   /**
    * @brief Dense LU factorization with partial pivoting for general matrices.
    * @tparam LinearSystem Type of linear system to solve

--- a/src/Rodin/Solver/ForwardDecls.h
+++ b/src/Rodin/Solver/ForwardDecls.h
@@ -30,7 +30,7 @@ namespace Rodin::Solver
    * where @f$ A @f$ is the operator (matrix), @f$ x @f$ is the solution vector,
    * and @f$ b @f$ is the right-hand side vector.
    *
-   * @see LinearSolverBase for the full implementation.
+   * @see @ref LinearSolverBase "LinearSolverBase" for the full implementation.
    */
   template <class LinearSystem>
   class LinearSolverBase;

--- a/src/Rodin/Solver/ForwardDecls.h
+++ b/src/Rodin/Solver/ForwardDecls.h
@@ -60,6 +60,12 @@ namespace Rodin::Solver
    * The CG method is an iterative solver particularly efficient for large
    * sparse symmetric positive definite systems.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref CG "CG<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Iterative conjugate gradient solver for sparse SPD systems. |
+   * | @ref CG "CG<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Iterative conjugate gradient solver for dense SPD systems. |
+   * | @ref CG "CG<PETSc::Math::LinearSystem>" | PETSc KSP-backed conjugate gradient solver. |
+   *
    * @see CGSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -71,6 +77,10 @@ namespace Rodin::Solver
    *
    * Performs Cholesky decomposition @f$ A = LL^T @f$ for symmetric positive
    * definite sparse matrices.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SimplicialLLT "SimplicialLLT<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Eigen sparse LLT factorization for SPD sparse systems. |
    *
    * @see SimplicialLLTSpecializations for available template specializations.
    */
@@ -84,6 +94,10 @@ namespace Rodin::Solver
    * Performs Cholesky decomposition @f$ A = LDL^T @f$ without square root
    * for symmetric positive definite sparse matrices.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SimplicialLDLT "SimplicialLDLT<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Eigen sparse LDLT factorization for SPD sparse systems. |
+   *
    * @see SimplicialLDLTSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -94,6 +108,10 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * Performs robust Cholesky decomposition with pivoting for dense matrices.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref LDLT "LDLT<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Eigen dense LDLT factorization with pivoting. |
    *
    * @see LDLTSpecializations for available template specializations.
    */
@@ -107,6 +125,10 @@ namespace Rodin::Solver
    *
    * Performs LU decomposition with partial pivoting for dense matrices.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref PartialPivLU "PartialPivLU<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Eigen dense LU factorization with partial pivoting. |
+   *
    * @see PartialPivLUSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -117,6 +139,10 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * Performs QR decomposition using Householder reflections for dense matrices.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref HouseholderQR "HouseholderQR<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Eigen dense Householder QR factorization. |
    *
    * @see HouseholderQRSpecializations for available template specializations.
    */
@@ -129,6 +155,10 @@ namespace Rodin::Solver
    *
    * Performs LU decomposition for general (non-symmetric) sparse matrices.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SparseLU "SparseLU<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Eigen sparse LU factorization for general sparse systems. |
+   *
    * @see SparseLUSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -139,6 +169,10 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * Performs QR decomposition with numerical column pivoting for sparse matrices.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SparseQR "SparseQR<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Eigen sparse QR factorization with column pivoting. |
    *
    * @see SparseQRSpecializations for available template specializations.
    */
@@ -151,6 +185,11 @@ namespace Rodin::Solver
    *
    * Iterative solver for least-squares problems @f$ \min_x \|Ax - b\|^2 @f$.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref LeastSquaresCG "LeastSquaresCG<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Least-squares conjugate gradient solver for sparse systems. |
+   * | @ref LeastSquaresCG "LeastSquaresCG<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Least-squares conjugate gradient solver for dense systems. |
+   *
    * @see LeastSquaresCGSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -162,6 +201,10 @@ namespace Rodin::Solver
    *
    * The BiCGSTAB method is an iterative solver for non-symmetric linear systems.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref BiCGSTAB "BiCGSTAB<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Stabilized bi-conjugate gradient solver for sparse non-symmetric systems. |
+   *
    * @see BiCGSTABSpecializations for available template specializations.
    */
   template <class LinearSystem>
@@ -172,6 +215,12 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * GMRES is an iterative method for solving non-symmetric linear systems.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GMRES "GMRES<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Restarted GMRES solver for sparse non-symmetric systems. |
+   * | @ref GMRES "GMRES<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Restarted GMRES solver for dense non-symmetric systems. |
+   * | @ref GMRES "GMRES<PETSc::Math::LinearSystem>" | PETSc KSP-backed GMRES solver. |
    */
   template <class LinearSystem>
   class GMRES;
@@ -181,13 +230,36 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * DGMRES is a variant of GMRES with deflation techniques.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref DGMRES "DGMRES<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Deflated GMRES solver for sparse non-symmetric systems. |
+   * | @ref DGMRES "DGMRES<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Deflated GMRES solver for dense non-symmetric systems. |
    */
   template <class LinearSystem>
   class DGMRES;
 
+  /**
+   * @brief Induced dimension reduction iterative solver.
+   * @tparam LinearSystem Type of linear system to solve
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref IDRS "IDRS<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | IDR(s) solver for sparse non-symmetric systems. |
+   * | @ref IDRS "IDRS<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | IDR(s) solver for dense non-symmetric systems. |
+   */
   template <class LinearSystem>
   class IDRS;
 
+  /**
+   * @brief Minimum residual iterative solver.
+   * @tparam LinearSystem Type of linear system to solve
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref MINRES "MINRES<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | MINRES solver for sparse symmetric indefinite systems. |
+   * | @ref MINRES "MINRES<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | MINRES solver for dense symmetric indefinite systems. |
+   */
   template <class LinearSystem>
   class MINRES;
 
@@ -196,6 +268,11 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * IDR(s)STABL is an induced dimension reduction method with stabilization.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref IDRSTABL "IDRSTABL<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | Stabilized IDR(s) solver for sparse non-symmetric systems. |
+   * | @ref IDRSTABL "IDRSTABL<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>>" | Stabilized IDR(s) solver for dense non-symmetric systems. |
    */
   template <class LinearSystem>
   class IDRSTABL;
@@ -206,6 +283,10 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * High-performance sparse QR factorization from the SuiteSparse library.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref SPQR "SPQR<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | SuiteSparseQR factorization for sparse systems. |
    *
    * @see SPQRSpecializations for available template specializations.
    */
@@ -219,6 +300,10 @@ namespace Rodin::Solver
    * @tparam LinearSystem Type of linear system to solve
    *
    * High-performance sparse direct solver from the SuiteSparse library.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref UMFPack "UMFPack<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>" | UMFPACK multifrontal sparse LU factorization. |
    *
    * @see UMFPackSpecializations for available template specializations.
    */

--- a/src/Rodin/Solver/GMRES.h
+++ b/src/Rodin/Solver/GMRES.h
@@ -39,7 +39,7 @@
  *   std::cout << "Converged!\n";
  * ```
  *
- * @see GMRES for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_g_m_r_e_s.html">GMRES</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_GMRES_H
 #define RODIN_SOLVER_GMRES_H
@@ -72,7 +72,13 @@ namespace Rodin::Solver
   /**
    * @defgroup GMRESSpecializations GMRES Template Specializations
    * @brief Template specializations of the GMRES class.
-   * @see GMRES
+   * @see @ref GMRES
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GMRES "GMRES<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Iterative GMRES solver for sparse systems. |
+   * | @ref GMRES "GMRES<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Iterative GMRES solver for dense systems. |
+   * | @ref GMRES "GMRES<PETSc::LinearSystem>" | PETSc-backed GMRES solver for distributed systems. |
    */
 
   /**

--- a/src/Rodin/Solver/HouseholderQR.h
+++ b/src/Rodin/Solver/HouseholderQR.h
@@ -34,7 +34,7 @@
  * solver.solve();
  * ```
  *
- * @see HouseholderQR for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_householder_q_r.html">HouseholderQR</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_HOUSEHOLDERQR_H
 #define RODIN_SOLVER_HOUSEHOLDERQR_H
@@ -64,7 +64,7 @@ namespace Rodin::Solver
   /**
    * @defgroup HouseholderQRSpecializations HouseholderQR Template Specializations
    * @brief Template specializations of the HouseholderQR class.
-   * @see HouseholderQR
+   * @see @ref HouseholderQR
    */
 
   /**

--- a/src/Rodin/Solver/IDRS.h
+++ b/src/Rodin/Solver/IDRS.h
@@ -58,7 +58,12 @@ namespace Rodin::Solver
   /**
    * @defgroup IDRSSpecializations IDRS Template Specializations
    * @brief Template specializations of the IDRS class.
-   * @see IDRS
+   * @see @ref IDRS
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref IDRS "IDRS<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Iterative IDR(s) solver for sparse systems. |
+   * | @ref IDRS "IDRS<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Iterative IDR(s) solver for dense systems. |
    */
 
   /**

--- a/src/Rodin/Solver/IDRSTABL.h
+++ b/src/Rodin/Solver/IDRSTABL.h
@@ -56,7 +56,12 @@ namespace Rodin::Solver
   /**
    * @defgroup IDRSTABLSpecializations IDRSTABL Template Specializations
    * @brief Template specializations of the IDRSTABL class.
-   * @see IDRSTABL
+   * @see @ref IDRSTABL
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref IDRSTABL "IDRSTABL<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Stabilized IDR(s) solver for sparse systems. |
+   * | @ref IDRSTABL "IDRSTABL<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Stabilized IDR(s) solver for dense systems. |
    */
 
   /**

--- a/src/Rodin/Solver/LDLT.h
+++ b/src/Rodin/Solver/LDLT.h
@@ -34,7 +34,7 @@
  * solver.solve();
  * ```
  *
- * @see LDLT for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_l_d_l_t.html">LDLT</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_LDLT_H
 #define RODIN_SOLVER_LDLT_H
@@ -65,7 +65,7 @@ namespace Rodin::Solver
   /**
    * @defgroup LDLTSpecializations LDLT Template Specializations
    * @brief Template specializations of the LDLT class.
-   * @see LDLT
+   * @see @ref LDLT
    */
 
   /**

--- a/src/Rodin/Solver/LeastSquaresCG.h
+++ b/src/Rodin/Solver/LeastSquaresCG.h
@@ -33,7 +33,7 @@
  * solver.setTolerance(1e-10).setMaxIterations(1000).solve();
  * ```
  *
- * @see LeastSquaresCG for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_least_squares_c_g.html">LeastSquaresCG</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_LEASTSQUARESCG_H
 #define RODIN_SOLVER_LEASTSQUARESCG_H
@@ -62,7 +62,12 @@ namespace Rodin::Solver
   /**
    * @defgroup LeastSquaresCGSpecializations LeastSquaresCG Template Specializations
    * @brief Template specializations of the LeastSquaresCG class.
-   * @see LeastSquaresCG
+   * @see @ref LeastSquaresCG
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref LeastSquaresCG "LeastSquaresCG<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Least-squares conjugate-gradient solver for sparse systems. |
+   * | @ref LeastSquaresCG "LeastSquaresCG<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Least-squares conjugate-gradient solver for dense systems. |
    */
 
   /**
@@ -218,7 +223,7 @@ namespace Rodin::Solver
    *
    * @tparam Scalar The scalar type (e.g., Real, Complex)
    *
-   * @see LeastSquaresCG<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
+   * @see @ref LeastSquaresCG<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
    */
   template <class Scalar>
   class LeastSquaresCG<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>> final

--- a/src/Rodin/Solver/LeastSquaresCG.h
+++ b/src/Rodin/Solver/LeastSquaresCG.h
@@ -223,7 +223,7 @@ namespace Rodin::Solver
    *
    * @tparam Scalar The scalar type (e.g., Real, Complex)
    *
-   * @see @ref LeastSquaresCG<Math::LinearSystem<Math::SparseMatrix<Scalar>, Math::Vector<Scalar>>>
+   * @see <a href="class_rodin_1_1_solver_1_1_least_squares_c_g.html">LeastSquaresCG</a>
    */
   template <class Scalar>
   class LeastSquaresCG<Math::LinearSystem<Math::Matrix<Scalar>, Math::Vector<Scalar>>> final

--- a/src/Rodin/Solver/MINRES.h
+++ b/src/Rodin/Solver/MINRES.h
@@ -40,7 +40,7 @@
  *   std::cout << "Converged!\n";
  * ```
  *
- * @see MINRES for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_m_i_n_r_e_s.html">MINRES</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_MINRES_H
 #define RODIN_SOLVER_MINRES_H
@@ -73,7 +73,12 @@ namespace Rodin::Solver
   /**
    * @defgroup MINRESSpecializations MINRES Template Specializations
    * @brief Template specializations of the MINRES class.
-   * @see MINRES
+   * @see @ref MINRES
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref MINRES "MINRES<LinearSystem<SparseMatrix<Scalar>, Vector<Scalar>>>" | Minimal residual solver for sparse symmetric systems. |
+   * | @ref MINRES "MINRES<LinearSystem<Matrix<Scalar>, Vector<Scalar>>>" | Minimal residual solver for dense symmetric systems. |
    */
 
   /**

--- a/src/Rodin/Solver/NewtonSolver.h
+++ b/src/Rodin/Solver/NewtonSolver.h
@@ -28,15 +28,18 @@ namespace Rodin::Solver
    * @brief Base interface for Newton-type nonlinear solvers.
    *
    * Newton solver class for solving nonlinear systems through a
-   * Variational::ProblemBase that assembles the tangent system at each iterate:
+   * <a href="_variational_2_problem_8h.html">Variational::ProblemBase</a>
+   * that assembles the tangent system at each iterate:
    * @f[
    * J(u^k)\,\delta u^k = -F(u^k), \qquad
    * u^{k + 1} = u^k + \delta u^k.
    * @f]
    *
    * The linear solver is passed by reference at construction time.
-   * The associated ProblemBase is obtained from the solver via
-   * LinearSolverBase::getProblem().
+   * The associated
+   * <a href="_variational_2_problem_8h.html">ProblemBase</a>
+   * is obtained from the solver via
+   * @ref LinearSolverBase "LinearSolverBase::getProblem()".
    *
    * @tparam LinearSolver Type of the linear solver used at each Newton step.
    *   Must have a FormLanguage::Traits specialization providing LinearSystemType.
@@ -182,12 +185,14 @@ namespace Rodin::Solver
    * used both as the initial guess and as the storage for the final iterate.
    *
    * @par Associated tangential problem
-   * The solver obtains the tangential @c Variational::ProblemBase from the
-   * supplied linear solver through @c LinearSolverBase::getProblem().
+   * The solver obtains the tangential
+   * <a href="_variational_2_problem_8h.html">Variational::ProblemBase</a>
+   * from the supplied linear solver through
+   * @ref LinearSolverBase "LinearSolverBase::getProblem()".
    * At each Newton iteration:
    * - the tangential problem is reassembled by calling @c assemble(),
    * - the assembled linear system is accessed through
-   *   @c ProblemBase::getLinearSystem(),
+   *   <a href="_variational_2_problem_8h.html">ProblemBase::getLinearSystem()</a>,
    * - the linear correction is computed by the associated linear solver.
    *
    * @par Contract

--- a/src/Rodin/Solver/PartialPivLU.h
+++ b/src/Rodin/Solver/PartialPivLU.h
@@ -34,7 +34,7 @@
  * - Eigen's PartialPivLU assumes the matrix is square and invertible.
  * - If rank deficiency is possible and must be handled robustly, FullPivLU is safer.
  *
- * @see Eigen::PartialPivLU
+ * @see <a href="https://eigen.tuxfamily.org/dox/classEigen_1_1PartialPivLU.html">Eigen::PartialPivLU</a>
  */
 #ifndef RODIN_SOLVER_PARTIALPIVLU_H
 #define RODIN_SOLVER_PARTIALPIVLU_H

--- a/src/Rodin/Solver/SPQR.h
+++ b/src/Rodin/Solver/SPQR.h
@@ -39,7 +39,7 @@
  * @note This solver requires SPQR from SuiteSparse to be installed
  * and RODIN_USE_SPQR to be defined at compile time.
  *
- * @see SPQR for the solver implementation
+ * @see <a href="_s_p_q_r_8h.html">SPQR</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_SPQR_H
 #define RODIN_SOLVER_SPQR_H
@@ -74,7 +74,7 @@ namespace Rodin::Solver
   /**
    * @defgroup SPQRSpecializations SPQR Template Specializations
    * @brief Template specializations of the SPQR class.
-   * @see SPQR
+   * @see @ref SPQR
    */
 
   /**

--- a/src/Rodin/Solver/SimplicialLDLT.h
+++ b/src/Rodin/Solver/SimplicialLDLT.h
@@ -34,7 +34,7 @@
  * solver.solve();
  * ```
  *
- * @see SimplicialLDLT for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_simplicial_l_d_l_t.html">SimplicialLDLT</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_SIMPLICIALLDLT_H
 #define RODIN_SOLVER_SIMPLICIALLDLT_H
@@ -63,7 +63,7 @@ namespace Rodin::Solver
   /**
    * @defgroup SimplicialLDLTSpecializations SimplicialLDLT Template Specializations
    * @brief Template specializations of the SimplicialLDLT class.
-   * @see SimplicialLDLT
+   * @see @ref SimplicialLDLT
    */
 
   /**

--- a/src/Rodin/Solver/SimplicialLLT.h
+++ b/src/Rodin/Solver/SimplicialLLT.h
@@ -35,7 +35,7 @@
  * solver.solve();
  * ```
  *
- * @see SimplicialLLT for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_simplicial_l_l_t.html">SimplicialLLT</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_SIMPLICIALLLT_H
 #define RODIN_SOLVER_SIMPLICIALLLT_H
@@ -65,7 +65,7 @@ namespace Rodin::Solver
   /**
    * @defgroup SimplicialLLTSpecializations SimplicialLLT Template Specializations
    * @brief Template specializations of the SimplicialLLT class.
-   * @see SimplicialLLT
+   * @see @ref SimplicialLLT
    */
 
   /**

--- a/src/Rodin/Solver/SparseLU.h
+++ b/src/Rodin/Solver/SparseLU.h
@@ -34,7 +34,7 @@
  * solver.solve();
  * ```
  *
- * @see SparseLU for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_sparse_l_u.html">SparseLU</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_SPARSELU_H
 #define RODIN_SOLVER_SPARSELU_H
@@ -63,7 +63,7 @@ namespace Rodin::Solver
   /**
    * @defgroup SparseLUSpecializations SparseLU Template Specializations
    * @brief Template specializations of the SparseLU class.
-   * @see SparseLU
+   * @see @ref SparseLU
    */
 
   /**

--- a/src/Rodin/Solver/SparseQR.h
+++ b/src/Rodin/Solver/SparseQR.h
@@ -35,7 +35,7 @@
  * solver.solve();
  * ```
  *
- * @see SparseQR for the solver implementation
+ * @see <a href="class_rodin_1_1_solver_1_1_sparse_q_r.html">SparseQR</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_SPARSEQR_H
 #define RODIN_SOLVER_SPARSEQR_H
@@ -65,7 +65,7 @@ namespace Rodin::Solver
   /**
    * @defgroup SparseQRSpecializations SparseQR Template Specializations
    * @brief Template specializations of the SparseQR class.
-   * @see SparseQR
+   * @see @ref SparseQR
    */
 
   /**

--- a/src/Rodin/Solver/UMFPack.h
+++ b/src/Rodin/Solver/UMFPack.h
@@ -40,7 +40,7 @@
  * @note This solver requires UMFPACK from SuiteSparse to be installed
  * and RODIN_USE_UMFPACK to be defined at compile time.
  *
- * @see UMFPack for the solver implementation
+ * @see <a href="_u_m_f_pack_8h.html">UMFPack</a> for the solver implementation
  */
 #ifndef RODIN_SOLVER_UMFPACK_H
 #define RODIN_SOLVER_UMFPACK_H
@@ -72,7 +72,7 @@ namespace Rodin::Solver
   /**
    * @defgroup UMFPackSpecializations UMFPack Template Specializations
    * @brief Template specializations of the UMFPack class.
-   * @see UMFPack
+   * @see @ref UMFPack
    */
 
   /**
@@ -210,5 +210,3 @@ namespace Rodin::Solver
 
 #endif // #ifdef RODIN_USE_UMFPACK
 #endif
-
-

--- a/src/Rodin/Test.h
+++ b/src/Rodin/Test.h
@@ -15,7 +15,7 @@
  * implementations, including convergence tests, manufactured solutions, and
  * error analysis tools.
  *
- * @see Rodin::Test
+ * @see <a href="namespace_rodin_1_1_test.html">Rodin::Test</a>
  */
 
 #endif

--- a/src/Rodin/Test/FDProbe.h
+++ b/src/Rodin/Test/FDProbe.h
@@ -54,6 +54,11 @@ namespace Rodin::Test
    * constrained DOFs are zero.
    *
    * @tparam ProblemType Rodin variational problem type.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref FDProbe "FDProbe<ProblemType>" | Nonlinear problem probe comparing assembled tangent actions against central finite differences. |
+   * | @ref FDProbe "FDProbe<Math::LinearSystem<Operator, Vector>>" | Linear-system probe comparing @f$Aw@f$ against finite differences of @f$Ax-b@f$. |
    */
   template <class ProblemType>
   class FDProbe

--- a/src/Rodin/Threads.h
+++ b/src/Rodin/Threads.h
@@ -20,7 +20,7 @@
  * - **Unsafe**: Markers for non-thread-safe operations
  * - **Mutable**: Thread-safe mutable state wrappers
  *
- * @see Rodin::Threads
+ * @see <a href="namespace_rodin_1_1_threads.html">Rodin::Threads</a>
  */
 
 #include "Threads/Mutex.h"

--- a/src/Rodin/Tuple.h
+++ b/src/Rodin/Tuple.h
@@ -16,8 +16,8 @@
  * These operations are useful for compile-time metaprogramming and type-safe
  * container manipulation.
  *
- * @see Rodin::Tuple
- * @see Rodin::Pair
+ * @see <a href="class_rodin_1_1_tuple.html">Rodin::Tuple</a>
+ * @see <a href="class_rodin_1_1_pair.html">Rodin::Pair</a>
  */
 
 #include <tuple>

--- a/src/Rodin/Utility.h
+++ b/src/Rodin/Utility.h
@@ -23,7 +23,7 @@
  * - **Helper Constructs**: Overloaded, Make, OptionalReference, Cast
  * - **Compile-Time Values**: False, DependentValue, IntegerSequence
  *
- * @see Rodin::Utility
+ * @see <a href="namespace_rodin_1_1_utility.html">Rodin::Utility</a>
  */
 
 #include "Utility/Overloaded.h"

--- a/src/Rodin/Utility/Wrap.h
+++ b/src/Rodin/Utility/Wrap.h
@@ -25,6 +25,11 @@ namespace Rodin::Utility
    *
    * Wrap takes a Tuple type and an external template, and produces a new
    * Tuple where each element type has been wrapped with the external template.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Wrap "Wrap<...>" | Undefined primary template used to restrict the metafunction to supported pack shapes. |
+   * | @ref Wrap "Wrap<Tuple<Ts...>>" | Tuple specialization that maps an external unary template over every tuple element. |
    */
   template <class ...>
   class Wrap;

--- a/src/Rodin/Variational/Average.h
+++ b/src/Rodin/Variational/Average.h
@@ -31,7 +31,12 @@ namespace Rodin::Variational
   /**
    * @defgroup AverageSpecializations Average Template Specializations
    * @brief Template specializations of the Average class.
-   * @see Average
+   * @see @ref Average
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Average "Average<FunctionBase<FunctionDerived>>" | Arithmetic average of a traceable function across an interior interface. |
+   * | @ref Average "Average<ShapeFunctionBase<NestedDerived, FES, Space>>" | Arithmetic average of a test or trial shape function across an interior interface. |
    */
 
   /**
@@ -63,7 +68,7 @@ namespace Rodin::Variational
    *
    * @tparam FunctionDerived Type of the function being averaged
    *
-   * @see Jump
+   * @see @ref Jump
    */
   template <class FunctionDerived>
   class Average<FunctionBase<FunctionDerived>> final

--- a/src/Rodin/Variational/BilinearForm.h
+++ b/src/Rodin/Variational/BilinearForm.h
@@ -61,7 +61,12 @@ namespace Rodin::Variational
   /**
    * @defgroup BilinearFormSpecializations BilinearForm Template Specializations
    * @brief Template specializations of the BilinearForm class.
-   * @see BilinearForm
+   * @see <a href="_variational_2_bilinear_form_8h.html">BilinearForm</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref BilinearForm "BilinearForm<Solution, TrialFES, TestFES, Math::SparseMatrix<Scalar>>" | Bilinear form assembled into a sparse matrix operator. |
+   * | @ref BilinearForm "BilinearForm<Solution, TrialFES, TestFES, Math::Matrix<Scalar>>" | Bilinear form assembled into a dense matrix operator. |
    */
 
   /**

--- a/src/Rodin/Variational/BoundaryIntegral.h
+++ b/src/Rodin/Variational/BoundaryIntegral.h
@@ -52,6 +52,11 @@ namespace Rodin::Variational
    * @brief Template specializations of the BoundaryIntegral class.
    *
    * @see BoundaryIntegral
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref BoundaryIntegral "BoundaryIntegral<Dot<TrialShapeFunction, TestShapeFunction>>" | Boundary integral of a trial/test dot product. |
+   * | @ref BoundaryIntegral "BoundaryIntegral<ShapeFunctionBase<Dot<FunctionBase, TestShapeFunction>>>" | Boundary integral of a test operator. |
    */
 
   /**

--- a/src/Rodin/Variational/ComplexFunction.h
+++ b/src/Rodin/Variational/ComplexFunction.h
@@ -26,6 +26,13 @@ namespace Rodin::Variational
    * @defgroup ComplexFunctionSpecializations ComplexFunction Template Specializations
    * @brief Template specializations of the ComplexFunction class.
    * @see ComplexFunction
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref ComplexFunction "ComplexFunction<Complex>" | Constant complex-valued function. |
+   * | @ref ComplexFunction "ComplexFunction<FunctionBase<NestedDerived>>" | Complex wrapper around a nested function. |
+   * | @ref ComplexFunction "ComplexFunction<FunctionBase<Real>, FunctionBase<Imaginary>>" | Complex function assembled from real and imaginary parts. |
+   * | @ref ComplexFunction "ComplexFunction<F>" | Complex function constructed from an arbitrary scalar callable. |
    */
 
   /**

--- a/src/Rodin/Variational/Conjugate.h
+++ b/src/Rodin/Variational/Conjugate.h
@@ -38,7 +38,12 @@ namespace Rodin::Variational
   /**
    * @defgroup ConjugateSpecializations Conjugate Template Specializations
    * @brief Template specializations of the Conjugate class.
-   * @see Conjugate
+   * @see @ref Conjugate
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Conjugate "Conjugate<FunctionBase<NestedDerived>>" | Pointwise complex conjugate of a function expression. |
+   * | @ref Conjugate "Conjugate<ShapeFunctionBase<NestedDerived, FES, Space>>" | Complex conjugate of a test or trial shape function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/Derivative.h
+++ b/src/Rodin/Variational/Derivative.h
@@ -65,7 +65,12 @@ namespace Rodin::FormLanguage
 /**
  * @defgroup DerivativeSpecializations Derivative Template Specializations
  * @brief Template specializations of the Derivative class.
- * @see Derivative
+ * @see @ref Derivative
+ *
+ * | Specialization | Description |
+ * |----------------|-------------|
+ * | @ref Derivative "Derivative<H1<K, Scalar, Mesh>, ShapeFunction<NestedDerived, H1<K, Scalar, Mesh>, Space>>" | Directional derivative of an H1 shape function. |
+ * | @ref Derivative "Derivative<P1<Range, Mesh>, GridFunction<P1<Range, Mesh>, Data>>" | Directional derivative of a P1 grid function. |
  */
 
 namespace Rodin::Variational

--- a/src/Rodin/Variational/DirichletBC.h
+++ b/src/Rodin/Variational/DirichletBC.h
@@ -236,6 +236,11 @@ namespace Rodin::Variational
    * @defgroup DirichletBCSpecializations DirichletBC Template Specializations
    * @brief Template specializations of the DirichletBC class.
    * @see DirichletBC
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref DirichletBC "DirichletBC<TrialFunction<Solution, FES>, FunctionBase<FunctionDerived>>" | Value-prescribing condition @f$u=g@f$. |
+   * | @ref DirichletBC "DirichletBC<TrialFunction<Solution, FES>, Identification>" | Linear-in-DOFs identification condition between trial functions. |
    */
 
   /**

--- a/src/Rodin/Variational/Div.h
+++ b/src/Rodin/Variational/Div.h
@@ -42,7 +42,17 @@ namespace Rodin::Variational
   /**
     * @defgroup DivSpecializations Div Template Specializations
     * @brief Template specializations of the Div class.
-    * @see Div
+    * @see @ref Div
+    *
+    * | Specialization | Description |
+    * |----------------|-------------|
+    * | @ref DivBase "DivBase<GridFunction<FES, Data>, Derived>" | Generic divergence base for vector-valued grid functions. |
+    * | @ref Div "Div<P0g<Scalar, Mesh>, GridFunction<P0g<Scalar, Mesh>, Data>>" | Divergence of a discontinuous P0g grid function. |
+    * | @ref Div "Div<P0g<Scalar, Mesh>, ShapeFunction<NestedDerived, P0g<Scalar, Mesh>, Space>>" | Divergence of a P0g shape-function expression. |
+    * | @ref Div "Div<H1<K, Scalar, Mesh>, GridFunction<H1<K, Scalar, Mesh>, Data>>" | Divergence of an H1 grid function. |
+    * | @ref Div "Div<H1<K, Scalar, Mesh>, ShapeFunction<NestedDerived, H1<K, Scalar, Mesh>, Space>>" | Divergence of an H1 shape-function expression. |
+    * | @ref Div "Div<P1<Scalar, Mesh>, GridFunction<P1<Scalar, Mesh>, Data>>" | Divergence of a P1 grid function. |
+    * | @ref Div "Div<P1<Scalar, Mesh>, ShapeFunction<NestedDerived, P1<Scalar, Mesh>, Space>>" | Divergence of a P1 shape-function expression. |
     */
 
   /**

--- a/src/Rodin/Variational/Dot.h
+++ b/src/Rodin/Variational/Dot.h
@@ -143,6 +143,14 @@ namespace Rodin::Variational
    * Provides dot product (inner product) operations for:
    * - Function × Function → Real-valued function
    * - Function × ShapeFunction → Real-valued shape function  
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Dot "Dot<FunctionBase<LHS>, FunctionBase<RHS>>" | Pointwise dot product of two function expressions. |
+   * | @ref Dot "Dot<FunctionBase<LHS>, ShapeFunctionBase<RHS, FES, Space>>" | Dot product of a function with a shape function. |
+   * | @ref Dot "Dot<ShapeFunctionBase<LHS, FES, Space>, FunctionBase<RHS>>" | Dot product of a shape function with a function expression. |
+   * | @ref Dot "Dot<ShapeFunctionBase<LHS>, ShapeFunctionBase<RHS>>" | Dot product of trial and test shape functions. |
+   * | @ref Dot "Dot<Potential, ShapeFunctionBase>" | Dot product of a potential with a test shape function. |
    * - ShapeFunction × Function → Real-valued shape function
    * - ShapeFunction × ShapeFunction → Bilinear form entry
    *

--- a/src/Rodin/Variational/FaceIntegral.h
+++ b/src/Rodin/Variational/FaceIntegral.h
@@ -36,7 +36,10 @@
  * auto symmetry = FaceIntegral(Jump(u), Average(Grad(v)));
  * ```
  *
- * @see InterfaceIntegral, BoundaryIntegral, Jump, Average
+ * @see <a href="_interface_integral_8h.html">InterfaceIntegral</a>
+ * @see <a href="_boundary_integral_8h.html">BoundaryIntegral</a>
+ * @see <a href="_jump_8h.html">Jump</a>
+ * @see <a href="_average_8h.html">Average</a>
  */
 #ifndef RODIN_VARIATIONAL_FACEINTEGRAL_H
 #define RODIN_VARIATIONAL_FACEINTEGRAL_H
@@ -56,6 +59,11 @@ namespace Rodin::Variational
    * @brief Template specializations of the FaceIntegral class.
    *
    * @see FaceIntegral
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref FaceIntegral "FaceIntegral<Dot<TrialShapeFunction, TestShapeFunction>>" | Face integral of a trial/test dot product. |
+   * | @ref FaceIntegral "FaceIntegral<ShapeFunctionBase<Dot<FunctionBase, TestShapeFunction>>>" | Face integral of a test operator. |
    */
 
   /**

--- a/src/Rodin/Variational/FaceNormal.h
+++ b/src/Rodin/Variational/FaceNormal.h
@@ -104,7 +104,10 @@
  * auto un = Dot(velocity, n);
  * ```
  *
- * @see BoundaryNormal, InterfaceIntegral, Jump, Average
+ * @see <a href="_boundary_normal_8h.html">BoundaryNormal</a>
+ * @see <a href="_interface_integral_8h.html">InterfaceIntegral</a>
+ * @see <a href="_jump_8h.html">Jump</a>
+ * @see <a href="_average_8h.html">Average</a>
  */
 #ifndef RODIN_VARIATIONAL_FACENORMAL_H
 #define RODIN_VARIATIONAL_FACENORMAL_H

--- a/src/Rodin/Variational/FiniteElement.h
+++ b/src/Rodin/Variational/FiniteElement.h
@@ -37,7 +37,9 @@
  * - 2D: Triangle (vertices at (0,0), (1,0), (0,1)) or quadrilateral [0,1]²
  * - 3D: Tetrahedron, hexahedron, prism, pyramid
  *
- * @see P0, P1, FiniteElementSpace
+ * @see <a href="class_rodin_1_1_variational_1_1_p0.html">P0</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
+ * @see <a href="_variational_2_finite_element_space_8h.html">FiniteElementSpace</a>
  */
 #ifndef RODIN_VARIATIONAL_FINITEELEMENT_H
 #define RODIN_VARIATIONAL_FINITEELEMENT_H

--- a/src/Rodin/Variational/Function.h
+++ b/src/Rodin/Variational/Function.h
@@ -136,7 +136,7 @@ namespace Rodin::Variational
        *
        * @param[in] i Component index
        * @returns Component function object
-       * @see Component
+       * @see <a href="_component_8h.html">Component</a>
        */
       auto operator()(size_t i) const
       {
@@ -149,7 +149,7 @@ namespace Rodin::Variational
        * @param[in] i Row index
        * @param[in] j Column index
        * @returns Component function object
-       * @see Component
+       * @see <a href="_component_8h.html">Component</a>
        */
       auto operator()(size_t i, size_t j) const
       {
@@ -192,7 +192,7 @@ namespace Rodin::Variational
        * For matrix-valued functions @f$ A(x) @f$, returns @f$ A^T(x) @f$.
        *
        * @returns Transposed function object
-       * @see Transpose
+       * @see <a href="_transpose_8h.html">Transpose</a>
        */
       constexpr
       auto T() const
@@ -209,7 +209,7 @@ namespace Rodin::Variational
        *
        * @param[in] attr Mesh attribute defining the trace domain
        * @returns Reference to self (for method chaining)
-       * @see getTraceDomain
+       * @see getTraceDomain()
        */
       constexpr
       Derived& traceOf(const Geometry::Attribute& attr)
@@ -241,7 +241,7 @@ namespace Rodin::Variational
        *
        * @param[in] attr Set of mesh attributes defining the trace domain
        * @returns Reference to self (for method chaining)
-       * @see getTraceDomain
+       * @see getTraceDomain()
        */
       constexpr
       Derived& traceOf(const FlatSet<Geometry::Attribute>& attr)

--- a/src/Rodin/Variational/Grad.h
+++ b/src/Rodin/Variational/Grad.h
@@ -61,7 +61,17 @@ namespace Rodin::Variational
   /**
    * @defgroup GradSpecializations Grad Template Specializations
    * @brief Template specializations of the Grad class.
-   * @see Grad
+   * @see @ref Grad
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GradBase "GradBase<GridFunction<FES, Data>, Derived>" | Generic gradient base for scalar grid functions. |
+   * | @ref Grad "Grad<H1<K, Scalar, Mesh>, GridFunction<H1<K, Scalar, Mesh>, Data>>" | Gradient of an H1 grid function. |
+   * | @ref Grad "Grad<H1<K, Scalar, Mesh>, ShapeFunction<NestedDerived, H1<K, Scalar, Mesh>, Space>>" | Gradient of an H1 shape-function expression. |
+   * | @ref Grad "Grad<P1<Range, Mesh>, GridFunction<P1<Range, Mesh>, Data>>" | Gradient of a P1 grid function. |
+   * | @ref Grad "Grad<P1<Range, Mesh>, ShapeFunction<NestedDerived, P1<Range, Mesh>, Space>>" | Gradient of a P1 shape-function expression. |
+   * | @ref Grad "Grad<P0<Range, Mesh>, GridFunction<P0<Range, Mesh>, Data>>" | Gradient of a P0 grid function. |
+   * | @ref Grad "Grad<P0<Range, Mesh>, ShapeFunction<NestedDerived, P0<Range, Mesh>, Space>>" | Gradient of a P0 shape-function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -44,7 +44,8 @@
  * u.save("solution.vtu");
  * ```
  *
- * @see TrialFunction, FiniteElementSpace
+ * @see <a href="_variational_2_trial_function_8h.html">TrialFunction</a>
+ * @see <a href="_variational_2_finite_element_space_8h.html">FiniteElementSpace</a>
  */
 #ifndef RODIN_VARIATIONAL_GRIDFUNCTION_H
 #define RODIN_VARIATIONAL_GRIDFUNCTION_H
@@ -103,7 +104,12 @@ namespace Rodin::Variational
   /**
    * @defgroup GridFunctionSpecializations GridFunction Template Specializations
    * @brief Template specializations of the GridFunction class.
-   * @see GridFunction
+   * @see <a href="_variational_2_grid_function_8h.html">GridFunction</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref GridFunction "GridFunction<FES, Math::Vector<Scalar>>" | Grid function backed by a dense local vector. |
+   * | @ref GridFunction "GridFunction<FES, Vec>" | Grid function backed by a PETSc vector for distributed assembly. |
    */
 
   /**

--- a/src/Rodin/Variational/GridFunction.h
+++ b/src/Rodin/Variational/GridFunction.h
@@ -300,7 +300,8 @@ namespace Rodin::Variational
    *
    * @par Coefficients vs values
    * For nodal spaces of degree one (@ref P1 "P1") the coefficient vector
-   * holds vertex values. For higher-order spaces (`H1\<K\>`,
+   * holds vertex values. For higher-order spaces
+   * (<a href="_variational_2_h1_8h.html">H1&lt;K&gt;</a>,
    * @f$ K \ge 2 @f$) the underlying basis is not plain nodal Lagrange, and
    * @b coefficients @b are @b not @b nodal @b values: always evaluate
    * through getValue() (or the element basis) instead of reading the data

--- a/src/Rodin/Variational/H1/Derivative.h
+++ b/src/Rodin/Variational/H1/Derivative.h
@@ -21,7 +21,9 @@
  * For H1<K> elements, partial derivatives are polynomial of degree K-1 on
  * each element.
  *
- * @see Derivative, Grad, H1
+ * @see <a href="_derivative_8h.html">Derivative</a>
+ * @see <a href="_grad_8h.html">Grad</a>
+ * @see <a href="_variational_2_h1_8h.html">H1</a>
  */
 
 #include "Rodin/Geometry/Mesh.h"

--- a/src/Rodin/Variational/H1/ForwardDecls.h
+++ b/src/Rodin/Variational/H1/ForwardDecls.h
@@ -32,6 +32,11 @@ namespace Rodin::Variational
    * @note For an overview of all the possible specializations of the
    * H1 class, please see @ref H1ElementSpecializations.
    *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref H1Element "H1Element<K, Scalar>" | Scalar-valued H1-conforming Lagrange element of degree `K`. |
+   * | @ref H1Element "H1Element<K, SpatialVector<Scalar>>" | Vector-valued H1-conforming Lagrange element of degree `K`. |
+   *
    * @see H1ElementSpecializations
    */
   template <size_t K, class Range>
@@ -49,6 +54,13 @@ namespace Rodin::Variational
    *
    * @note For an overview of all the possible specializations of the
    * H1 class, please see @ref H1Specializations.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref H1 "H1<K, Scalar, Mesh<Context::Local>>" | Scalar-valued local-mesh H1-conforming space of degree `K`. |
+   * | @ref H1 "H1<K, SpatialVector<Scalar>, Mesh<Context::Local>>" | Vector-valued local-mesh H1-conforming space of degree `K`. |
+   * | @ref H1 "H1<K, Scalar, Mesh<Context::MPI>>" | Scalar-valued distributed H1-conforming space of degree `K`. |
+   * | @ref H1 "H1<K, SpatialVector<Scalar>, Mesh<Context::MPI>>" | Vector-valued distributed H1-conforming space of degree `K`. |
    *
    * @see H1Specializations
    */

--- a/src/Rodin/Variational/H1/Grad.h
+++ b/src/Rodin/Variational/H1/Grad.h
@@ -32,9 +32,7 @@
 namespace Rodin::Variational
 {
   /**
-   * @defgroup GradSpecializations Grad Template Specializations
-   * @brief Template specializations of the Grad class.
-   * @see Grad
+   * @addtogroup GradSpecializations
    */
 
   /**

--- a/src/Rodin/Variational/H1/H1.h
+++ b/src/Rodin/Variational/H1/H1.h
@@ -69,6 +69,13 @@ namespace Rodin::Variational
    * @defgroup H1Specializations H1 Template Specializations
    * @brief Template specializations of the H1 class.
    * @see H1
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref H1 "H1<K, Scalar, Mesh<Context::Local>>" | Scalar-valued local-mesh Lagrange space of degree @f$K@f$. |
+   * | @ref H1 "H1<K, SpatialVector<Scalar>, Mesh<Context::Local>>" | Vector-valued local-mesh Lagrange space of degree @f$K@f$. |
+   * | @ref H1 "H1<K, Scalar, Mesh<Context::MPI>>" | Scalar-valued distributed-mesh Lagrange space of degree @f$K@f$. |
+   * | @ref H1 "H1<K, SpatialVector<Scalar>, Mesh<Context::MPI>>" | Vector-valued distributed-mesh Lagrange space of degree @f$K@f$. |
    */
 
   template <size_t K, class Range, class Mesh = Geometry::Mesh<Context::Local>>

--- a/src/Rodin/Variational/H1/H1Element.h
+++ b/src/Rodin/Variational/H1/H1Element.h
@@ -18,9 +18,9 @@
  * - Arbitrary polynomial degree K
  * - Support for scalar and vector-valued fields
  *
- * @see H1Element
- * @see RealH1Element
- * @see VectorH1Element
+ * @see <a href="_h1_element_8h.html">H1Element</a>
+ * @see <a href="_h1_element_8h.html">RealH1Element</a>
+ * @see <a href="_h1_element_8h.html">VectorH1Element</a>
  */
 
 #include <cstddef>
@@ -83,6 +83,11 @@ namespace Rodin::Variational
    * @defgroup H1ElementSpecializations H1Element Template Specializations
    * @brief Template specializations of the H1Element class.
    * @see H1Element
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref H1Element "H1Element<K, Scalar>" | Scalar-valued continuous Lagrange element of degree @f$K@f$. |
+   * | @ref H1Element "H1Element<K, SpatialVector<Scalar>>" | Vector-valued continuous Lagrange element of degree @f$K@f$. |
    */
 
   /**

--- a/src/Rodin/Variational/H1/Jacobian.h
+++ b/src/Rodin/Variational/H1/Jacobian.h
@@ -23,7 +23,10 @@
  *
  * For H1<K> elements, the Jacobian is polynomial of degree K-1 on each element.
  *
- * @see Jacobian, H1, Grad, Div
+ * @see <a href="_jacobian_8h.html">Jacobian</a>
+ * @see <a href="_variational_2_h1_8h.html">H1</a>
+ * @see <a href="_grad_8h.html">Grad</a>
+ * @see <a href="_div_8h.html">Div</a>
  */
 #ifndef RODIN_VARIATIONAL_H1_JACOBIAN_H
 #define RODIN_VARIATIONAL_H1_JACOBIAN_H

--- a/src/Rodin/Variational/Integral.h
+++ b/src/Rodin/Variational/Integral.h
@@ -65,6 +65,12 @@ namespace Rodin::Variational
    * @brief Template specializations of the Integral class.
    *
    * @see Integral
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Integral "Integral<Dot<TrialShapeFunction, TestShapeFunction>>" | Integral of a trial/test dot product. |
+   * | @ref Integral "Integral<ShapeFunctionBase<Dot<FunctionBase, TestShapeFunction>>>" | Integral of a test operator. |
+   * | @ref Integral "Integral<GridFunction<FES, Data>>" | Integral of a discrete grid function. |
    */
 
   /**

--- a/src/Rodin/Variational/Integrator.h
+++ b/src/Rodin/Variational/Integrator.h
@@ -46,7 +46,8 @@ namespace Rodin::Variational
    * 3. Local contributions are mapped to global indices
    * 4. Global matrix/vector is updated with local contributions
    *
-   * @see LinearFormIntegratorBase, BilinearFormIntegratorBase
+   * @see <a href="_linear_form_integrator_8h.html">LinearFormIntegratorBase</a>
+   * @see <a href="_bilinear_form_integrator_8h.html">BilinearFormIntegratorBase</a>
    */
   class Integrator : public FormLanguage::Base
   {

--- a/src/Rodin/Variational/InterfaceIntegral.h
+++ b/src/Rodin/Variational/InterfaceIntegral.h
@@ -44,7 +44,10 @@
  * auto symmetry = InterfaceIntegral(Jump(u), Average(Grad(v)));
  * ```
  *
- * @see FaceIntegral, BoundaryIntegral, Jump, Average
+ * @see <a href="_face_integral_8h.html">FaceIntegral</a>
+ * @see <a href="_boundary_integral_8h.html">BoundaryIntegral</a>
+ * @see <a href="_jump_8h.html">Jump</a>
+ * @see <a href="_average_8h.html">Average</a>
  */
 #ifndef RODIN_VARIATIONAL_INTERFACEINTEGRAL_H
 #define RODIN_VARIATIONAL_INTERFACEINTEGRAL_H
@@ -62,7 +65,12 @@ namespace Rodin::Variational
    * @defgroup InterfaceIntegralSpecializations InterfaceIntegral Template Specializations
    * @brief Template specializations of the InterfaceIntegral class.
    *
-   * @see InterfaceIntegral
+   * @see @ref InterfaceIntegral
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref InterfaceIntegral "InterfaceIntegral<Dot<ShapeFunctionBase<LHSDerived, TrialFES, TrialSpace>, ShapeFunctionBase<RHSDerived, TestFES, TestSpace>>>" | Interior-face bilinear integrator for dot products of trial and test shape-function expressions. |
+   * | @ref InterfaceIntegral "InterfaceIntegral<FunctionBase<FunctionDerived>>" | Interior-face integrator for a general function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/Jacobian.h
+++ b/src/Rodin/Variational/Jacobian.h
@@ -53,7 +53,17 @@ namespace Rodin::Variational
   /**
    * @defgroup JacobianSpecializations Jacobian Template Specializations
    * @brief Template specializations of the Jacobian class.
-   * @see Jacobian
+   * @see @ref Jacobian
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref JacobianBase "JacobianBase<GridFunction<FES, Data>, Derived>" | Generic Jacobian base for vector-valued grid functions. |
+   * | @ref Jacobian "Jacobian<P0g<Scalar, Mesh>, GridFunction<P0g<Scalar, Mesh>, Data>>" | Jacobian of a discontinuous P0g grid function. |
+   * | @ref Jacobian "Jacobian<P0g<Scalar, Mesh>, ShapeFunction<NestedDerived, P0g<Scalar, Mesh>, Space>>" | Jacobian of a P0g shape-function expression. |
+   * | @ref Jacobian "Jacobian<H1<K, Scalar, Mesh>, GridFunction<H1<K, Scalar, Mesh>, Data>>" | Jacobian of an H1 grid function. |
+   * | @ref Jacobian "Jacobian<H1<K, Scalar, Mesh>, ShapeFunction<NestedDerived, H1<K, Scalar, Mesh>, Space>>" | Jacobian of an H1 shape-function expression. |
+   * | @ref Jacobian "Jacobian<P1<Range, Mesh>, GridFunction<P1<Range, Mesh>, Data>>" | Jacobian of a P1 grid function. |
+   * | @ref Jacobian "Jacobian<P1<Range, Mesh>, ShapeFunction<NestedDerived, P1<Range, Mesh>, Space>>" | Jacobian of a P1 shape-function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/Jump.h
+++ b/src/Rodin/Variational/Jump.h
@@ -32,7 +32,12 @@ namespace Rodin::Variational
   /**
    * @defgroup JumpSpecializations Jump Template Specializations
    * @brief Template specializations of the Jump class.
-   * @see Jump
+   * @see @ref Jump
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Jump "Jump<FunctionBase<FunctionDerived>>" | Jump of a traceable function across an interior interface. |
+   * | @ref Jump "Jump<ShapeFunctionBase<NestedDerived, FES, Space>>" | Jump of a test or trial shape function across an interior interface. |
    */
 
   /**
@@ -65,7 +70,7 @@ namespace Rodin::Variational
    *
    * @tparam FunctionDerived Type of the function being jumped
    *
-   * @see Average
+   * @see @ref Average
    */
   template <class FunctionDerived>
   class Jump<FunctionBase<FunctionDerived>> final

--- a/src/Rodin/Variational/MatrixFunction.h
+++ b/src/Rodin/Variational/MatrixFunction.h
@@ -40,7 +40,7 @@ namespace Rodin::Variational
   /**
    * @defgroup MatrixFunctionSpecializations MatrixFunction Template Specializations
    * @brief Template specializations of the MatrixFunction class.
-   * @see MatrixFunction
+   * @see <a href="_matrix_function_8h.html">MatrixFunction</a>
    */
 
   /**
@@ -66,7 +66,9 @@ namespace Rodin::Variational
    * - `A(i, j)` for the entry at row i, column j
    * - `A(i)` for the i-th row (returning a vector function)
    *
-   * @see FunctionBase, VectorFunction, Transpose
+   * @see <a href="class_rodin_1_1_variational_1_1_function_base.html">FunctionBase</a>
+   * @see <a href="_vector_function_8h.html">VectorFunction</a>
+   * @see <a href="_transpose_8h.html">Transpose</a>
    */
   template <class Scalar, class Derived>
   class MatrixFunctionBase : public FunctionBase<MatrixFunctionBase<Scalar, Derived>>

--- a/src/Rodin/Variational/Max.h
+++ b/src/Rodin/Variational/Max.h
@@ -22,7 +22,12 @@ namespace Rodin::Variational
   /**
    * @defgroup MaxSpecializations Max Template Specializations
    * @brief Template specializations of the Max class.
-   * @see Max
+   * @see @ref Max
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Max "Max<FunctionBase<LHSDerived>, FunctionBase<RHSDerived>>" | Pointwise maximum of two function expressions. |
+   * | @ref Max "Max<FunctionBase<NestedDerived>, Real>" | Pointwise maximum of a function expression and a scalar constant. |
    */
 
   /**

--- a/src/Rodin/Variational/Mult.h
+++ b/src/Rodin/Variational/Mult.h
@@ -152,7 +152,13 @@ namespace Rodin::Variational
   /**
    * @defgroup MultSpecializations Mult Template Specializations
    * @brief Template specializations of the Mult class.
-   * @see Mult
+   * @see @ref Mult
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Mult "Mult<FunctionBase<LHSDerived>, FunctionBase<RHSDerived>>" | Pointwise product of two function expressions. |
+   * | @ref Mult "Mult<FunctionBase<LHSDerived>, ShapeFunctionBase<RHSDerived, FES, Space>>" | Product of a function expression with a test or trial shape-function expression. |
+   * | @ref Mult "Mult<ShapeFunctionBase<LHSDerived, FES, Space>, FunctionBase<RHSDerived>>" | Product of a test or trial shape-function expression with a function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/P0/ForwardDecls.h
+++ b/src/Rodin/Variational/P0/ForwardDecls.h
@@ -20,9 +20,15 @@ namespace Rodin::Variational
    * @tparam Range Range value type
    *
    * @note For an overview of all the possible specializations of the
-   * P0 class, please see `P0Specializations`.
+   * P0 class, please see
+   * <a href="_variational_2_p0_8h.html">P0Specializations</a>.
    *
-   * @see P0ElementSpecializations
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0Element "P0Element<Scalar>" | Scalar-valued discontinuous piecewise constant element. |
+   * | @ref P0Element "P0Element<SpatialVector<Scalar>>" | Vector-valued discontinuous piecewise constant element. |
+   *
+   * @see <a href="_p0_element_8h.html">P0ElementSpecializations</a>
    */
   template <class Range>
   class P0Element;
@@ -41,9 +47,15 @@ namespace Rodin::Variational
    * for a given vector dimension @f$ d \in \mathbb{N} @f$.
    *
    * @note For an overview of all the possible specializations of the
-   * P0 class, please see `P0Specializations`.
+   * P0 class, please see
+   * <a href="_variational_2_p0_8h.html">P0Specializations</a>.
    *
-   * @see `P0Specializations`
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0 "P0<Real, Mesh<Context::Local>>" | Scalar-valued local-mesh discontinuous piecewise constant space. |
+   * | @ref P0 "P0<Range, Mesh<Context::MPI>>" | Scalar or vector-valued distributed-mesh discontinuous piecewise constant space. |
+   *
+   * @see <a href="_variational_2_p0_8h.html">P0Specializations</a>
    */
   template <class Range, class Mesh>
   class P0;
@@ -76,4 +88,3 @@ namespace Rodin::Variational
 }
 
 #endif
-

--- a/src/Rodin/Variational/P0/P0.h
+++ b/src/Rodin/Variational/P0/P0.h
@@ -59,7 +59,12 @@ namespace Rodin::Variational
   /**
    * @defgroup P0Specializations P0 Template Specializations
    * @brief Template specializations of the P0 class.
-   * @see P0
+   * @see <a href="class_rodin_1_1_variational_1_1_p0.html">P0</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0 "P0<Real, Mesh<Context::Local>>" | Scalar-valued local-mesh discontinuous piecewise constant space. |
+   * | @ref P0 "P0<Range, Mesh<Context::MPI>>" | Scalar or vector-valued distributed-mesh discontinuous piecewise constant space. |
    */
 
   template <class Range, class Mesh = Geometry::Mesh<Context::Local>>

--- a/src/Rodin/Variational/P0/P0Element.h
+++ b/src/Rodin/Variational/P0/P0Element.h
@@ -81,7 +81,12 @@ namespace Rodin::Variational
   /**
    * @defgroup P0ElementSpecializations P0Element Template Specializations
    * @brief Template specializations of the P0Element class.
-   * @see P0Element
+   * @see <a href="class_rodin_1_1_variational_1_1_p0_element.html">P0Element</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0Element "P0Element<Scalar>" | Scalar-valued discontinuous piecewise constant element. |
+   * | @ref P0Element "P0Element<SpatialVector<Scalar>>" | Vector-valued discontinuous piecewise constant element. |
    */
 
   /**

--- a/src/Rodin/Variational/P0g/ForwardDecls.h
+++ b/src/Rodin/Variational/P0g/ForwardDecls.h
@@ -14,12 +14,32 @@
 
 namespace Rodin::Variational
 {
+  /**
+   * @brief Forward declaration of global P0 finite elements.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0gElement "P0gElement<Scalar>" | Scalar global constant element with one basis function @f$1@f$. |
+   * | @ref P0gElement "P0gElement<Math::SpatialVector<Scalar>>" | Vector-valued global constant element with one constant basis vector per component. |
+   *
+   * @tparam Range Value range of the element.
+   */
   template <class Range>
   class P0gElement;
 
+  /**
+   * @brief Forward declaration of global constant finite element spaces.
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P0g "P0g<Real, Mesh<Context::Local>>" | Scalar global constant space on a local mesh with one degree of freedom. |
+   * | @ref P0g "P0g<Math::SpatialVector<Real>, Mesh<Context::Local>>" | Vector-valued global constant space on a local mesh with one degree of freedom per component. |
+   *
+   * @tparam Range Value range of the finite element space.
+   * @tparam Mesh Mesh type on which the space is defined.
+   */
   template <class Range, class Mesh>
   class P0g;
 }
 
 #endif
-

--- a/src/Rodin/Variational/P1/Derivative.h
+++ b/src/Rodin/Variational/P1/Derivative.h
@@ -22,7 +22,9 @@
  *
  * For P1 elements, partial derivatives are piecewise constant on each element.
  *
- * @see Derivative, Grad, P1
+ * @see <a href="_derivative_8h.html">Derivative</a>
+ * @see <a href="_grad_8h.html">Grad</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
  */
 
 #include "Rodin/Math/Vector.h"

--- a/src/Rodin/Variational/P1/ForwardDecls.h
+++ b/src/Rodin/Variational/P1/ForwardDecls.h
@@ -19,9 +19,15 @@ namespace Rodin::Variational
    * @tparam Range Range value type
    *
    * @note For an overview of all the possible specializations of the
-   * P1 class, please see `P1Specializations`.
+   * P1 class, please see
+   * <a href="_variational_2_p1_8h.html">P1Specializations</a>.
    *
-   * @see P1ElementSpecializations
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P1Element "P1Element<Scalar>" | Scalar-valued continuous piecewise linear element. |
+   * | @ref P1Element "P1Element<SpatialVector<Scalar>>" | Vector-valued continuous piecewise linear element. |
+   *
+   * @see <a href="_p1_element_8h.html">P1ElementSpecializations</a>
    */
   template <class Range>
   class P1Element;
@@ -40,9 +46,16 @@ namespace Rodin::Variational
    * for a given vector dimension @f$ d \in \mathbb{N} @f$.
    *
    * @note For an overview of all the possible specializations of the
-   * P1 class, please see `P1Specializations`.
+   * P1 class, please see
+   * <a href="_variational_2_p1_8h.html">P1Specializations</a>.
    *
-   * @see `P1Specializations`
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P1 "P1<Scalar, Mesh<Context::Local>>" | Scalar-valued local-mesh continuous piecewise linear space. |
+   * | @ref P1 "P1<SpatialVector<Scalar>, Mesh<Context::Local>>" | Vector-valued local-mesh continuous piecewise linear space. |
+   * | @ref P1 "P1<Range, Mesh<Context::MPI>>" | Scalar or vector-valued distributed-mesh continuous piecewise linear space. |
+   *
+   * @see <a href="_variational_2_p1_8h.html">P1Specializations</a>
    */
   template <class Range, class Mesh>
   class P1;

--- a/src/Rodin/Variational/P1/Grad.h
+++ b/src/Rodin/Variational/P1/Grad.h
@@ -31,9 +31,7 @@
 namespace Rodin::Variational
 {
   /**
-   * @defgroup GradSpecializations Grad Template Specializations
-   * @brief Template specializations of the Grad class.
-   * @see Grad
+   * @addtogroup GradSpecializations
    */
 
   /**

--- a/src/Rodin/Variational/P1/Jacobian.h
+++ b/src/Rodin/Variational/P1/Jacobian.h
@@ -24,7 +24,10 @@
  * For P1 elements, the Jacobian is piecewise constant on each element since
  * P1 basis function gradients are constant per element.
  *
- * @see Jacobian, P1, Grad, Div
+ * @see <a href="_jacobian_8h.html">Jacobian</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
+ * @see <a href="_grad_8h.html">Grad</a>
+ * @see <a href="_div_8h.html">Div</a>
  */
 #ifndef RODIN_VARIATIONAL_P1_JACOBIAN_H
 #define RODIN_VARIATIONAL_P1_JACOBIAN_H

--- a/src/Rodin/Variational/P1/LinearForm.h
+++ b/src/Rodin/Variational/P1/LinearForm.h
@@ -19,7 +19,8 @@
  *   L(v) = \int_\Omega f \cdot v \, dx + \int_{\partial\Omega} g \cdot v \, ds
  * @f]
  *
- * @see LinearForm, P1
+ * @see <a href="_variational_2_linear_form_8h.html">LinearForm</a>
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
  */
 #ifndef RODIN_VARIATIONAL_P1_LINEARFORM_H
 #define RODIN_VARIATIONAL_P1_LINEARFORM_H

--- a/src/Rodin/Variational/P1/P1.h
+++ b/src/Rodin/Variational/P1/P1.h
@@ -55,7 +55,13 @@ namespace Rodin::Variational
   /**
    * @defgroup P1Specializations P1 Template Specializations
    * @brief Template specializations of the P1 class.
-   * @see P1
+   * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P1 "P1<Scalar, Mesh<Context::Local>>" | Scalar-valued local-mesh continuous piecewise linear space. |
+   * | @ref P1 "P1<SpatialVector<Scalar>, Mesh<Context::Local>>" | Vector-valued local-mesh continuous piecewise linear space. |
+   * | @ref P1 "P1<Range, Mesh<Context::MPI>>" | Scalar or vector-valued distributed-mesh continuous piecewise linear space. |
    */
 
   template <class Range, class Mesh = Geometry::Mesh<Context::Local>>

--- a/src/Rodin/Variational/P1/P1Element.h
+++ b/src/Rodin/Variational/P1/P1Element.h
@@ -57,7 +57,12 @@ namespace Rodin::Variational
   /**
    * @defgroup P1ElementSpecializations P1Element Template Specializations
    * @brief Template specializations of the P1Element class.
-   * @see P1Element
+   * @see <a href="class_rodin_1_1_variational_1_1_p1_element.html">P1Element</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref P1Element "P1Element<Scalar>" | Scalar-valued continuous piecewise linear element. |
+   * | @ref P1Element "P1Element<SpatialVector<Scalar>>" | Vector-valued continuous piecewise linear element. |
    */
 
   /**

--- a/src/Rodin/Variational/P1/Potential.h
+++ b/src/Rodin/Variational/P1/Potential.h
@@ -14,7 +14,8 @@
  *
  * @note Current implementation is a placeholder for future development.
  *
- * @see P1, Integral
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
+ * @see <a href="_integral_8h.html">Integral</a>
  */
 #ifndef RODIN_VARIATIONAL_P1_POTENTIAL_H
 #define RODIN_VARIATIONAL_P1_POTENTIAL_H
@@ -34,4 +35,3 @@ namespace Rodin::Variational
 {}
 
 #endif
-

--- a/src/Rodin/Variational/P1/QuadratureRule.h
+++ b/src/Rodin/Variational/P1/QuadratureRule.h
@@ -31,7 +31,9 @@
  * evaluation when possible. Mixed trial/test P1 spaces are supported for the
  * mass, stiffness, and Jacobian forms.
  *
- * @see P1, QuadratureFormula, Integral
+ * @see <a href="class_rodin_1_1_variational_1_1_p1.html">P1</a>
+ * @see <a href="_quadrature_formula_8h.html">QuadratureFormula</a>
+ * @see <a href="_integral_8h.html">Integral</a>
  */
 #ifndef RODIN_VARIATIONAL_P1_QUADRATURERULE_H
 #define RODIN_VARIATIONAL_P1_QUADRATURERULE_H

--- a/src/Rodin/Variational/Potential.h
+++ b/src/Rodin/Variational/Potential.h
@@ -166,7 +166,12 @@ namespace Rodin::Variational
   /**
    * @defgroup PotentialSpecializations Potential Template Specializations
    * @brief Template specializations of the Potential class.
-   * @see Potential
+   * @see @ref Potential
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Potential "Potential<LHS, FunctionBase<RHSDerived>>" | Nonlocal potential operator applied to a function expression. |
+   * | @ref Potential "Potential<LHS, ShapeFunctionBase<RHSDerived, FES, Space>>" | Nonlocal potential operator applied to a test or trial shape-function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/Problem.h
+++ b/src/Rodin/Variational/Problem.h
@@ -93,6 +93,12 @@ namespace Rodin::Variational
    * @defgroup ProblemSpecializations Problem Template Specializations
    * @brief Template specializations of the Problem class.
    * @see Problem
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Problem "Problem<LinearSystem, U, V>" | Linear variational problem with one trial and one test function. |
+   * | @ref Problem "Problem<LinearSystem, U1, U2, U3, Us...>" | Mixed linear variational problem with three or more functions. |
+   * | @ref Problem "Problem<PETSc::LinearSystem, ...>" | PETSc-backed variational problem for distributed linear systems. |
    */
 
   /**

--- a/src/Rodin/Variational/QuadratureRule.h
+++ b/src/Rodin/Variational/QuadratureRule.h
@@ -66,8 +66,23 @@ namespace Rodin::Variational
    * @defgroup QuadratureRuleSpecializations QuadratureRule Template Specializations
    * @brief Template specializations of the QuadratureRule class.
    *
-   * @see QuadratureRule
-   * @see RodinQuadrature
+   * @see @ref QuadratureRule
+   * @see @ref RodinQuadrature
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref QuadratureRule "QuadratureRule<FunctionBase<FunctionDerived>>" | Generic quadrature rule for function expressions on mesh polytopes. |
+   * | @ref QuadratureRule "QuadratureRule<GridFunction<FES, Data>>" | Quadrature rule for grid-function values on mesh polytopes. |
+   * | @ref QuadratureRule "QuadratureRule<Dot<ShapeFunctionBase<LHSDerived, TrialFES, TrialSpace>, ShapeFunctionBase<RHSDerived, TestFES, TestSpace>>>" | Generic bilinear quadrature rule for trial/test dot products. |
+   * | @ref QuadratureRule "QuadratureRule<ShapeFunctionBase<NestedDerived, FES, TestSpace>>" | Generic linear quadrature rule for test shape functions. |
+   * | @ref QuadratureRule "QuadratureRule<H1<K, Scalar, Mesh>, Dot<Grad<Trial>, Grad<Test>>>" | H1 stiffness integrator for gradients of trial and test functions. |
+   * | @ref QuadratureRule "QuadratureRule<H1<K, Scalar, Mesh>, Dot<Trial, Test>>" | H1 mass integrator for trial/test dot products. |
+   * | @ref QuadratureRule "QuadratureRule<H1<K, Scalar, Mesh>, Dot<Coefficient, Test>>" | H1 linear-form integrator with a coefficient function. |
+   * | @ref QuadratureRule "QuadratureRule<H1<K, Scalar, Mesh>, Dot<Grad<Coefficient>, Grad<Test>>>" | H1 linear-form integrator for gradient coefficients. |
+   * | @ref QuadratureRule "QuadratureRule<P1<Range, Mesh>, Dot<Grad<Trial>, Grad<Test>>>" | P1 stiffness integrator for gradients of trial and test functions. |
+   * | @ref QuadratureRule "QuadratureRule<P1<Range, Mesh>, Dot<Trial, Test>>" | P1 mass integrator for trial/test dot products. |
+   * | @ref QuadratureRule "QuadratureRule<P1<Range, Mesh>, Dot<Coefficient, Test>>" | P1 linear-form integrator with a coefficient function. |
+   * | @ref QuadratureRule "QuadratureRule<P1<Range, Mesh>, Dot<Grad<Coefficient>, Grad<Test>>>" | P1 linear-form integrator for gradient coefficients. |
    */
 
   /**

--- a/src/Rodin/Variational/RealFunction.h
+++ b/src/Rodin/Variational/RealFunction.h
@@ -39,7 +39,14 @@ namespace Rodin::Variational
   /**
    * @defgroup RealFunctionSpecializations RealFunction Template Specializations
    * @brief Template specializations of the RealFunction class.
-   * @see RealFunction
+   * @see <a href="_real_function_8h.html">RealFunction</a>
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref RealFunction "RealFunction<FunctionBase<NestedDerived>>" | Real-valued wrapper around a nested function. |
+   * | @ref RealFunction "RealFunction<Real>" | Constant real-valued function. |
+   * | @ref RealFunction "RealFunction<Integer>" | Constant real-valued function initialized from an integer. |
+   * | @ref RealFunction "RealFunction<F>" | Real function constructed from an arbitrary scalar callable. |
    */
 
   /**
@@ -63,7 +70,8 @@ namespace Rodin::Variational
    * );
    * ```
    *
-   * @see ScalarFunctionBase, RealFunction
+   * @see <a href="_scalar_function_8h.html">ScalarFunctionBase</a>
+   * @see <a href="_real_function_8h.html">RealFunction</a>
    */
   template <class Derived>
   class RealFunctionBase : public ScalarFunctionBase<Real, RealFunctionBase<Derived>>

--- a/src/Rodin/Variational/ScalarFunction.h
+++ b/src/Rodin/Variational/ScalarFunction.h
@@ -34,9 +34,7 @@ namespace Rodin::FormLanguage
 namespace Rodin::Variational
 {
   /**
-   * @defgroup RealFunctionSpecializations RealFunction Template Specializations
-   * @brief Template specializations of the RealFunction class.
-   * @see RealFunction
+   * @addtogroup RealFunctionSpecializations
    */
 
   /**
@@ -55,7 +53,10 @@ namespace Rodin::Variational
    * @note This serves as an intermediate base between FunctionBase and concrete
    * scalar function types like RealFunction, ComplexFunction, and BooleanFunction.
    *
-   * @see FunctionBase, RealFunction, ComplexFunction, BooleanFunction
+   * @see <a href="class_rodin_1_1_variational_1_1_function_base.html">FunctionBase</a>
+   * @see <a href="_real_function_8h.html">RealFunction</a>
+   * @see <a href="_complex_function_8h.html">ComplexFunction</a>
+   * @see <a href="_boolean_function_8h.html">BooleanFunction</a>
    */
   template <class Scalar, class Derived>
   class ScalarFunctionBase

--- a/src/Rodin/Variational/Sum.h
+++ b/src/Rodin/Variational/Sum.h
@@ -83,7 +83,12 @@ namespace Rodin::Variational
   /**
    * @defgroup SumSpecializations Sum Template Specializations
    * @brief Template specializations of the Sum class.
-   * @see Sum
+   * @see @ref Sum
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Sum "Sum<FunctionBase<LHSDerived>, FunctionBase<RHSDerived>>" | Pointwise sum of two function expressions. |
+   * | @ref Sum "Sum<ShapeFunctionBase<LHSDerived, FES, Space>, ShapeFunctionBase<RHSDerived, FES, Space>>" | Sum of compatible test or trial shape-function expressions. |
    */
 
   /**

--- a/src/Rodin/Variational/Transpose.h
+++ b/src/Rodin/Variational/Transpose.h
@@ -22,7 +22,12 @@ namespace Rodin::Variational
   /**
    * @defgroup TransposeSpecializations Transpose Template Specializations
    * @brief Template specializations of the Transpose class.
-   * @see Transpose
+   * @see @ref Transpose
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Transpose "Transpose<FunctionBase<NestedDerived>>" | Pointwise transpose of a matrix-valued function expression. |
+   * | @ref Transpose "Transpose<ShapeFunctionBase<NestedDerived, FES, Space>>" | Transpose of a matrix-valued test or trial shape-function expression. |
    */
 
   /**

--- a/src/Rodin/Variational/UnaryMinus.h
+++ b/src/Rodin/Variational/UnaryMinus.h
@@ -46,7 +46,16 @@ namespace Rodin::Variational
   /**
    * @defgroup UnaryMinusSpecializations UnaryMinus Template Specializations
    * @brief Template specializations of the UnaryMinus class.
-   * @see UnaryMinus
+   * @see @ref UnaryMinus
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref UnaryMinus "UnaryMinus<FunctionBase<NestedDerived>>" | Pointwise negation of a function expression. |
+   * | @ref UnaryMinus "UnaryMinus<ShapeFunctionBase<NestedDerived, FES, Space>>" | Negation of a test or trial shape-function expression. |
+   * | @ref UnaryMinus "UnaryMinus<LinearFormIntegratorBase<Number>>" | Negation of a linear-form integrator. |
+   * | @ref UnaryMinus "UnaryMinus<FormLanguage::List<LinearFormIntegratorBase<Number>>>" | Negation of a list of linear-form integrators. |
+   * | @ref UnaryMinus "UnaryMinus<LocalBilinearFormIntegratorBase<Number>>" | Negation of a local bilinear-form integrator. |
+   * | @ref UnaryMinus "UnaryMinus<FormLanguage::List<LocalBilinearFormIntegratorBase<Number>>>" | Negation of a list of local bilinear-form integrators. |
    */
 
   /**

--- a/src/Rodin/Variational/VectorFunction.h
+++ b/src/Rodin/Variational/VectorFunction.h
@@ -46,7 +46,13 @@ namespace Rodin::Variational
   /**
    * @defgroup VectorFunctionSpecializations VectorFunction Template Specializations
    * @brief Template specializations of the VectorFunction class.
-   * @see VectorFunction
+   * @see @ref VectorFunction
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref VectorFunction "VectorFunction<Math::Vector<Scalar>>" | Constant vector-valued function backed by a dense vector. |
+   * | @ref VectorFunction "VectorFunction<V, Values...>" | Vector-valued function assembled from component values. |
+   * | @ref VectorFunction "VectorFunction<F>" | Callable vector-valued function evaluated from a point. |
    */
 
   /**
@@ -72,7 +78,9 @@ namespace Rodin::Variational
    * - Index notation: `f(i)` for the i-th component
    * - Coordinate accessors: `f.x()`, `f.y()`, `f.z()` for first three components
    *
-   * @see FunctionBase, RealFunction, MatrixFunction
+   * @see <a href="class_rodin_1_1_variational_1_1_function_base.html">FunctionBase</a>
+   * @see <a href="_real_function_8h.html">RealFunction</a>
+   * @see <a href="_matrix_function_8h.html">MatrixFunction</a>
    */
   template <class Scalar, class Derived>
   class VectorFunctionBase : public FunctionBase<VectorFunctionBase<Scalar, Derived>>
@@ -147,7 +155,7 @@ namespace Rodin::Variational
        * @param[in] i Component index (0-based)
        * @returns Component function object
        * @pre i < getDimension()
-       * @see Component
+       * @see <a href="_component_8h.html">Component</a>
        */
       constexpr
       auto operator()(size_t i) const

--- a/src/Rodin/Variational/Zero.h
+++ b/src/Rodin/Variational/Zero.h
@@ -28,7 +28,12 @@ namespace Rodin::Variational
   /**
    * @defgroup ZeroSpecializations Zero Template Specializations
    * @brief Template specializations of the Zero class.
-   * @see Zero
+   * @see @ref Zero
+   *
+   * | Specialization | Description |
+   * |----------------|-------------|
+   * | @ref Zero "Zero<Scalar>" | Constant scalar zero function. |
+   * | @ref Zero "Zero<Math::SpatialVector<Scalar>>" | Constant spatial-vector zero function. |
    */
 
   /**


### PR DESCRIPTION
## Summary
- add specialization tables to Doxygen main pages for Mesh and other specialized class families across Geometry, Variational, Assembly, IO, PETSc, Solver, Solid, and related modules
- fix rendered docs references so See also entries and specialization rows link under m.css
- record the specialization-table requirement in the agent knowledge base and Doxygen CI documentation

## Verification
- cmake --build build --target RodinDoxygen
- rg -n "unable to resolve|unresolved|warning: unable|error:" build/rodin_doxygen_mcss.log
- rendered See also audit: OK, class/header refs linked
- explicit local HTML link audit: OK
- rendered primary-page specialization-table audit: OK
- git diff --check

## Base notes
- PR is based on origin/develop at 2d53333eb Git LFS Migration (#328)
- Latest merge commit observed on develop: 0dca03afb Merge branch 'develop' of github.com:cbritopacheco/rodin into develop\n\n## Local notes\n- git-lfs is not installed in this environment; push required --no-verify to bypass the unavailable local LFS pre-push hook. No LFS-tracked payloads were added in this doc-only change.